### PR TITLE
feat: deploy jiangping (采购订单管理系统) - PMC跟仓管

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,6 +240,7 @@ volumes:
 | task-api | 任务 API | — | Standalone (Node.js) | — | — |
 | new-product-schedule | 新产品开发进度表 | Engineering | Standalone (Node.js) | /new-product-schedule/ | https://github.com/hufan4308-blip/new-product-schedule |
 | figure-mold-cost-system | 模具手办采购订单 | Engineering | Standalone (Node.js) | /figure-mold-cost-system/ | https://github.com/hufan4308-blip/figure-mold-cost-system |
+| jiangping | 采购订单管理系统 | PMC跟仓管 | Standalone (Python/Flask) | /jiangping/ | https://github.com/fxxaxxx/jiangping |
 
 ### 旧插件（已删除）
 

--- a/apps/jiangping/.gitignore
+++ b/apps/jiangping/.gitignore
@@ -1,0 +1,7 @@
+.env
+*.db
+data/
+uploads/
+__pycache__/
+*.pyc
+.DS_Store

--- a/apps/jiangping/Dockerfile
+++ b/apps/jiangping/Dockerfile
@@ -1,0 +1,25 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# System dependencies for pdfplumber, easyocr, and general operation
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    libgl1-mesa-glx \
+    libglib2.0-0 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install CPU-only PyTorch first (much smaller than full torch)
+RUN pip install --no-cache-dir torch torchvision --index-url https://download.pytorch.org/whl/cpu
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt gunicorn
+
+COPY . .
+
+# Ensure data and uploads directories exist
+RUN mkdir -p /app/data /app/uploads
+
+EXPOSE 5001
+
+CMD ["gunicorn", "--bind", "0.0.0.0:5001", "--workers", "2", "--timeout", "120", "app:create_app()"]

--- a/apps/jiangping/Dockerfile
+++ b/apps/jiangping/Dockerfile
@@ -22,4 +22,4 @@ RUN mkdir -p /app/data /app/uploads
 
 EXPOSE 5001
 
-CMD ["gunicorn", "--bind", "0.0.0.0:5001", "--workers", "2", "--timeout", "120", "app:create_app()"]
+CMD ["gunicorn", "--bind", "0.0.0.0:5001", "--workers", "2", "--timeout", "120", "wsgi:app"]

--- a/apps/jiangping/app.py
+++ b/apps/jiangping/app.py
@@ -1,0 +1,62 @@
+import os
+from flask import Flask, jsonify
+from config import Config
+from models import db
+
+
+class PrefixMiddleware:
+    """Set SCRIPT_NAME so url_for generates correct URLs behind a reverse proxy."""
+    def __init__(self, app, prefix=''):
+        self.app = app
+        self.prefix = prefix
+
+    def __call__(self, environ, start_response):
+        environ['SCRIPT_NAME'] = self.prefix
+        return self.app(environ, start_response)
+
+
+def create_app():
+    app = Flask(__name__)
+    app.config.from_object(Config)
+    os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
+
+    # Apply BASE_PATH prefix for sub-path reverse proxy
+    base_path = os.environ.get('BASE_PATH', '')
+    if base_path:
+        app.wsgi_app = PrefixMiddleware(app.wsgi_app, prefix=base_path)
+
+    db.init_app(app)
+    with app.app_context():
+        db.create_all()
+
+    from routes.upload import bp as upload_bp
+    from routes.purchase import bp as purchase_bp
+    from routes.supplier import bp as supplier_bp
+    from routes.delivery import bp as delivery_bp
+    from routes.export import bp as export_bp
+    from routes.dashboard import bp as dashboard_bp
+    from routes.delivery_mgmt import bp as delivery_mgmt_bp
+
+    app.register_blueprint(upload_bp)
+    app.register_blueprint(purchase_bp)
+    app.register_blueprint(supplier_bp)
+    app.register_blueprint(delivery_bp)
+    app.register_blueprint(export_bp)
+    app.register_blueprint(dashboard_bp)
+    app.register_blueprint(delivery_mgmt_bp)
+
+    @app.route('/')
+    def index():
+        from flask import redirect, url_for
+        return redirect(url_for('upload.upload_page'))
+
+    @app.route('/health')
+    def health():
+        return jsonify({'status': 'ok'})
+
+    return app
+
+
+if __name__ == '__main__':
+    app = create_app()
+    app.run(debug=True, port=5001)

--- a/apps/jiangping/config.py
+++ b/apps/jiangping/config.py
@@ -1,0 +1,11 @@
+import os
+
+BASE_DIR = os.path.abspath(os.path.dirname(__file__))
+DATA_DIR = os.environ.get('DATA_PATH', BASE_DIR)
+
+class Config:
+    SECRET_KEY = os.environ.get('SECRET_KEY', 'huadeng-jiangping-2026')
+    SQLALCHEMY_DATABASE_URI = 'sqlite:///' + os.path.join(DATA_DIR, 'data.db')
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    UPLOAD_FOLDER = os.environ.get('UPLOAD_FOLDER', os.path.join(BASE_DIR, 'uploads'))
+    MAX_CONTENT_LENGTH = 16 * 1024 * 1024

--- a/apps/jiangping/models.py
+++ b/apps/jiangping/models.py
@@ -1,0 +1,79 @@
+from flask_sqlalchemy import SQLAlchemy
+from datetime import datetime, date
+from decimal import Decimal
+
+db = SQLAlchemy()
+
+class Supplier(db.Model):
+    __tablename__ = 'suppliers'
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(200), unique=True, nullable=False)
+    short_name = db.Column(db.String(50))
+    contact = db.Column(db.String(50))
+    tel = db.Column(db.String(50))
+    fax = db.Column(db.String(50))
+    address = db.Column(db.String(300))
+    orders = db.relationship('PurchaseOrder', backref='supplier', lazy='dynamic')
+
+class PurchaseOrder(db.Model):
+    __tablename__ = 'purchase_orders'
+    id = db.Column(db.Integer, primary_key=True)
+    po_no = db.Column(db.String(50), unique=True, nullable=False)
+    po_date = db.Column(db.Date)
+    supplier_id = db.Column(db.Integer, db.ForeignKey('suppliers.id'))
+    delivery_date = db.Column(db.Date)
+    receiver = db.Column(db.String(50))
+    total_amount = db.Column(db.Numeric(12, 2), default=0)
+    pdf_filename = db.Column(db.String(200))
+    created_at = db.Column(db.DateTime, default=datetime.now)
+    items = db.relationship('PurchaseItem', backref='order', lazy='dynamic', cascade='all, delete-orphan')
+
+class PurchaseItem(db.Model):
+    __tablename__ = 'purchase_items'
+    id = db.Column(db.Integer, primary_key=True)
+    purchase_order_id = db.Column(db.Integer, db.ForeignKey('purchase_orders.id'), nullable=False)
+    material_code = db.Column(db.String(50))
+    product_code = db.Column(db.String(50))
+    product_name = db.Column(db.String(200))
+    specification = db.Column(db.String(200))
+    quantity = db.Column(db.Integer, default=0)
+    unit = db.Column(db.String(20), default='PCS')
+    unit_price = db.Column(db.Numeric(10, 4), default=0)
+    amount = db.Column(db.Numeric(12, 2), default=0)
+    remarks = db.Column(db.String(200))
+    deliveries = db.relationship('DeliveryRecord', backref='purchase_item', lazy='dynamic', cascade='all, delete-orphan')
+
+class DeliveryNote(db.Model):
+    """交货单（供应商送货单）"""
+    __tablename__ = 'delivery_notes'
+    id = db.Column(db.Integer, primary_key=True)
+    supplier_id = db.Column(db.Integer, db.ForeignKey('suppliers.id'))
+    delivery_no = db.Column(db.String(50))
+    delivery_date = db.Column(db.Date)
+    total_amount = db.Column(db.Numeric(12, 2), default=0)
+    created_at = db.Column(db.DateTime, default=datetime.now)
+    supplier = db.relationship('Supplier', backref=db.backref('delivery_notes', lazy='dynamic'))
+    items = db.relationship('DeliveryNoteItem', backref='note', lazy='dynamic', cascade='all, delete-orphan')
+
+class DeliveryNoteItem(db.Model):
+    """交货明细"""
+    __tablename__ = 'delivery_note_items'
+    id = db.Column(db.Integer, primary_key=True)
+    delivery_note_id = db.Column(db.Integer, db.ForeignKey('delivery_notes.id'), nullable=False)
+    po_no = db.Column(db.String(50))
+    product_code = db.Column(db.String(50))
+    product_name = db.Column(db.String(200))
+    quantity = db.Column(db.Numeric(10, 2), default=0)
+    unit = db.Column(db.String(20), default='PCS')
+    unit_price = db.Column(db.Numeric(10, 4), default=0)
+    amount = db.Column(db.Numeric(12, 2), default=0)
+    remarks = db.Column(db.String(200))
+
+class DeliveryRecord(db.Model):
+    __tablename__ = 'delivery_records'
+    id = db.Column(db.Integer, primary_key=True)
+    purchase_item_id = db.Column(db.Integer, db.ForeignKey('purchase_items.id'), nullable=False)
+    delivery_date = db.Column(db.Date)
+    delivered_quantity = db.Column(db.Integer, default=0)
+    remarks = db.Column(db.String(200))
+    created_at = db.Column(db.DateTime, default=datetime.now)

--- a/apps/jiangping/parser/delivery_parser.py
+++ b/apps/jiangping/parser/delivery_parser.py
@@ -1,0 +1,176 @@
+"""
+Delivery note parser using OCR (EasyOCR).
+Supports PDF and image files.
+Extracts: date, supplier, delivery_no, and line items.
+"""
+
+import re
+import os
+from datetime import datetime
+
+
+def parse_delivery_file(filepath: str) -> dict:
+    """Parse a delivery note PDF or image via OCR.
+
+    Returns dict with raw OCR lines and best-effort extracted fields.
+    """
+    ext = os.path.splitext(filepath)[1].lower()
+    if ext == '.pdf':
+        lines = _ocr_pdf(filepath)
+    else:
+        lines = _ocr_image(filepath)
+
+    return _extract_fields(lines)
+
+
+def _ocr_pdf(filepath: str) -> list:
+    """OCR all pages of a PDF."""
+    import pdfplumber
+    import tempfile
+
+    all_lines = []
+    pdf = pdfplumber.open(filepath)
+    for page in pdf.pages:
+        text = page.extract_text()
+        if text and len(text.strip()) > 30:
+            all_lines.extend(text.strip().split('\n'))
+        else:
+            img = page.to_image(resolution=300)
+            tmp = tempfile.NamedTemporaryFile(suffix='.png', delete=False)
+            img.save(tmp.name)
+            tmp.close()
+            all_lines.extend(_ocr_image(tmp.name))
+            os.unlink(tmp.name)
+    pdf.close()
+    return all_lines
+
+
+def _ocr_image(filepath: str) -> list:
+    """OCR an image file, return text lines sorted top-to-bottom."""
+    import easyocr
+    reader = easyocr.Reader(['ch_sim', 'en'], gpu=False, verbose=False)
+    results = reader.readtext(filepath)
+    results.sort(key=lambda r: (r[0][0][1], r[0][0][0]))
+    return [text for (_, text, _) in results]
+
+
+def _extract_fields(lines: list) -> dict:
+    """Best-effort extraction from OCR text lines."""
+    raw = '\n'.join(lines)
+    result = {
+        'supplier': '',
+        'delivery_date': '',
+        'delivery_no': '',
+        'items': [],
+        'raw_text': raw,
+    }
+
+    # --- Date ---
+    for pat in [
+        r'(\d{4})[年./-](\d{1,2})[月./-](\d{1,2})',
+        r'(\d{2})-([A-Za-z]{3})-(\d{2,4})',
+    ]:
+        m = re.search(pat, raw)
+        if m:
+            g = m.groups()
+            try:
+                if len(g[0]) == 4:
+                    result['delivery_date'] = f'{int(g[0])}-{int(g[1]):02d}-{int(g[2]):02d}'
+                else:
+                    dt = datetime.strptime(m.group(), '%d-%b-%y')
+                    result['delivery_date'] = dt.strftime('%Y-%m-%d')
+            except Exception:
+                pass
+            if result['delivery_date']:
+                break
+
+    # --- Delivery No (送货单号) ---
+    for pat in [
+        r'送货单号[：:.\s]*([A-Za-z0-9\-]+)',
+        r'单\s*号[：:.\s]*([A-Za-z0-9\-]+)',
+        r'No[.:]?\s*([A-Za-z0-9\-]+)',
+    ]:
+        m = re.search(pat, raw, re.IGNORECASE)
+        if m:
+            result['delivery_no'] = m.group(1).strip()
+            break
+
+    # --- Supplier ---
+    for pat in [
+        r'供[应應]商[：:.\s]*(.+?)(?:\n|$)',
+        r'([\u4e00-\u9fff]{2,}(?:有限公司|厂|工厂|制品|塑胶|五金|电子|包装|印刷)[\u4e00-\u9fff]*)',
+    ]:
+        m = re.search(pat, raw)
+        if m:
+            result['supplier'] = m.group(1).strip()
+            break
+
+    # --- PO No (采购单号 / FDJA...) ---
+    default_po = ''
+    for pat in [
+        r'(FDJA[\d\-]+)',
+        r'采购单号[：:.\s]*([A-Za-z0-9\-]+)',
+        r'PO[.:\s]+([A-Za-z0-9\-]+)',
+    ]:
+        m = re.search(pat, raw, re.IGNORECASE)
+        if m:
+            default_po = m.group(1).strip()
+            break
+
+    # --- Items: scan lines for quantity patterns ---
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        # Skip header-like lines
+        if re.search(r'(货号|名称|数量|单位|单价|金额|日期|备注|合计|送货单)', line):
+            continue
+
+        # Try to find quantity (number followed by optional unit)
+        qty_match = re.search(r'(\d[\d,]*\.?\d*)\s*(PCS|pcs|Pcs|个|件|套|箱|KG|kg|只|片|米|卷|支)?', line)
+        if not qty_match:
+            continue
+
+        qty_str = qty_match.group(1).replace(',', '')
+        try:
+            qty = float(qty_str)
+        except ValueError:
+            continue
+        if qty <= 0:
+            continue
+
+        unit = qty_match.group(2) or 'PCS'
+
+        # Extract product info from the text before/around the quantity
+        text_before = line[:qty_match.start()].strip()
+        text_after = line[qty_match.end():].strip()
+
+        # Try to split into code + name
+        product_code = ''
+        product_name = text_before
+
+        # If starts with alphanumeric code
+        code_match = re.match(r'^([A-Za-z0-9][\w\-]*)\s+(.+)', text_before)
+        if code_match:
+            product_code = code_match.group(1)
+            product_name = code_match.group(2)
+
+        if not product_name or len(product_name) < 2:
+            product_name = text_before or text_after
+
+        if not product_name or len(product_name) < 2:
+            continue
+
+        # Check for PO number in this line
+        po_match = re.search(r'(FDJA[\d\-]+)', line)
+        line_po = po_match.group(1) if po_match else default_po
+
+        result['items'].append({
+            'product_code': product_code,
+            'product_name': product_name,
+            'quantity': qty,
+            'unit': unit,
+            'po_no': line_po,
+        })
+
+    return result

--- a/apps/jiangping/parser/pdf_parser.py
+++ b/apps/jiangping/parser/pdf_parser.py
@@ -1,0 +1,240 @@
+"""
+PDF Parser for Huadeng purchase orders.
+
+Extracts structured data from standardised two-page PDF purchase orders
+produced by 东莞华登塑胶制品有限公司.
+"""
+
+import re
+import pdfplumber
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def parse_purchase_pdf(pdf_path: str) -> dict:
+    """Parse a Huadeng purchase-order PDF and return a structured dict.
+
+    Returns:
+        {
+            'po_no': str,            # e.g. 'FDJA20260158'
+            'supplier_name': str,
+            'po_date': str,          # 'YYYY-MM-DD'
+            'delivery_date': str,    # 'YYYY-MM-DD'
+            'receiver': str,
+            'items': [
+                {
+                    'product_code': str,
+                    'product_name': str,
+                    'specification': str,
+                    'quantity': int,
+                    'unit': str,
+                    'unit_price': float,
+                    'amount': float,
+                    'material_code': str,
+                },
+                ...
+            ],
+        }
+    """
+    with pdfplumber.open(pdf_path) as pdf:
+        pages = pdf.pages
+
+        # --- header from first page text ---
+        page1_text = pages[0].extract_text() or ''
+        header = _parse_header(page1_text)
+
+        # --- items from all page tables ---
+        items = []
+        for page in pages:
+            tables = page.extract_tables()
+            for table in tables:
+                items.extend(_parse_table_rows(table))
+
+        # --- delivery info from first page text (also present on page 2) ---
+        delivery_info = _parse_delivery_info(page1_text)
+        header.update(delivery_info)
+
+    return {**header, 'items': items}
+
+
+# ---------------------------------------------------------------------------
+# Header parsing
+# ---------------------------------------------------------------------------
+
+def _parse_header(text: str) -> dict:
+    result = {}
+
+    # Supplier name: line containing '供應商：' or '供应商：'
+    m = re.search(r'供[應应]商[：:]\s*(.+?)\s+採購單編號', text)
+    if m:
+        result['supplier_name'] = m.group(1).strip()
+
+    # PO number: e.g. FDJA20260158-01  →  base = FDJA20260158
+    m = re.search(r'採購單編號[：:]\s*([A-Z0-9]+(?:-\d+)?)', text)
+    if m:
+        raw = m.group(1).strip()
+        # Strip page suffix like -01, -02
+        result['po_no'] = re.sub(r'-\d+$', '', raw)
+
+    # Date: 2026年03月18日
+    m = re.search(r'日\s*[期期][：:]\s*(\d{4})年(\d{2})月(\d{2})日', text)
+    if m:
+        result['po_date'] = f'{m.group(1)}-{m.group(2)}-{m.group(3)}'
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Delivery / receiver parsing
+# ---------------------------------------------------------------------------
+
+def _parse_delivery_info(text: str) -> dict:
+    result = {}
+
+    # Delivery date: "2026年03月31日 前交货"
+    m = re.search(r'(\d{4})年(\d{2})月(\d{2})日\s*前交货', text)
+    if m:
+        result['delivery_date'] = f'{m.group(1)}-{m.group(2)}-{m.group(3)}'
+
+    # Receiver: 收货人：江平
+    m = re.search(r'收货人[：:]\s*([^\s,，;；\n]+)', text)
+    if m:
+        result['receiver'] = m.group(1).strip()
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Table row parsing
+# ---------------------------------------------------------------------------
+
+_AMOUNT_RE = re.compile(r'[\d,]+\.?\d*')
+_MATERIAL_CODE_RE = re.compile(r'\b\d{8}\b')
+_QTY_UNIT_RE = re.compile(r'^(\d+)\s+([A-Za-z]+)$')
+
+
+def _parse_table_rows(table: list) -> list:
+    """Extract item dicts from a raw pdfplumber table (list of lists)."""
+    items = []
+    for row in table:
+        if not row or len(row) < 5:
+            continue
+        item = _try_parse_item_row(row)
+        if item:
+            items.append(item)
+    return items
+
+
+def _try_parse_item_row(row: list) -> dict | None:
+    """Return a parsed item dict if the row looks like a data row, else None."""
+    # Column indices (7 columns total):
+    # 0: 貨號 (usually empty)
+    # 1: 貨物名稱 (product name + spec, newline-separated)
+    # 2: 數量/單位
+    # 3: 單價
+    # 4: 金額(￥)
+    # 5: 物料位置/物料編號
+    # 6: 備註
+
+    col_name = (row[1] or '').strip()
+    col_qty_unit = (row[2] or '').strip()
+    col_price = (row[3] or '').strip()
+    col_amount = (row[4] or '').strip()
+    col_material = (row[5] or '').strip() if len(row) > 5 else ''
+
+    # Must have product name and numeric price/amount
+    if not col_name or not col_price or not col_amount:
+        return None
+
+    # Price must be a plain decimal number
+    try:
+        unit_price = float(col_price.replace(',', ''))
+    except ValueError:
+        return None
+
+    # Amount: strip leading ￥ / spaces, then parse
+    amount_clean = col_amount.lstrip('￥').strip()
+    try:
+        amount = float(amount_clean.replace(',', ''))
+    except ValueError:
+        return None
+
+    # Sanity: amount must be positive
+    if amount <= 0:
+        return None
+
+    # Qty/unit: "5000 PCS"
+    qty_unit_m = _QTY_UNIT_RE.match(col_qty_unit)
+    if not qty_unit_m:
+        return None
+    quantity = int(qty_unit_m.group(1))
+    unit = qty_unit_m.group(2).upper()
+
+    # Validate quantity * price ≈ amount (within 1%)
+    expected = quantity * unit_price
+    if amount > 0 and abs(expected - amount) / amount > 0.01:
+        return None
+
+    # Material code: 8-digit number
+    mc_match = _MATERIAL_CODE_RE.search(col_material)
+    material_code = mc_match.group(0) if mc_match else ''
+
+    # Split product name cell into (code, name, specification)
+    product_code, product_name, specification = _split_product_name(col_name)
+
+    return {
+        'product_code': product_code,
+        'product_name': product_name,
+        'specification': specification,
+        'quantity': quantity,
+        'unit': unit,
+        'unit_price': unit_price,
+        'amount': amount,
+        'material_code': material_code,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Product name splitting
+# ---------------------------------------------------------------------------
+
+def _split_product_name(raw: str) -> tuple[str, str, str]:
+    """Split a raw product-name cell into (product_code, product_name, specification).
+
+    Examples
+    --------
+    "JWC2269-彩卡（XS码）\\n350G粉灰 4C+光油"
+        → ("JWC2269", "彩卡 XS码", "350G粉灰 4C+光油")
+
+    "JWC4336-彩卡-R04（XS码）\\n350G粉灰 4C+光油"
+        → ("JWC4336", "彩卡-R04 XS码", "350G粉灰 4C+光油")
+    """
+    parts = raw.split('\n', 1)
+    first_line = parts[0].strip()
+    specification = parts[1].strip() if len(parts) > 1 else ''
+
+    # Extract product code: leading alphanumeric segment before the first '-'
+    # that is followed by Chinese characters.
+    # e.g. "JWC2269-彩卡（XS码）" → code="JWC2269", rest="彩卡（XS码）"
+    code_match = re.match(r'^([A-Z0-9]+)-(.+)$', first_line, re.UNICODE)
+    if code_match:
+        product_code = code_match.group(1)
+        remainder = code_match.group(2)
+    else:
+        product_code = ''
+        remainder = first_line
+
+    # Normalise brackets: （XS码） → XS码, removing full-width parens
+    # Also handle ASCII parens just in case
+    def normalise_brackets(s: str) -> str:
+        s = re.sub(r'[（(]', ' ', s)
+        s = re.sub(r'[）)]', '', s)
+        return s.strip()
+
+    product_name = normalise_brackets(remainder)
+    # Collapse multiple spaces
+    product_name = re.sub(r'\s+', ' ', product_name).strip()
+
+    return product_code, product_name, specification

--- a/apps/jiangping/requirements.txt
+++ b/apps/jiangping/requirements.txt
@@ -1,0 +1,6 @@
+Flask==3.1.1
+Flask-SQLAlchemy==3.1.1
+pdfplumber==0.11.6
+pandas==2.2.3
+openpyxl==3.1.5
+easyocr==1.7.2

--- a/apps/jiangping/routes/dashboard.py
+++ b/apps/jiangping/routes/dashboard.py
@@ -1,0 +1,71 @@
+from flask import Blueprint, render_template, request, jsonify
+from models import db, PurchaseOrder, PurchaseItem, Supplier, DeliveryRecord
+from sqlalchemy import func
+
+bp = Blueprint('dashboard', __name__, url_prefix='/dashboard')
+
+@bp.route('/')
+def dashboard_page():
+    return render_template('dashboard.html')
+
+@bp.route('/api/by_supplier')
+def by_supplier():
+    rows = db.session.query(
+        Supplier.short_name, func.sum(PurchaseOrder.total_amount).label('total')
+    ).join(PurchaseOrder).group_by(Supplier.id).order_by(func.sum(PurchaseOrder.total_amount).desc()).all()
+    return jsonify({'labels': [r[0] or '未知' for r in rows], 'data': [float(r[1] or 0) for r in rows]})
+
+@bp.route('/api/by_month')
+def by_month():
+    rows = db.session.query(
+        func.strftime('%Y-%m', PurchaseOrder.po_date).label('month'),
+        func.sum(PurchaseOrder.total_amount).label('total')
+    ).group_by('month').order_by('month').all()
+    return jsonify({'labels': [r[0] for r in rows], 'data': [float(r[1] or 0) for r in rows]})
+
+@bp.route('/api/by_product')
+def by_product():
+    n = request.args.get('n', 20, type=int)
+    rows = db.session.query(
+        PurchaseItem.product_code, func.sum(PurchaseItem.quantity).label('total_qty'),
+        func.sum(PurchaseItem.amount).label('total_amount')
+    ).group_by(PurchaseItem.product_code).order_by(func.sum(PurchaseItem.quantity).desc()).limit(n).all()
+    return jsonify({'labels': [r[0] or '未知' for r in rows], 'quantities': [int(r[1] or 0) for r in rows], 'amounts': [float(r[2] or 0) for r in rows]})
+
+@bp.route('/api/delivery_stats')
+def delivery_stats():
+    items = PurchaseItem.query.all()
+    stats = {'on_time': 0, 'late': 0, 'undelivered': 0, 'partial': 0}
+    for item in items:
+        delivered_qty = db.session.query(
+            func.coalesce(func.sum(DeliveryRecord.delivered_quantity), 0)
+        ).filter(DeliveryRecord.purchase_item_id == item.id).scalar()
+        if delivered_qty == 0:
+            stats['undelivered'] += 1
+        elif delivered_qty < item.quantity:
+            stats['partial'] += 1
+        else:
+            last_delivery = DeliveryRecord.query.filter_by(purchase_item_id=item.id).order_by(DeliveryRecord.delivery_date.desc()).first()
+            if last_delivery and item.order.delivery_date and last_delivery.delivery_date and last_delivery.delivery_date <= item.order.delivery_date:
+                stats['on_time'] += 1
+            else:
+                stats['late'] += 1
+    return jsonify(stats)
+
+@bp.route('/api/period_compare')
+def period_compare():
+    p1_from = request.args.get('p1_from')
+    p1_to = request.args.get('p1_to')
+    p2_from = request.args.get('p2_from')
+    p2_to = request.args.get('p2_to')
+    def get_period_data(date_from, date_to):
+        rows = db.session.query(
+            Supplier.short_name, func.sum(PurchaseOrder.total_amount).label('total')
+        ).join(PurchaseOrder).filter(
+            PurchaseOrder.po_date >= date_from, PurchaseOrder.po_date <= date_to
+        ).group_by(Supplier.id).all()
+        return {r[0] or '未知': float(r[1] or 0) for r in rows}
+    data1 = get_period_data(p1_from, p1_to) if p1_from and p1_to else {}
+    data2 = get_period_data(p2_from, p2_to) if p2_from and p2_to else {}
+    all_suppliers = sorted(set(list(data1.keys()) + list(data2.keys())))
+    return jsonify({'labels': all_suppliers, 'period1': [data1.get(s, 0) for s in all_suppliers], 'period2': [data2.get(s, 0) for s in all_suppliers]})

--- a/apps/jiangping/routes/delivery.py
+++ b/apps/jiangping/routes/delivery.py
@@ -1,0 +1,58 @@
+from flask import Blueprint, render_template, request, jsonify
+from models import db, PurchaseOrder, PurchaseItem, DeliveryRecord, Supplier
+from sqlalchemy import func
+
+bp = Blueprint('delivery', __name__, url_prefix='/delivery')
+
+@bp.route('/')
+def delivery_page():
+    suppliers = Supplier.query.order_by(Supplier.short_name).all()
+    return render_template('delivery.html', suppliers=suppliers)
+
+@bp.route('/api/reconciliation')
+def api_reconciliation():
+    supplier_id = request.args.get('supplier_id', type=int)
+    po_no = request.args.get('po_no', '').strip()
+    query = db.session.query(PurchaseItem).join(PurchaseOrder).join(Supplier)
+    if supplier_id:
+        query = query.filter(PurchaseOrder.supplier_id == supplier_id)
+    if po_no:
+        query = query.filter(PurchaseOrder.po_no.contains(po_no))
+    items = query.order_by(PurchaseOrder.po_date.desc()).all()
+    result = []
+    for item in items:
+        delivered_qty = db.session.query(
+            func.coalesce(func.sum(DeliveryRecord.delivered_quantity), 0)
+        ).filter(DeliveryRecord.purchase_item_id == item.id).scalar()
+        diff = delivered_qty - item.quantity
+        if delivered_qty == 0:
+            status = 'undelivered'
+        elif diff < 0:
+            status = 'partial'
+        elif diff == 0:
+            status = 'complete'
+        else:
+            status = 'over'
+        result.append({
+            'item_id': item.id, 'po_no': item.order.po_no,
+            'po_date': item.order.po_date.strftime('%Y-%m-%d') if item.order.po_date else '',
+            'supplier': item.order.supplier.short_name or item.order.supplier.name,
+            'product_code': item.product_code, 'product_name': item.product_name,
+            'quantity': item.quantity, 'delivered_qty': delivered_qty,
+            'diff': diff, 'status': status,
+            'delivery_date': item.order.delivery_date.strftime('%Y-%m-%d') if item.order.delivery_date else '',
+        })
+    return jsonify({'data': result})
+
+@bp.route('/api/record', methods=['POST'])
+def add_delivery_record():
+    data = request.get_json()
+    record = DeliveryRecord(
+        purchase_item_id=data['item_id'],
+        delivery_date=data.get('delivery_date'),
+        delivered_quantity=data.get('delivered_quantity', 0),
+        remarks=data.get('remarks', ''),
+    )
+    db.session.add(record)
+    db.session.commit()
+    return jsonify({'success': True})

--- a/apps/jiangping/routes/delivery_mgmt.py
+++ b/apps/jiangping/routes/delivery_mgmt.py
@@ -1,0 +1,645 @@
+import os
+from datetime import datetime
+from flask import Blueprint, render_template, request, jsonify, flash, redirect, url_for, current_app
+from models import db, DeliveryNote, DeliveryNoteItem, Supplier, PurchaseOrder, PurchaseItem
+import pandas as pd
+
+bp = Blueprint('delivery_mgmt', __name__, url_prefix='/delivery-mgmt')
+
+
+@bp.route('/')
+def list_deliveries():
+    suppliers = Supplier.query.order_by(Supplier.short_name).all()
+    return render_template('delivery_mgmt.html', suppliers=suppliers)
+
+
+@bp.route('/api/list')
+def api_list():
+    """Return delivery note items, grouped by delivery note."""
+    query = db.session.query(DeliveryNoteItem).join(DeliveryNote).join(Supplier)
+
+    supplier_id = request.args.get('supplier_id', type=int)
+    if supplier_id:
+        query = query.filter(DeliveryNote.supplier_id == supplier_id)
+    date_from = request.args.get('date_from')
+    if date_from:
+        query = query.filter(DeliveryNote.delivery_date >= date_from)
+    date_to = request.args.get('date_to')
+    if date_to:
+        query = query.filter(DeliveryNote.delivery_date <= date_to)
+    po_no = request.args.get('po_no', '').strip()
+    if po_no:
+        query = query.filter(DeliveryNoteItem.po_no.contains(po_no))
+
+    items = query.order_by(
+        Supplier.short_name,
+        DeliveryNote.delivery_date.desc(),
+        DeliveryNote.delivery_no,
+        DeliveryNoteItem.id,
+    ).all()
+
+    result = []
+    last_note_id = None
+    for item in items:
+        note = item.note
+        is_first = (note.id != last_note_id)
+        last_note_id = note.id
+
+        result.append({
+            'note_id': note.id,
+            'item_id': item.id,
+            'delivery_date': note.delivery_date.strftime('%#m/%#d') if note.delivery_date and is_first else '',
+            'supplier': (note.supplier.short_name or note.supplier.name) if is_first else '',
+            'delivery_no': note.delivery_no if is_first else '',
+            'product_code': item.product_code or '',
+            'product_name': item.product_name or '',
+            'quantity': float(item.quantity or 0),
+            'unit': item.unit or 'PCS',
+            'unit_price': float(item.unit_price or 0),
+            'amount': float(item.amount or 0),
+            'po_no': item.po_no or '',
+            'is_first': is_first,
+        })
+    return jsonify({'data': result})
+
+
+@bp.route('/import-excel', methods=['POST'])
+def import_excel():
+    """Import delivery data from an Excel file (one sheet per supplier)."""
+    if 'file' not in request.files:
+        flash('没有选择文件', 'danger')
+        return redirect(url_for('delivery_mgmt.list_deliveries'))
+
+    file = request.files['file']
+    if not file.filename.lower().endswith(('.xls', '.xlsx')):
+        flash('请上传 Excel 文件 (.xls 或 .xlsx)', 'danger')
+        return redirect(url_for('delivery_mgmt.list_deliveries'))
+
+    filepath = os.path.join(current_app.config['UPLOAD_FOLDER'], file.filename)
+    file.save(filepath)
+
+    try:
+        xls = pd.ExcelFile(filepath)
+        total_notes = 0
+        total_items = 0
+
+        for sheet_name in xls.sheet_names:
+            df = pd.read_excel(xls, sheet_name=sheet_name, header=None)
+            if df.empty or len(df) < 2:
+                continue
+
+            # A1 contains the supplier name
+            supplier_short = str(df.iloc[0, 0]).strip() if pd.notna(df.iloc[0, 0]) else sheet_name.strip()
+            if not supplier_short or supplier_short == 'nan':
+                supplier_short = sheet_name.strip()
+
+            # Find or create supplier
+            supplier = Supplier.query.filter_by(short_name=supplier_short).first()
+            if not supplier:
+                supplier = Supplier(name=supplier_short, short_name=supplier_short)
+                db.session.add(supplier)
+                db.session.flush()
+
+            # Detect columns from header row
+            header = [str(c).strip() for c in df.iloc[0].tolist()]
+            col_map = _detect_delivery_columns(header)
+            if col_map is None:
+                continue
+
+            current_note = None
+
+            for idx in range(1, len(df)):
+                row = df.iloc[idx]
+
+                def cell(key):
+                    ci = col_map.get(key)
+                    if ci is None or ci >= len(row):
+                        return None
+                    v = row.iloc[ci]
+                    return v if pd.notna(v) else None
+
+                product_name = str(cell('product_name') or '').strip()
+                quantity = cell('quantity')
+
+                # Skip empty rows and subtotal rows (only amount, no product_name)
+                if not product_name or product_name == 'nan':
+                    # Check if it's a subtotal row (only J column has value)
+                    continue
+
+                delivery_no_val = cell('delivery_no')
+                delivery_date_val = cell('delivery_date')
+
+                # New delivery note if delivery_no is present
+                if delivery_no_val is not None and str(delivery_no_val).strip() and str(delivery_no_val).strip() != 'nan':
+                    dn_no = str(delivery_no_val).strip()
+                    # Clean up numeric delivery_no
+                    try:
+                        dn_num = float(dn_no)
+                        dn_no = str(int(dn_num)) if dn_num == int(dn_num) else dn_no
+                    except (ValueError, TypeError):
+                        pass
+
+                    dn_date = _parse_excel_date(delivery_date_val)
+
+                    current_note = DeliveryNote(
+                        supplier_id=supplier.id,
+                        delivery_no=dn_no,
+                        delivery_date=dn_date,
+                        total_amount=0,
+                    )
+                    db.session.add(current_note)
+                    db.session.flush()
+                    total_notes += 1
+
+                if not current_note:
+                    continue
+
+                # Parse values
+                product_code = str(cell('product_code') or '').strip()
+                if product_code == 'nan':
+                    product_code = ''
+                unit = str(cell('unit') or 'PCS').strip()
+                if unit == 'nan':
+                    unit = 'PCS'
+                unit_price = cell('unit_price') or 0
+                amount = cell('amount') or 0
+                po_no = str(cell('po_no') or '').strip()
+                if po_no == 'nan':
+                    po_no = ''
+
+                try:
+                    quantity = float(quantity) if quantity else 0
+                except (ValueError, TypeError):
+                    quantity = 0
+                try:
+                    unit_price = float(unit_price) if unit_price else 0
+                except (ValueError, TypeError):
+                    unit_price = 0
+                try:
+                    amount = float(amount) if amount else 0
+                except (ValueError, TypeError):
+                    amount = 0
+
+                dn_item = DeliveryNoteItem(
+                    delivery_note_id=current_note.id,
+                    po_no=po_no,
+                    product_code=product_code,
+                    product_name=product_name,
+                    quantity=quantity,
+                    unit=unit,
+                    unit_price=unit_price,
+                    amount=amount,
+                    remarks='',
+                )
+                db.session.add(dn_item)
+                total_items += 1
+
+                # Update matching purchase item remarks with "M/D送qty"
+                if po_no and current_note.delivery_date and quantity:
+                    _update_purchase_remarks(
+                        po_no, product_name, product_code,
+                        current_note.delivery_date, quantity,
+                    )
+
+            # Update note totals for this supplier
+            for note in DeliveryNote.query.filter_by(supplier_id=supplier.id).all():
+                note.total_amount = sum(
+                    float(i.amount or 0) for i in note.items.all()
+                )
+
+        db.session.commit()
+        flash(f'导入成功！共导入 {total_notes} 个交货单，{total_items} 条明细', 'success')
+
+    except Exception as e:
+        db.session.rollback()
+        flash(f'导入失败: {str(e)}', 'danger')
+
+    return redirect(url_for('delivery_mgmt.list_deliveries'))
+
+
+@bp.route('/api/parse', methods=['POST'])
+def api_parse():
+    """Upload and OCR a delivery note PDF/image, return parsed data."""
+    if 'file' not in request.files:
+        return jsonify({'error': '没有选择文件'}), 400
+    file = request.files['file']
+    ext = os.path.splitext(file.filename)[1].lower()
+    if ext not in ('.pdf', '.jpg', '.jpeg', '.png', '.bmp', '.tiff', '.tif'):
+        return jsonify({'error': '请上传 PDF 或图片文件'}), 400
+
+    filepath = os.path.join(current_app.config['UPLOAD_FOLDER'], file.filename)
+    file.save(filepath)
+
+    try:
+        from parser.delivery_parser import parse_delivery_file
+        data = parse_delivery_file(filepath)
+
+        # Auto-match purchase data for each item
+        for item in data.get('items', []):
+            po_no = item.get('po_no', '')
+            product_name = item.get('product_name', '')
+            product_code = item.get('product_code', '')
+            match = _find_purchase_item(po_no, product_name, product_code)
+            if match:
+                item['unit'] = match.unit or item.get('unit', 'PCS')
+                item['unit_price'] = float(match.unit_price or 0)
+                item['amount'] = round(float(item.get('quantity', 0)) * float(match.unit_price or 0), 2)
+                # Also fill in matched product info for accuracy
+                if not item.get('product_code'):
+                    item['product_code'] = match.product_code or ''
+            else:
+                item.setdefault('unit', 'PCS')
+                item.setdefault('unit_price', 0)
+                item.setdefault('amount', 0)
+
+        return jsonify(data)
+    except Exception as e:
+        return jsonify({'error': f'解析失败: {str(e)}'}), 400
+
+
+@bp.route('/api/match-purchase', methods=['POST'])
+def api_match_purchase():
+    """Match a po_no + product to get unit/price from purchase data."""
+    data = request.get_json()
+    po_no = (data.get('po_no') or '').strip()
+    product_name = (data.get('product_name') or '').strip()
+    product_code = (data.get('product_code') or '').strip()
+
+    match = _find_purchase_item(po_no, product_name, product_code)
+    if match:
+        return jsonify({
+            'found': True,
+            'unit': match.unit or 'PCS',
+            'unit_price': float(match.unit_price or 0),
+            'product_code': match.product_code or '',
+            'product_name': match.product_name or '',
+        })
+    return jsonify({'found': False})
+
+
+@bp.route('/api/purchase-items', methods=['GET'])
+def api_purchase_items():
+    """Return all items for a given po_no, for dropdown selection."""
+    po_no = request.args.get('po_no', '').strip()
+    if not po_no:
+        return jsonify({'items': []})
+    order = PurchaseOrder.query.filter_by(po_no=po_no).first()
+    if not order:
+        return jsonify({'items': []})
+    items = []
+    for item in order.items.all():
+        items.append({
+            'product_code': item.product_code or '',
+            'product_name': item.product_name or '',
+            'unit': item.unit or 'PCS',
+            'unit_price': float(item.unit_price or 0),
+            'quantity': int(item.quantity or 0),
+        })
+    return jsonify({'items': items})
+
+
+@bp.route('/api/create', methods=['POST'])
+def api_create():
+    """Create a new delivery note with items."""
+    data = request.get_json()
+    if not data:
+        return jsonify({'error': '无数据'}), 400
+
+    supplier_id = data.get('supplier_id')
+    if not supplier_id:
+        return jsonify({'error': '请选择供应商'}), 400
+
+    delivery_date = None
+    if data.get('delivery_date'):
+        try:
+            delivery_date = datetime.strptime(data['delivery_date'], '%Y-%m-%d').date()
+        except ValueError:
+            pass
+
+    note = DeliveryNote(
+        supplier_id=supplier_id,
+        delivery_no=data.get('delivery_no', ''),
+        delivery_date=delivery_date,
+        total_amount=0,
+    )
+    db.session.add(note)
+    db.session.flush()
+
+    items_data = data.get('items', [])
+    for it in items_data:
+        product_name = (it.get('product_name') or '').strip()
+        if not product_name:
+            continue
+        qty = float(it.get('quantity') or 0)
+        unit_price = float(it.get('unit_price') or 0)
+        amount = float(it.get('amount') or 0)
+        po_no = (it.get('po_no') or '').strip()
+        product_code = (it.get('product_code') or '').strip()
+
+        item = DeliveryNoteItem(
+            delivery_note_id=note.id,
+            po_no=po_no,
+            product_code=product_code,
+            product_name=product_name,
+            quantity=qty,
+            unit=(it.get('unit') or 'PCS').strip(),
+            unit_price=unit_price,
+            amount=amount,
+            remarks='',
+        )
+        db.session.add(item)
+
+        if po_no and delivery_date and qty:
+            _update_purchase_remarks(po_no, product_name, product_code, delivery_date, qty)
+
+    note.total_amount = sum(float(i.get('amount') or 0) for i in items_data)
+    db.session.commit()
+    return jsonify({'success': True, 'note_id': note.id})
+
+
+@bp.route('/api/item/<int:item_id>', methods=['PUT'])
+def api_update_item(item_id):
+    """Update a delivery note item."""
+    item = DeliveryNoteItem.query.get_or_404(item_id)
+    data = request.get_json()
+
+    old_po_no = item.po_no
+    old_name = item.product_name
+    old_code = item.product_code
+    old_qty = float(item.quantity or 0)
+    old_date = item.note.delivery_date
+
+    for field in ['product_code', 'product_name', 'po_no', 'unit', 'remarks']:
+        if field in data:
+            setattr(item, field, (data[field] or '').strip())
+    for field in ['quantity', 'unit_price', 'amount']:
+        if field in data:
+            try:
+                setattr(item, field, float(data[field] or 0))
+            except (ValueError, TypeError):
+                pass
+
+    # Recalculate note total
+    note = item.note
+    db.session.flush()
+    note.total_amount = sum(float(i.amount or 0) for i in note.items.all())
+
+    # Update purchase remarks: remove old entry, add new
+    if old_date and old_qty and old_po_no:
+        _remove_purchase_remarks(old_po_no, old_name, old_code, old_date, old_qty)
+    new_qty = float(item.quantity or 0)
+    if item.po_no and note.delivery_date and new_qty:
+        _update_purchase_remarks(
+            item.po_no, item.product_name, item.product_code,
+            note.delivery_date, new_qty,
+        )
+
+    db.session.commit()
+    return jsonify({'success': True})
+
+
+@bp.route('/api/item/<int:item_id>', methods=['DELETE'])
+def api_delete_item(item_id):
+    """Delete a delivery note item."""
+    item = DeliveryNoteItem.query.get_or_404(item_id)
+    note = item.note
+
+    # Remove from purchase remarks
+    if item.po_no and note.delivery_date and item.quantity:
+        _remove_purchase_remarks(
+            item.po_no, item.product_name, item.product_code,
+            note.delivery_date, float(item.quantity),
+        )
+
+    db.session.delete(item)
+    db.session.flush()
+
+    # If note has no more items, delete the note too
+    if note.items.count() == 0:
+        db.session.delete(note)
+    else:
+        note.total_amount = sum(float(i.amount or 0) for i in note.items.all())
+
+    db.session.commit()
+    return jsonify({'success': True})
+
+
+@bp.route('/api/note/<int:note_id>', methods=['DELETE'])
+def api_delete_note(note_id):
+    """Delete an entire delivery note and all its items."""
+    note = DeliveryNote.query.get_or_404(note_id)
+
+    # Remove all purchase remarks for this note's items
+    for item in note.items.all():
+        if item.po_no and note.delivery_date and item.quantity:
+            _remove_purchase_remarks(
+                item.po_no, item.product_name, item.product_code,
+                note.delivery_date, float(item.quantity),
+            )
+
+    db.session.delete(note)
+    db.session.commit()
+    return jsonify({'success': True})
+
+
+@bp.route('/api/item/add', methods=['POST'])
+def api_add_item():
+    """Add an item to an existing delivery note."""
+    data = request.get_json()
+    note_id = data.get('note_id')
+    note = DeliveryNote.query.get_or_404(note_id)
+
+    product_name = (data.get('product_name') or '').strip()
+    if not product_name:
+        return jsonify({'error': '请输入货号名称'}), 400
+
+    qty = float(data.get('quantity') or 0)
+    unit_price = float(data.get('unit_price') or 0)
+    amount = float(data.get('amount') or 0)
+    po_no = (data.get('po_no') or '').strip()
+    product_code = (data.get('product_code') or '').strip()
+
+    item = DeliveryNoteItem(
+        delivery_note_id=note.id,
+        po_no=po_no,
+        product_code=product_code,
+        product_name=product_name,
+        quantity=qty,
+        unit=(data.get('unit') or 'PCS').strip(),
+        unit_price=unit_price,
+        amount=amount,
+        remarks='',
+    )
+    db.session.add(item)
+    db.session.flush()
+    note.total_amount = sum(float(i.amount or 0) for i in note.items.all())
+
+    if po_no and note.delivery_date and qty:
+        _update_purchase_remarks(po_no, product_name, product_code, note.delivery_date, qty)
+
+    db.session.commit()
+    return jsonify({'success': True, 'item_id': item.id})
+
+
+@bp.route('/<int:note_id>/delete', methods=['POST'])
+def delete_note(note_id):
+    note = DeliveryNote.query.get_or_404(note_id)
+    for item in note.items.all():
+        if item.po_no and note.delivery_date and item.quantity:
+            _remove_purchase_remarks(
+                item.po_no, item.product_name, item.product_code,
+                note.delivery_date, float(item.quantity),
+            )
+    db.session.delete(note)
+    db.session.commit()
+    flash(f'交货单 {note.delivery_no} 已删除', 'success')
+    return redirect(url_for('delivery_mgmt.list_deliveries'))
+
+
+def _update_purchase_remarks(po_no, product_name, product_code, delivery_date, quantity):
+    """Append 'M/D送qty' to matching purchase item remarks."""
+    order = PurchaseOrder.query.filter_by(po_no=po_no).first()
+    if not order:
+        return
+
+    # Try matching by product_name first, then by product_code
+    match = None
+    if product_name:
+        match = PurchaseItem.query.filter_by(
+            purchase_order_id=order.id, product_name=product_name
+        ).first()
+    if not match and product_code:
+        match = PurchaseItem.query.filter_by(
+            purchase_order_id=order.id, product_code=product_code
+        ).first()
+
+    if not match:
+        return
+
+    # Format: "M/D送qty"
+    m = delivery_date.month
+    d = delivery_date.day
+    qty_str = str(int(quantity)) if quantity == int(quantity) else str(quantity)
+    new_entry = f'{m}/{d}送{qty_str}'
+
+    current = (match.remarks or '').strip()
+    if new_entry in current:
+        return  # Already recorded
+    if current:
+        match.remarks = current + '，' + new_entry
+    else:
+        match.remarks = new_entry
+
+
+def _find_purchase_item(po_no, product_name, product_code):
+    """Find matching purchase item by po_no + product_name/product_code."""
+    if not po_no:
+        return None
+    order = PurchaseOrder.query.filter_by(po_no=po_no).first()
+    if not order:
+        return None
+    match = None
+    # Exact match by product_name
+    if product_name:
+        match = PurchaseItem.query.filter_by(
+            purchase_order_id=order.id, product_name=product_name
+        ).first()
+    # Exact match by product_code
+    if not match and product_code:
+        match = PurchaseItem.query.filter_by(
+            purchase_order_id=order.id, product_code=product_code
+        ).first()
+    # Fuzzy match by product_name (LIKE)
+    if not match and product_name:
+        match = PurchaseItem.query.filter(
+            PurchaseItem.purchase_order_id == order.id,
+            PurchaseItem.product_name.contains(product_name),
+        ).first()
+    # Reverse fuzzy: purchase product_name contains in delivery product_name
+    if not match and product_name:
+        for pi in order.items.all():
+            if pi.product_name and pi.product_name in product_name:
+                match = pi
+                break
+    return match
+
+
+def _remove_purchase_remarks(po_no, product_name, product_code, delivery_date, quantity):
+    """Remove 'M/D送qty' from matching purchase item remarks."""
+    order = PurchaseOrder.query.filter_by(po_no=po_no).first()
+    if not order:
+        return
+
+    match = None
+    if product_name:
+        match = PurchaseItem.query.filter_by(
+            purchase_order_id=order.id, product_name=product_name
+        ).first()
+    if not match and product_code:
+        match = PurchaseItem.query.filter_by(
+            purchase_order_id=order.id, product_code=product_code
+        ).first()
+    if not match:
+        return
+
+    m = delivery_date.month
+    d = delivery_date.day
+    qty_str = str(int(quantity)) if quantity == int(quantity) else str(quantity)
+    entry = f'{m}/{d}送{qty_str}'
+
+    current = (match.remarks or '').strip()
+    if entry not in current:
+        return
+
+    # Remove the entry and clean up separators
+    parts = [p.strip() for p in current.replace('、', '，').replace(',', '，').split('，') if p.strip()]
+    parts = [p for p in parts if p != entry]
+    match.remarks = '，'.join(parts)
+
+
+def _detect_delivery_columns(header):
+    """Detect column indices from header row."""
+    col_map = {}
+    name_mapping = {
+        'delivery_date': ('日期',),
+        'delivery_no': ('送货单号',),
+        'product_code': ('货号',),
+        'product_name': ('货号名称', '货品名称', '品名'),
+        'quantity': ('数量',),
+        'unit': ('单位RMB', '单位'),
+        'unit_price': ('单价RMB', '单价'),
+        'amount': ('金额RMB', '金额'),
+        'po_no': ('备注',),
+    }
+    for key, names in name_mapping.items():
+        for i, h in enumerate(header):
+            if h in names:
+                col_map[key] = i
+                break
+
+    # Must have at least delivery_no and product_name
+    if 'product_name' not in col_map:
+        return None
+    return col_map
+
+
+def _parse_excel_date(val):
+    """Parse various date formats from Excel."""
+    if val is None or (isinstance(val, float) and pd.isna(val)):
+        return None
+    if isinstance(val, datetime):
+        return val.date()
+    if isinstance(val, pd.Timestamp):
+        return val.date()
+    try:
+        if isinstance(val, (int, float)):
+            serial = int(val)
+            # Valid Excel serial dates are roughly 1 ~ 73050 (1900-01-01 ~ 2099-12-31)
+            if 1 <= serial <= 73050:
+                return (pd.Timestamp('1899-12-30') + pd.Timedelta(days=serial)).date()
+    except Exception:
+        pass
+    try:
+        return datetime.strptime(str(val).strip(), '%Y-%m-%d').date()
+    except Exception:
+        return None

--- a/apps/jiangping/routes/export.py
+++ b/apps/jiangping/routes/export.py
@@ -1,0 +1,150 @@
+import io
+from flask import Blueprint, request, send_file
+from models import db, Supplier, PurchaseOrder, PurchaseItem, DeliveryNote, DeliveryNoteItem
+from sqlalchemy import func
+from openpyxl.utils import get_column_letter
+import pandas as pd
+
+bp = Blueprint('export', __name__, url_prefix='/export')
+
+
+def _auto_fit_columns(writer):
+    """Auto-fit column widths based on cell content length."""
+    for sheet_name in writer.sheets:
+        ws = writer.sheets[sheet_name]
+        for col in ws.columns:
+            max_len = 0
+            col_letter = get_column_letter(col[0].column)
+            for cell in col:
+                val = str(cell.value) if cell.value is not None else ''
+                # Chinese characters count as ~2 width
+                length = 0
+                for ch in val:
+                    length += 2 if ord(ch) > 127 else 1
+                if length > max_len:
+                    max_len = length
+            ws.column_dimensions[col_letter].width = min(max_len + 3, 60)
+
+
+@bp.route('/excel')
+def export_excel():
+    supplier_id = request.args.get('supplier_id', type=int)
+    date_from = request.args.get('date_from')
+    date_to = request.args.get('date_to')
+    year = request.args.get('year', type=int)
+    query = db.session.query(PurchaseItem).join(PurchaseOrder).join(Supplier)
+    if supplier_id:
+        query = query.filter(PurchaseOrder.supplier_id == supplier_id)
+    if year:
+        query = query.filter(db.extract('year', PurchaseOrder.po_date) == year)
+    if date_from:
+        query = query.filter(PurchaseOrder.po_date >= date_from)
+    if date_to:
+        query = query.filter(PurchaseOrder.po_date <= date_to)
+    items = query.order_by(Supplier.short_name, PurchaseOrder.po_date).all()
+    supplier_data = {}
+    for item in items:
+        order = item.order
+        supplier = order.supplier
+        key = supplier.short_name or supplier.name
+        if key not in supplier_data:
+            supplier_data[key] = []
+        delivered_qty = db.session.query(
+            func.coalesce(func.sum(DeliveryNoteItem.quantity), 0)
+        ).join(DeliveryNote).filter(
+            DeliveryNoteItem.po_no == order.po_no,
+            DeliveryNoteItem.product_name == item.product_name,
+        ).scalar()
+        delivered_qty = float(delivered_qty)
+        purchase_qty = float(item.quantity or 0)
+        outstanding = purchase_qty - delivered_qty
+
+        if outstanding > 0:
+            outstanding_str = int(outstanding) if outstanding == int(outstanding) else outstanding
+        elif outstanding == 0 and delivered_qty > 0:
+            outstanding_str = '已送完'
+        else:
+            outstanding_str = ''
+
+        supplier_data[key].append({
+            '日期': order.po_date.strftime('%#m/%#d') if order.po_date else '',
+            '采购单号': order.po_no,
+            '货号': item.product_code or '',
+            '货品名称': item.product_name or '',
+            '数量': item.quantity,
+            '单位RMB': item.unit,
+            '单价RMB': float(item.unit_price or 0),
+            '金额RMB': float(item.amount or 0),
+            '交货期': order.delivery_date.strftime('%#m/%#d') if order.delivery_date else '',
+            '备注': item.remarks or '',
+            '欠数': outstanding_str,
+        })
+    output = io.BytesIO()
+    with pd.ExcelWriter(output, engine='openpyxl') as writer:
+        if not supplier_data:
+            pd.DataFrame().to_excel(writer, sheet_name='无数据', index=False)
+        for sheet_name, rows in supplier_data.items():
+            df = pd.DataFrame(rows)
+            df.to_excel(writer, sheet_name=sheet_name[:31], index=False)
+        _auto_fit_columns(writer)
+    output.seek(0)
+    return send_file(
+        output,
+        mimetype='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        as_attachment=True,
+        download_name='采购数据.xlsx'
+    )
+
+
+@bp.route('/delivery-excel')
+def export_delivery_excel():
+    supplier_id = request.args.get('supplier_id', type=int)
+    date_from = request.args.get('date_from')
+    date_to = request.args.get('date_to')
+    po_no = request.args.get('po_no', '').strip()
+    query = db.session.query(DeliveryNoteItem).join(DeliveryNote).join(Supplier)
+    if supplier_id:
+        query = query.filter(DeliveryNote.supplier_id == supplier_id)
+    if date_from:
+        query = query.filter(DeliveryNote.delivery_date >= date_from)
+    if date_to:
+        query = query.filter(DeliveryNote.delivery_date <= date_to)
+    if po_no:
+        query = query.filter(DeliveryNoteItem.po_no.contains(po_no))
+    items = query.order_by(
+        Supplier.short_name, DeliveryNote.delivery_date, DeliveryNote.delivery_no, DeliveryNoteItem.id
+    ).all()
+    supplier_data = {}
+    for item in items:
+        note = item.note
+        supplier = note.supplier
+        key = supplier.short_name or supplier.name
+        if key not in supplier_data:
+            supplier_data[key] = []
+        supplier_data[key].append({
+            '日期': note.delivery_date.strftime('%#m/%#d') if note.delivery_date else '',
+            '供应商': key,
+            '送货单号': note.delivery_no or '',
+            '货号': item.product_code or '',
+            '货号名称': item.product_name or '',
+            '数量': float(item.quantity or 0),
+            '单位RMB': item.unit or 'PCS',
+            '单价RMB': float(item.unit_price or 0),
+            '金额RMB': float(item.amount or 0),
+            '采购单号': item.po_no or '',
+        })
+    output = io.BytesIO()
+    with pd.ExcelWriter(output, engine='openpyxl') as writer:
+        if not supplier_data:
+            pd.DataFrame().to_excel(writer, sheet_name='无数据', index=False)
+        for sheet_name, rows in supplier_data.items():
+            df = pd.DataFrame(rows)
+            df.to_excel(writer, sheet_name=sheet_name[:31], index=False)
+        _auto_fit_columns(writer)
+    output.seek(0)
+    return send_file(
+        output,
+        mimetype='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        as_attachment=True,
+        download_name='交货数据.xlsx'
+    )

--- a/apps/jiangping/routes/purchase.py
+++ b/apps/jiangping/routes/purchase.py
@@ -1,0 +1,445 @@
+import os
+import re
+from datetime import datetime
+from flask import Blueprint, render_template, request, jsonify, flash, redirect, url_for, current_app
+from models import db, PurchaseOrder, PurchaseItem, Supplier, DeliveryNoteItem, DeliveryNote
+from sqlalchemy import func
+import pandas as pd
+
+bp = Blueprint('purchase', __name__, url_prefix='/purchases')
+
+@bp.route('/')
+def list_purchases():
+    suppliers = Supplier.query.order_by(Supplier.short_name).all()
+    # Collect distinct years from purchase orders
+    year_rows = db.session.query(
+        db.func.distinct(db.extract('year', PurchaseOrder.po_date))
+    ).filter(PurchaseOrder.po_date.isnot(None)).order_by(
+        db.extract('year', PurchaseOrder.po_date).desc()
+    ).all()
+    years = [int(r[0]) for r in year_rows]
+    return render_template('purchases.html', suppliers=suppliers, years=years)
+
+@bp.route('/api/list')
+def api_list():
+    """Return item-level data in Excel format, grouped by PO."""
+    query = db.session.query(PurchaseItem).join(PurchaseOrder).join(Supplier)
+
+    supplier_id = request.args.get('supplier_id', type=int)
+    if supplier_id:
+        query = query.filter(PurchaseOrder.supplier_id == supplier_id)
+    year = request.args.get('year', type=int)
+    if year:
+        query = query.filter(db.extract('year', PurchaseOrder.po_date) == year)
+    date_from = request.args.get('date_from')
+    if date_from:
+        query = query.filter(PurchaseOrder.po_date >= date_from)
+    date_to = request.args.get('date_to')
+    if date_to:
+        query = query.filter(PurchaseOrder.po_date <= date_to)
+    po_no = request.args.get('po_no', '').strip()
+    if po_no:
+        query = query.filter(PurchaseOrder.po_no.contains(po_no))
+
+    items = query.order_by(
+        Supplier.short_name, PurchaseOrder.po_date.desc(), PurchaseOrder.po_no, PurchaseItem.id
+    ).all()
+
+    result = []
+    last_po_no = None
+    for item in items:
+        order = item.order
+        is_first = (order.po_no != last_po_no)
+        last_po_no = order.po_no
+
+        # Calculate delivered quantity from delivery notes
+        delivered_qty = db.session.query(
+            func.coalesce(func.sum(DeliveryNoteItem.quantity), 0)
+        ).join(DeliveryNote).filter(
+            DeliveryNoteItem.po_no == order.po_no,
+            DeliveryNoteItem.product_name == item.product_name,
+        ).scalar()
+        delivered_qty = float(delivered_qty)
+        purchase_qty = float(item.quantity or 0)
+        outstanding = purchase_qty - delivered_qty
+
+        result.append({
+            'order_id': order.id,
+            'item_id': item.id,
+            'po_date': order.po_date.strftime('%#m/%#d') if order.po_date else '',
+            'po_no': order.po_no or '',
+            'product_code': item.product_code or '',
+            'product_name': item.product_name or '',
+            'quantity': item.quantity,
+            'unit': item.unit or 'PCS',
+            'unit_price': float(item.unit_price or 0),
+            'amount': float(item.amount or 0),
+            'delivered_qty': delivered_qty,
+            'outstanding': outstanding,
+            'delivery_date': order.delivery_date.strftime('%#m/%#d') if order.delivery_date and is_first else '',
+            'remarks': item.remarks or '',
+            'is_first': is_first,
+        })
+    return jsonify({'data': result})
+
+@bp.route('/<int:order_id>')
+def detail(order_id):
+    order = PurchaseOrder.query.get_or_404(order_id)
+    items = order.items.all()
+    return render_template('purchase_detail.html', order=order, items=items)
+
+@bp.route('/<int:order_id>/delete', methods=['POST'])
+def delete_order(order_id):
+    order = PurchaseOrder.query.get_or_404(order_id)
+    db.session.delete(order)
+    db.session.commit()
+    flash(f'采购单 {order.po_no} 已删除', 'success')
+    return redirect(url_for('purchase.list_purchases'))
+
+@bp.route('/import-excel', methods=['POST'])
+def import_excel():
+    """Import purchase data from an Excel file (one sheet per supplier)."""
+    if 'file' not in request.files:
+        flash('没有选择文件', 'danger')
+        return redirect(url_for('purchase.list_purchases'))
+
+    file = request.files['file']
+    if not file.filename.lower().endswith(('.xls', '.xlsx')):
+        flash('请上传 Excel 文件 (.xls 或 .xlsx)', 'danger')
+        return redirect(url_for('purchase.list_purchases'))
+
+    filepath = os.path.join(current_app.config['UPLOAD_FOLDER'], file.filename)
+    file.save(filepath)
+
+    try:
+        xls = pd.ExcelFile(filepath)
+        total_orders = 0
+        total_items = 0
+
+        for sheet_name in xls.sheet_names:
+            df = pd.read_excel(xls, sheet_name=sheet_name, header=None)
+            if df.empty or len(df) < 2:
+                continue
+
+            supplier_short = sheet_name.strip()
+
+            # Find or create supplier
+            supplier = Supplier.query.filter_by(short_name=supplier_short).first()
+            if not supplier:
+                supplier = Supplier(name=supplier_short, short_name=supplier_short)
+                db.session.add(supplier)
+                db.session.flush()
+
+            # Detect column mapping from header row (row 0)
+            header = [str(c).strip() for c in df.iloc[0].tolist()]
+            col_map = _detect_columns(header)
+            if col_map is None:
+                continue  # Skip unrecognized sheets
+
+            current_po_no = None
+            current_po_date = None
+            current_delivery_date = None
+            current_order = None
+
+            for idx in range(1, len(df)):
+                row = df.iloc[idx]
+
+                def cell(key):
+                    ci = col_map.get(key)
+                    if ci is None or ci >= len(row):
+                        return None
+                    v = row.iloc[ci]
+                    return v if pd.notna(v) else None
+
+                product_name = str(cell('product_name') or '').strip()
+                if not product_name or product_name == 'nan':
+                    continue
+
+                po_no_val = cell('po_no')
+                po_date_val = cell('po_date')
+                product_code = str(cell('product_code') or '').strip()
+                quantity = cell('quantity') or 0
+                unit = str(cell('unit') or 'PCS').strip()
+                unit_price = cell('unit_price') or 0
+                amount = cell('amount') or 0
+                delivery_date_val = cell('delivery_date')
+                remarks = str(cell('remarks') or '').strip()
+
+                # Skip if po_no is actually a date (datetime object or date-like string)
+                if po_no_val is not None and isinstance(po_no_val, datetime):
+                    if not current_po_date:
+                        current_po_date = po_no_val.date()
+                    po_no_val = None
+                elif po_no_val is not None:
+                    po_str = str(po_no_val).strip()
+                    # Detect date-like strings: "2025-07-22 00:00:00" or "2025-07-22"
+                    if re.match(r'^\d{4}-\d{2}-\d{2}', po_str):
+                        if not current_po_date:
+                            current_po_date = _parse_excel_date(po_no_val)
+                        po_no_val = None
+
+                # New order if PO.NO is present
+                if po_no_val is not None and str(po_no_val).strip() and str(po_no_val).strip() != 'nan':
+                    current_po_no = str(po_no_val).strip()
+                    current_po_date = _parse_excel_date(po_date_val)
+                    current_delivery_date = _parse_excel_date(delivery_date_val)
+
+                    current_order = PurchaseOrder.query.filter_by(po_no=current_po_no).first()
+                    if not current_order:
+                        current_order = PurchaseOrder(
+                            po_no=current_po_no,
+                            po_date=current_po_date,
+                            supplier_id=supplier.id,
+                            delivery_date=current_delivery_date,
+                            receiver='',
+                            total_amount=0,
+                            pdf_filename='',
+                        )
+                        db.session.add(current_order)
+                        db.session.flush()
+                        total_orders += 1
+                else:
+                    if delivery_date_val is not None:
+                        dd = _parse_excel_date(delivery_date_val)
+                        if dd:
+                            current_delivery_date = dd
+
+                if not current_order:
+                    continue
+
+                # Parse numeric values
+                try:
+                    quantity = int(float(quantity)) if quantity else 0
+                except (ValueError, TypeError):
+                    quantity = 0
+                try:
+                    unit_price = float(unit_price) if unit_price else 0
+                except (ValueError, TypeError):
+                    unit_price = 0
+                try:
+                    amount = float(amount) if amount else 0
+                except (ValueError, TypeError):
+                    amount = 0
+
+                # Handle product_code that might be numeric
+                if product_code and product_code != 'nan':
+                    try:
+                        pc = float(product_code)
+                        product_code = str(int(pc)) if pc == int(pc) else str(pc)
+                    except (ValueError, TypeError):
+                        pass
+                else:
+                    product_code = ''
+
+                item = PurchaseItem(
+                    purchase_order_id=current_order.id,
+                    product_code=product_code,
+                    product_name=product_name,
+                    specification='',
+                    quantity=quantity,
+                    unit=unit if unit != 'nan' else 'PCS',
+                    unit_price=unit_price,
+                    amount=amount,
+                    remarks=remarks if remarks != 'nan' else '',
+                )
+                db.session.add(item)
+                total_items += 1
+
+            # Update order totals
+            for order in PurchaseOrder.query.filter_by(supplier_id=supplier.id).all():
+                order.total_amount = sum(
+                    float(i.amount or 0) for i in order.items.all()
+                )
+
+        db.session.commit()
+        flash(f'导入成功！共导入 {total_orders} 个采购单，{total_items} 条明细', 'success')
+
+    except Exception as e:
+        db.session.rollback()
+        flash(f'导入失败: {str(e)}', 'danger')
+
+    return redirect(url_for('purchase.list_purchases'))
+
+
+def _detect_columns(header):
+    """Detect column indices from header row by matching known column names."""
+    col_map = {}
+    name_mapping = {
+        'po_date': ('PO期', '日期'),
+        'po_no': ('PO.NO', '采购单号', 'PO.No'),
+        'product_code': ('货号',),
+        'product_name': ('货品名称', '产品名称', '品名'),
+        'quantity': ('数量',),
+        'unit': ('单位RMB', '单位'),
+        'unit_price': ('单价RMB', '单价'),
+        'amount': ('金额RMB', '金额'),
+        'delivery_date': ('交货期', '交货日期'),
+        'remarks': ('备注',),
+    }
+    for key, names in name_mapping.items():
+        for i, h in enumerate(header):
+            if h in names:
+                col_map[key] = i
+                break
+
+    # Must have at least po_no and product_name to be valid
+    if 'po_no' not in col_map or 'product_name' not in col_map:
+        return None
+    return col_map
+
+
+def _parse_excel_date(val):
+    """Parse various date formats from Excel."""
+    if val is None or (isinstance(val, float) and pd.isna(val)):
+        return None
+    if isinstance(val, datetime):
+        return val.date()
+    if isinstance(val, pd.Timestamp):
+        return val.date()
+    try:
+        # Excel serial date number
+        if isinstance(val, (int, float)):
+            return pd.Timestamp('1899-12-30') + pd.Timedelta(days=int(val))
+    except Exception:
+        pass
+    try:
+        return datetime.strptime(str(val).strip(), '%Y-%m-%d').date()
+    except Exception:
+        return None
+
+
+@bp.route('/api/create', methods=['POST'])
+def api_create():
+    """Create a new purchase order with items."""
+    data = request.get_json()
+    if not data:
+        return jsonify({'error': '无数据'}), 400
+
+    supplier_id = data.get('supplier_id')
+    if not supplier_id:
+        return jsonify({'error': '请选择供应商'}), 400
+
+    po_no = (data.get('po_no') or '').strip()
+    if not po_no:
+        return jsonify({'error': '请输入采购单号'}), 400
+
+    # Check duplicate
+    existing = PurchaseOrder.query.filter_by(po_no=po_no).first()
+    if existing:
+        return jsonify({'error': f'采购单号 {po_no} 已存在'}), 400
+
+    po_date = None
+    if data.get('po_date'):
+        try:
+            po_date = datetime.strptime(data['po_date'], '%Y-%m-%d').date()
+        except ValueError:
+            pass
+
+    delivery_date = None
+    if data.get('delivery_date'):
+        try:
+            delivery_date = datetime.strptime(data['delivery_date'], '%Y-%m-%d').date()
+        except ValueError:
+            pass
+
+    order = PurchaseOrder(
+        po_no=po_no,
+        po_date=po_date,
+        supplier_id=supplier_id,
+        delivery_date=delivery_date,
+        receiver='',
+        total_amount=0,
+        pdf_filename='',
+    )
+    db.session.add(order)
+    db.session.flush()
+
+    for it in data.get('items', []):
+        product_name = (it.get('product_name') or '').strip()
+        if not product_name:
+            continue
+        item = PurchaseItem(
+            purchase_order_id=order.id,
+            product_code=(it.get('product_code') or '').strip(),
+            product_name=product_name,
+            specification='',
+            quantity=int(float(it.get('quantity') or 0)),
+            unit=(it.get('unit') or 'PCS').strip(),
+            unit_price=float(it.get('unit_price') or 0),
+            amount=float(it.get('amount') or 0),
+            remarks=(it.get('remarks') or '').strip(),
+        )
+        db.session.add(item)
+
+    order.total_amount = sum(float(i.get('amount') or 0) for i in data.get('items', []))
+    db.session.commit()
+    return jsonify({'success': True, 'order_id': order.id})
+
+
+@bp.route('/api/item/<int:item_id>', methods=['PUT'])
+def api_update_item(item_id):
+    """Update a purchase item."""
+    item = PurchaseItem.query.get_or_404(item_id)
+    data = request.get_json()
+    for field in ['product_code', 'product_name', 'specification', 'remarks']:
+        if field in data:
+            setattr(item, field, (data[field] or '').strip())
+    if 'unit' in data:
+        item.unit = (data['unit'] or 'PCS').strip()
+    for field in ['quantity']:
+        if field in data:
+            try:
+                setattr(item, field, int(float(data[field] or 0)))
+            except (ValueError, TypeError):
+                pass
+    for field in ['unit_price', 'amount']:
+        if field in data:
+            try:
+                setattr(item, field, float(data[field] or 0))
+            except (ValueError, TypeError):
+                pass
+
+    # Recalculate order total
+    order = item.order
+    db.session.flush()
+    order.total_amount = sum(float(i.amount or 0) for i in order.items.all())
+    db.session.commit()
+    return jsonify({'success': True})
+
+
+@bp.route('/api/item/<int:item_id>', methods=['DELETE'])
+def api_delete_item(item_id):
+    """Delete a purchase item."""
+    item = PurchaseItem.query.get_or_404(item_id)
+    order = item.order
+    db.session.delete(item)
+    db.session.flush()
+
+    # If order has no more items, delete the order too
+    if order.items.count() == 0:
+        db.session.delete(order)
+    else:
+        order.total_amount = sum(float(i.amount or 0) for i in order.items.all())
+
+    db.session.commit()
+    return jsonify({'success': True})
+
+
+@bp.route('/api/order/<int:order_id>', methods=['DELETE'])
+def api_delete_order(order_id):
+    """Delete an entire purchase order."""
+    order = PurchaseOrder.query.get_or_404(order_id)
+    db.session.delete(order)
+    db.session.commit()
+    return jsonify({'success': True})
+
+
+@bp.route('/item/<int:item_id>/update', methods=['POST'])
+def update_item(item_id):
+    item = PurchaseItem.query.get_or_404(item_id)
+    data = request.get_json()
+    for field in ['product_code', 'product_name', 'specification', 'quantity', 'unit', 'unit_price', 'amount', 'remarks']:
+        if field in data:
+            setattr(item, field, data[field])
+    db.session.commit()
+    return jsonify({'success': True})

--- a/apps/jiangping/routes/supplier.py
+++ b/apps/jiangping/routes/supplier.py
@@ -1,0 +1,24 @@
+from flask import Blueprint, render_template, request, jsonify
+from models import db, Supplier, PurchaseOrder
+from sqlalchemy import func
+
+bp = Blueprint('supplier', __name__, url_prefix='/suppliers')
+
+@bp.route('/')
+def list_suppliers():
+    suppliers = db.session.query(
+        Supplier,
+        func.count(PurchaseOrder.id).label('order_count'),
+        func.coalesce(func.sum(PurchaseOrder.total_amount), 0).label('total_amount')
+    ).outerjoin(PurchaseOrder).group_by(Supplier.id).order_by(Supplier.short_name).all()
+    return render_template('suppliers.html', suppliers=suppliers)
+
+@bp.route('/<int:supplier_id>/update', methods=['POST'])
+def update_supplier(supplier_id):
+    supplier = Supplier.query.get_or_404(supplier_id)
+    data = request.get_json()
+    for field in ['name', 'short_name', 'contact', 'tel', 'fax', 'address']:
+        if field in data:
+            setattr(supplier, field, data[field])
+    db.session.commit()
+    return jsonify({'success': True})

--- a/apps/jiangping/routes/upload.py
+++ b/apps/jiangping/routes/upload.py
@@ -1,0 +1,95 @@
+import os
+from datetime import datetime
+from flask import Blueprint, render_template, request, jsonify, current_app
+from werkzeug.utils import secure_filename
+from parser.pdf_parser import parse_purchase_pdf
+from models import db, Supplier, PurchaseOrder, PurchaseItem
+
+
+def _parse_date(date_str):
+    if not date_str:
+        return None
+    try:
+        return datetime.strptime(date_str, '%Y-%m-%d').date()
+    except (ValueError, TypeError):
+        return None
+
+
+bp = Blueprint('upload', __name__, url_prefix='/upload')
+
+
+@bp.route('/')
+def upload_page():
+    return render_template('upload.html')
+
+
+@bp.route('/parse', methods=['POST'])
+def parse_pdf():
+    if 'file' not in request.files:
+        return jsonify({'error': '没有选择文件'}), 400
+    file = request.files['file']
+    if not file.filename.lower().endswith('.pdf'):
+        return jsonify({'error': '请上传PDF文件'}), 400
+    original_name = file.filename
+    filepath = os.path.join(current_app.config['UPLOAD_FOLDER'], original_name)
+    file.save(filepath)
+    try:
+        data = parse_purchase_pdf(filepath)
+        data['pdf_filename'] = original_name
+        existing = PurchaseOrder.query.filter_by(po_no=data.get('po_no', '')).first()
+        if existing:
+            data['warning'] = f"采购单 {data['po_no']} 已存在，保存将覆盖原有数据"
+        return jsonify(data)
+    except Exception as e:
+        return jsonify({'error': f'PDF解析失败: {str(e)}'}), 400
+
+
+@bp.route('/save', methods=['POST'])
+def save_parsed():
+    data = request.get_json()
+    if not data:
+        return jsonify({'error': '无数据'}), 400
+    po_no = data.get('po_no', '')
+    supplier_name = data.get('supplier_name', '')
+    supplier = Supplier.query.filter_by(name=supplier_name).first()
+    if not supplier:
+        supplier = Supplier(
+            name=supplier_name,
+            short_name=supplier_name[:2] if supplier_name else '',
+            contact=data.get('supplier_contact', ''),
+            tel=data.get('supplier_tel', ''),
+            fax=data.get('supplier_fax', ''),
+        )
+        db.session.add(supplier)
+        db.session.flush()
+    existing = PurchaseOrder.query.filter_by(po_no=po_no).first()
+    if existing:
+        db.session.delete(existing)
+        db.session.flush()
+    order = PurchaseOrder(
+        po_no=po_no,
+        po_date=_parse_date(data.get('po_date')),
+        supplier_id=supplier.id,
+        delivery_date=_parse_date(data.get('delivery_date')),
+        receiver=data.get('receiver', ''),
+        total_amount=sum(item.get('amount', 0) for item in data.get('items', [])),
+        pdf_filename=data.get('pdf_filename', ''),
+    )
+    db.session.add(order)
+    db.session.flush()
+    for item_data in data.get('items', []):
+        item = PurchaseItem(
+            purchase_order_id=order.id,
+            material_code=item_data.get('material_code', ''),
+            product_code=item_data.get('product_code', ''),
+            product_name=item_data.get('product_name', ''),
+            specification=item_data.get('specification', ''),
+            quantity=item_data.get('quantity', 0),
+            unit=item_data.get('unit', 'PCS'),
+            unit_price=item_data.get('unit_price', 0),
+            amount=item_data.get('amount', 0),
+            remarks=item_data.get('remarks', ''),
+        )
+        db.session.add(item)
+    db.session.commit()
+    return jsonify({'success': True, 'message': f'采购单 {po_no} 已保存，共 {len(data.get("items", []))} 条明细'})

--- a/apps/jiangping/static/css/style.css
+++ b/apps/jiangping/static/css/style.css
@@ -1,0 +1,29 @@
+#sidebar .nav-link:hover {
+    background-color: rgba(255, 255, 255, 0.1);
+    border-radius: 0.375rem;
+}
+.border-dashed {
+    border-style: dashed !important;
+}
+#dropZone.border-primary {
+    background-color: rgba(13, 110, 253, 0.05);
+}
+
+/* 采购表格 - 不换行，可横向滚动 */
+.table-scroll-wrapper {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+}
+#purchases-table,
+#delivery-table {
+    white-space: nowrap;
+    width: auto !important;
+    min-width: 100%;
+}
+#purchases-table td,
+#purchases-table th,
+#delivery-table td,
+#delivery-table th {
+    white-space: nowrap;
+    padding: 0.4rem 0.6rem;
+}

--- a/apps/jiangping/static/js/app.js
+++ b/apps/jiangping/static/js/app.js
@@ -1,0 +1,6 @@
+if ($.fn.DataTable) {
+    $.extend($.fn.DataTable.defaults, {
+        pageLength: 25,
+        responsive: true,
+    });
+}

--- a/apps/jiangping/templates/base.html
+++ b/apps/jiangping/templates/base.html
@@ -40,6 +40,7 @@
     <script src="https://cdn.datatables.net/1.13.8/js/jquery.dataTables.min.js"></script>
     <script src="https://cdn.datatables.net/1.13.8/js/dataTables.bootstrap5.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
+    <script>var BASE_URL = '{{ request.script_root }}';</script>
     <script src="{{ url_for('static', filename='js/app.js') }}"></script>
     {% block extra_js %}{% endblock %}
 </body>

--- a/apps/jiangping/templates/base.html
+++ b/apps/jiangping/templates/base.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}采购管理系统{% endblock %}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="https://cdn.datatables.net/1.13.8/css/dataTables.bootstrap5.min.css" rel="stylesheet">
+    <link href="{{ url_for('static', filename='css/style.css') }}" rel="stylesheet">
+    {% block extra_css %}{% endblock %}
+</head>
+<body>
+    <div class="d-flex">
+        <nav id="sidebar" class="bg-dark text-white vh-100 position-fixed" style="width: 220px;">
+            <div class="p-3">
+                <h5 class="text-center mb-4">采购管理系统</h5>
+                <ul class="nav flex-column">
+                    <li class="nav-item mb-2"><a class="nav-link text-white {% if request.path.startswith('/upload') %}active bg-primary rounded{% endif %}" href="{{ url_for('upload.upload_page') }}"><i class="bi bi-cloud-upload me-2"></i>PDF导入</a></li>
+                    <li class="nav-item mb-2"><a class="nav-link text-white {% if request.path.startswith('/purchases') %}active bg-primary rounded{% endif %}" href="{{ url_for('purchase.list_purchases') }}"><i class="bi bi-cart me-2"></i>采购管理</a></li>
+                    <li class="nav-item mb-2"><a class="nav-link text-white {% if request.path.startswith('/suppliers') %}active bg-primary rounded{% endif %}" href="{{ url_for('supplier.list_suppliers') }}"><i class="bi bi-building me-2"></i>供应商管理</a></li>
+                    <li class="nav-item mb-2"><a class="nav-link text-white {% if request.path == '/delivery-mgmt' or request.path.startswith('/delivery-mgmt/') %}active bg-primary rounded{% endif %}" href="{{ url_for('delivery_mgmt.list_deliveries') }}"><i class="bi bi-truck me-2"></i>交货管理</a></li>
+                    <li class="nav-item mb-2"><a class="nav-link text-white {% if request.path == '/delivery' or request.path.startswith('/delivery/') %}active bg-primary rounded{% endif %}" href="{{ url_for('delivery.delivery_page') }}"><i class="bi bi-clipboard-check me-2"></i>收货对账</a></li>
+                    <li class="nav-item mb-2"><a class="nav-link text-white {% if request.path.startswith('/dashboard') %}active bg-primary rounded{% endif %}" href="{{ url_for('dashboard.dashboard_page') }}"><i class="bi bi-bar-chart me-2"></i>统计图表</a></li>
+                </ul>
+            </div>
+        </nav>
+        <main class="flex-grow-1" style="margin-left: 220px;">
+            <div class="container-fluid p-4">
+                {% with messages = get_flashed_messages(with_categories=true) %}
+                {% if messages %}{% for category, message in messages %}
+                <div class="alert alert-{{ category }} alert-dismissible fade show">{{ message }}<button type="button" class="btn-close" data-bs-dismiss="alert"></button></div>
+                {% endfor %}{% endif %}{% endwith %}
+                {% block content %}{% endblock %}
+            </div>
+        </main>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script src="https://cdn.datatables.net/1.13.8/js/jquery.dataTables.min.js"></script>
+    <script src="https://cdn.datatables.net/1.13.8/js/dataTables.bootstrap5.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
+    <script src="{{ url_for('static', filename='js/app.js') }}"></script>
+    {% block extra_js %}{% endblock %}
+</body>
+</html>

--- a/apps/jiangping/templates/dashboard.html
+++ b/apps/jiangping/templates/dashboard.html
@@ -86,7 +86,7 @@
     'use strict';
 
     // ── 1. By Supplier (horizontal bar) ────────────────────────────────────
-    fetch('/dashboard/api/by_supplier')
+    fetch(BASE_URL + '/dashboard/api/by_supplier')
         .then(r => r.json())
         .then(d => {
             new Chart(document.getElementById('chartSupplier'), {
@@ -120,7 +120,7 @@
         });
 
     // ── 2. By Month (line) ─────────────────────────────────────────────────
-    fetch('/dashboard/api/by_month')
+    fetch(BASE_URL + '/dashboard/api/by_month')
         .then(r => r.json())
         .then(d => {
             new Chart(document.getElementById('chartMonth'), {
@@ -155,7 +155,7 @@
         });
 
     // ── 3. By Product Top 20 (bar) ─────────────────────────────────────────
-    fetch('/dashboard/api/by_product?n=20')
+    fetch(BASE_URL + '/dashboard/api/by_product?n=20')
         .then(r => r.json())
         .then(d => {
             new Chart(document.getElementById('chartProduct'), {
@@ -191,7 +191,7 @@
         });
 
     // ── 4. Delivery Stats (doughnut) ───────────────────────────────────────
-    fetch('/dashboard/api/delivery_stats')
+    fetch(BASE_URL + '/dashboard/api/delivery_stats')
         .then(r => r.json())
         .then(d => {
             new Chart(document.getElementById('chartDelivery'), {
@@ -229,7 +229,7 @@
             return;
         }
 
-        const url = `/dashboard/api/period_compare?p1_from=${p1From}&p1_to=${p1To}&p2_from=${p2From}&p2_to=${p2To}`;
+        const url = BASE_URL + `/dashboard/api/period_compare?p1_from=${p1From}&p1_to=${p1To}&p2_from=${p2From}&p2_to=${p2To}`;
 
         fetch(url)
             .then(r => r.json())

--- a/apps/jiangping/templates/dashboard.html
+++ b/apps/jiangping/templates/dashboard.html
@@ -1,0 +1,281 @@
+{% extends 'base.html' %}
+{% block title %}统计图表 - 采购管理系统{% endblock %}
+
+{% block content %}
+<h2 class="mb-4">统计图表</h2>
+
+<!-- Row 1: By Supplier + By Month -->
+<div class="row g-4 mb-4">
+    <div class="col-md-6">
+        <div class="card h-100">
+            <div class="card-header fw-semibold">按供应商采购金额</div>
+            <div class="card-body">
+                <canvas id="chartSupplier"></canvas>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-6">
+        <div class="card h-100">
+            <div class="card-header fw-semibold">按月采购趋势</div>
+            <div class="card-body">
+                <canvas id="chartMonth"></canvas>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Row 2: By Product Top 20 + Delivery Stats -->
+<div class="row g-4 mb-4">
+    <div class="col-md-6">
+        <div class="card h-100">
+            <div class="card-header fw-semibold">按货号采购量 Top 20</div>
+            <div class="card-body">
+                <canvas id="chartProduct"></canvas>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-6">
+        <div class="card h-100">
+            <div class="card-header fw-semibold">交货情况</div>
+            <div class="card-body d-flex justify-content-center align-items-center">
+                <canvas id="chartDelivery" style="max-width: 320px; max-height: 320px;"></canvas>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Row 3: Period Comparison (full width) -->
+<div class="row g-4 mb-4">
+    <div class="col-12">
+        <div class="card">
+            <div class="card-header fw-semibold">按时间段对比</div>
+            <div class="card-body">
+                <div class="row g-3 align-items-end mb-3">
+                    <div class="col-auto">
+                        <label class="form-label mb-1 fw-semibold text-primary">时间段一</label>
+                        <div class="d-flex gap-2 align-items-center">
+                            <input type="date" id="p1From" class="form-control form-control-sm" style="width:150px;">
+                            <span class="text-muted">至</span>
+                            <input type="date" id="p1To" class="form-control form-control-sm" style="width:150px;">
+                        </div>
+                    </div>
+                    <div class="col-auto">
+                        <label class="form-label mb-1 fw-semibold text-danger">时间段二</label>
+                        <div class="d-flex gap-2 align-items-center">
+                            <input type="date" id="p2From" class="form-control form-control-sm" style="width:150px;">
+                            <span class="text-muted">至</span>
+                            <input type="date" id="p2To" class="form-control form-control-sm" style="width:150px;">
+                        </div>
+                    </div>
+                    <div class="col-auto">
+                        <button id="btnCompare" class="btn btn-primary btn-sm">
+                            <i class="bi bi-bar-chart-line me-1"></i>对比
+                        </button>
+                    </div>
+                </div>
+                <canvas id="chartPeriod"></canvas>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+(function () {
+    'use strict';
+
+    // ── 1. By Supplier (horizontal bar) ────────────────────────────────────
+    fetch('/dashboard/api/by_supplier')
+        .then(r => r.json())
+        .then(d => {
+            new Chart(document.getElementById('chartSupplier'), {
+                type: 'bar',
+                data: {
+                    labels: d.labels,
+                    datasets: [{
+                        label: '采购金额',
+                        data: d.data,
+                        backgroundColor: 'rgba(54,162,235,0.7)',
+                        borderColor: 'rgba(54,162,235,1)',
+                        borderWidth: 1
+                    }]
+                },
+                options: {
+                    indexAxis: 'y',
+                    responsive: true,
+                    plugins: {
+                        legend: { display: false }
+                    },
+                    scales: {
+                        x: {
+                            beginAtZero: true,
+                            ticks: {
+                                callback: v => '¥' + v.toLocaleString()
+                            }
+                        }
+                    }
+                }
+            });
+        });
+
+    // ── 2. By Month (line) ─────────────────────────────────────────────────
+    fetch('/dashboard/api/by_month')
+        .then(r => r.json())
+        .then(d => {
+            new Chart(document.getElementById('chartMonth'), {
+                type: 'line',
+                data: {
+                    labels: d.labels,
+                    datasets: [{
+                        label: '月度采购金额',
+                        data: d.data,
+                        borderColor: '#198754',
+                        backgroundColor: 'rgba(25,135,84,0.1)',
+                        fill: true,
+                        tension: 0.3,
+                        pointRadius: 4
+                    }]
+                },
+                options: {
+                    responsive: true,
+                    plugins: {
+                        legend: { display: false }
+                    },
+                    scales: {
+                        y: {
+                            beginAtZero: true,
+                            ticks: {
+                                callback: v => '¥' + v.toLocaleString()
+                            }
+                        }
+                    }
+                }
+            });
+        });
+
+    // ── 3. By Product Top 20 (bar) ─────────────────────────────────────────
+    fetch('/dashboard/api/by_product?n=20')
+        .then(r => r.json())
+        .then(d => {
+            new Chart(document.getElementById('chartProduct'), {
+                type: 'bar',
+                data: {
+                    labels: d.labels,
+                    datasets: [{
+                        label: '采购数量',
+                        data: d.quantities,
+                        backgroundColor: 'rgba(255,159,64,0.7)',
+                        borderColor: 'rgba(255,159,64,1)',
+                        borderWidth: 1
+                    }]
+                },
+                options: {
+                    responsive: true,
+                    plugins: {
+                        legend: { display: false }
+                    },
+                    scales: {
+                        y: {
+                            beginAtZero: true
+                        },
+                        x: {
+                            ticks: {
+                                maxRotation: 45,
+                                minRotation: 30
+                            }
+                        }
+                    }
+                }
+            });
+        });
+
+    // ── 4. Delivery Stats (doughnut) ───────────────────────────────────────
+    fetch('/dashboard/api/delivery_stats')
+        .then(r => r.json())
+        .then(d => {
+            new Chart(document.getElementById('chartDelivery'), {
+                type: 'doughnut',
+                data: {
+                    labels: ['准时', '延迟', '未交', '部分'],
+                    datasets: [{
+                        data: [d.on_time, d.late, d.undelivered, d.partial],
+                        backgroundColor: ['#198754', '#dc3545', '#6c757d', '#ffc107'],
+                        borderWidth: 2
+                    }]
+                },
+                options: {
+                    responsive: true,
+                    plugins: {
+                        legend: {
+                            position: 'bottom'
+                        }
+                    }
+                }
+            });
+        });
+
+    // ── 5. Period Comparison (bar, on button click) ────────────────────────
+    let periodChart = null;
+
+    document.getElementById('btnCompare').addEventListener('click', function () {
+        const p1From = document.getElementById('p1From').value;
+        const p1To   = document.getElementById('p1To').value;
+        const p2From = document.getElementById('p2From').value;
+        const p2To   = document.getElementById('p2To').value;
+
+        if (!p1From || !p1To || !p2From || !p2To) {
+            alert('请填写两个完整的时间段。');
+            return;
+        }
+
+        const url = `/dashboard/api/period_compare?p1_from=${p1From}&p1_to=${p1To}&p2_from=${p2From}&p2_to=${p2To}`;
+
+        fetch(url)
+            .then(r => r.json())
+            .then(d => {
+                if (periodChart) {
+                    periodChart.destroy();
+                    periodChart = null;
+                }
+                periodChart = new Chart(document.getElementById('chartPeriod'), {
+                    type: 'bar',
+                    data: {
+                        labels: d.labels,
+                        datasets: [
+                            {
+                                label: `时间段一 (${p1From} ~ ${p1To})`,
+                                data: d.period1,
+                                backgroundColor: 'rgba(54,162,235,0.7)',
+                                borderColor: 'rgba(54,162,235,1)',
+                                borderWidth: 1
+                            },
+                            {
+                                label: `时间段二 (${p2From} ~ ${p2To})`,
+                                data: d.period2,
+                                backgroundColor: 'rgba(255,99,132,0.7)',
+                                borderColor: 'rgba(255,99,132,1)',
+                                borderWidth: 1
+                            }
+                        ]
+                    },
+                    options: {
+                        responsive: true,
+                        plugins: {
+                            legend: { position: 'top' }
+                        },
+                        scales: {
+                            y: {
+                                beginAtZero: true,
+                                ticks: {
+                                    callback: v => '¥' + v.toLocaleString()
+                                }
+                            }
+                        }
+                    }
+                });
+            });
+    });
+})();
+</script>
+{% endblock %}

--- a/apps/jiangping/templates/delivery.html
+++ b/apps/jiangping/templates/delivery.html
@@ -1,0 +1,259 @@
+{% extends 'base.html' %}
+
+{% block title %}收货对账 - 采购管理系统{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h4 class="mb-0"><i class="bi bi-clipboard-check me-2"></i>收货对账</h4>
+</div>
+
+<!-- Filter Card -->
+<div class="card mb-4 shadow-sm">
+    <div class="card-body">
+        <div class="row g-3 align-items-end">
+            <div class="col-md-4">
+                <label for="supplierFilter" class="form-label">供应商</label>
+                <select id="supplierFilter" class="form-select">
+                    <option value="">-- 全部供应商 --</option>
+                    {% for s in suppliers %}
+                    <option value="{{ s.id }}">{{ s.short_name or s.name }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="col-md-4">
+                <label for="poNoFilter" class="form-label">采购单号</label>
+                <input type="text" id="poNoFilter" class="form-control" placeholder="输入采购单号搜索">
+            </div>
+            <div class="col-md-4">
+                <button id="btnQuery" class="btn btn-primary w-100">
+                    <i class="bi bi-search me-1"></i>查询
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Reconciliation Table -->
+<div class="card shadow-sm">
+    <div class="card-body">
+        <div class="table-responsive">
+            <table id="deliveryTable" class="table table-hover table-bordered align-middle w-100">
+                <thead class="table-dark">
+                    <tr>
+                        <th>采购单号</th>
+                        <th>采购日期</th>
+                        <th>供应商</th>
+                        <th>货号</th>
+                        <th>货品名称</th>
+                        <th>采购数量</th>
+                        <th>已交数量</th>
+                        <th>差异</th>
+                        <th>状态</th>
+                        <th>操作</th>
+                    </tr>
+                </thead>
+                <tbody></tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+<!-- Add Delivery Modal -->
+<div class="modal fade" id="addDeliveryModal" tabindex="-1" aria-labelledby="addDeliveryModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="addDeliveryModalLabel"><i class="bi bi-plus-circle me-2"></i>登记收货记录</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <form id="deliveryForm">
+                    <input type="hidden" id="modalItemId">
+                    <div class="mb-3">
+                        <label class="form-label text-muted">货品信息</label>
+                        <div id="modalItemInfo" class="p-2 bg-light rounded small"></div>
+                    </div>
+                    <div class="mb-3">
+                        <label for="modalDeliveryDate" class="form-label">收货日期 <span class="text-danger">*</span></label>
+                        <input type="date" id="modalDeliveryDate" class="form-control" required>
+                    </div>
+                    <div class="mb-3">
+                        <label for="modalQty" class="form-label">收货数量 <span class="text-danger">*</span></label>
+                        <input type="number" id="modalQty" class="form-control" min="1" required placeholder="请输入收货数量">
+                    </div>
+                    <div class="mb-3">
+                        <label for="modalRemarks" class="form-label">备注</label>
+                        <textarea id="modalRemarks" class="form-control" rows="2" placeholder="可选备注信息"></textarea>
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">取消</button>
+                <button type="button" id="btnSaveDelivery" class="btn btn-primary">
+                    <i class="bi bi-save me-1"></i>保存
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+const statusMap = {
+    undelivered: { label: '未交',   cls: 'danger'  },
+    partial:     { label: '少交',   cls: 'warning'  },
+    complete:    { label: '已完成', cls: 'success'  },
+    over:        { label: '超交',   cls: 'primary'  },
+};
+
+let table = null;
+
+function buildUrl() {
+    const supplierId = $('#supplierFilter').val();
+    const poNo = $('#poNoFilter').val().trim();
+    let url = '/delivery/api/reconciliation?';
+    if (supplierId) url += 'supplier_id=' + supplierId + '&';
+    if (poNo) url += 'po_no=' + encodeURIComponent(poNo) + '&';
+    return url;
+}
+
+function initTable() {
+    table = $('#deliveryTable').DataTable({
+        ajax: { url: buildUrl(), dataSrc: 'data' },
+        columns: [
+            { data: 'po_no' },
+            { data: 'po_date' },
+            { data: 'supplier' },
+            { data: 'product_code', defaultContent: '' },
+            { data: 'product_name', defaultContent: '' },
+            { data: 'quantity', className: 'text-end' },
+            { data: 'delivered_qty', className: 'text-end' },
+            {
+                data: 'diff', className: 'text-end',
+                render: function(data) {
+                    if (data > 0) return '<span class="text-primary">+' + data + '</span>';
+                    if (data < 0) return '<span class="text-danger">' + data + '</span>';
+                    return '<span class="text-success">0</span>';
+                }
+            },
+            {
+                data: 'status',
+                render: function(data) {
+                    const s = statusMap[data] || { label: data, cls: 'secondary' };
+                    return '<span class="badge bg-' + s.cls + '">' + s.label + '</span>';
+                }
+            },
+            {
+                data: null,
+                orderable: false,
+                render: function(data, type, row) {
+                    return '<button class="btn btn-sm btn-outline-primary add-delivery" '
+                        + 'data-item-id="' + row.item_id + '" '
+                        + 'data-po-no="' + row.po_no + '" '
+                        + 'data-product-code="' + (row.product_code || '') + '" '
+                        + 'data-product-name="' + (row.product_name || '') + '" '
+                        + 'data-quantity="' + row.quantity + '">'
+                        + '<i class="bi bi-plus-circle me-1"></i>登记收货</button>';
+                }
+            }
+        ],
+        language: {
+            url: 'https://cdn.datatables.net/plug-ins/1.13.8/i18n/zh.json'
+        },
+        order: [[1, 'desc']],
+        pageLength: 25,
+        responsive: true,
+    });
+}
+
+$(document).ready(function () {
+    // Set default date to today
+    const today = new Date().toISOString().split('T')[0];
+    $('#modalDeliveryDate').val(today);
+
+    initTable();
+
+    // Query button reloads table with new filters
+    $('#btnQuery').on('click', function () {
+        if (table) {
+            table.ajax.url(buildUrl()).load();
+        }
+    });
+
+    // Also allow Enter key in po_no input
+    $('#poNoFilter').on('keydown', function (e) {
+        if (e.key === 'Enter') $('#btnQuery').trigger('click');
+    });
+
+    // Open add delivery modal on row button click
+    $('#deliveryTable').on('click', '.add-delivery', function () {
+        const btn = $(this);
+        const itemId = btn.data('item-id');
+        const poNo = btn.data('po-no');
+        const productCode = btn.data('product-code');
+        const productName = btn.data('product-name');
+        const quantity = btn.data('quantity');
+
+        $('#modalItemId').val(itemId);
+        $('#modalItemInfo').html(
+            '<strong>采购单号：</strong>' + poNo +
+            '&nbsp;&nbsp;<strong>货号：</strong>' + (productCode || '-') +
+            '<br><strong>货品名称：</strong>' + (productName || '-') +
+            '&nbsp;&nbsp;<strong>采购数量：</strong>' + quantity
+        );
+        $('#modalQty').val('');
+        $('#modalRemarks').val('');
+        $('#modalDeliveryDate').val(new Date().toISOString().split('T')[0]);
+
+        const modal = new bootstrap.Modal(document.getElementById('addDeliveryModal'));
+        modal.show();
+    });
+
+    // Save delivery record
+    $('#btnSaveDelivery').on('click', function () {
+        const itemId = $('#modalItemId').val();
+        const deliveryDate = $('#modalDeliveryDate').val();
+        const qty = parseInt($('#modalQty').val(), 10);
+        const remarks = $('#modalRemarks').val().trim();
+
+        if (!deliveryDate) {
+            alert('请选择收货日期');
+            return;
+        }
+        if (!qty || qty < 1) {
+            alert('请输入有效的收货数量');
+            return;
+        }
+
+        $('#btnSaveDelivery').prop('disabled', true).html('<span class="spinner-border spinner-border-sm me-1"></span>保存中...');
+
+        $.ajax({
+            url: '/delivery/api/record',
+            type: 'POST',
+            contentType: 'application/json',
+            data: JSON.stringify({
+                item_id: parseInt(itemId, 10),
+                delivery_date: deliveryDate,
+                delivered_quantity: qty,
+                remarks: remarks,
+            }),
+            success: function (res) {
+                if (res.success) {
+                    bootstrap.Modal.getInstance(document.getElementById('addDeliveryModal')).hide();
+                    table.ajax.reload(null, false);
+                } else {
+                    alert('保存失败，请重试');
+                }
+            },
+            error: function () {
+                alert('请求失败，请检查网络或联系管理员');
+            },
+            complete: function () {
+                $('#btnSaveDelivery').prop('disabled', false).html('<i class="bi bi-save me-1"></i>保存');
+            }
+        });
+    });
+});
+</script>
+{% endblock %}

--- a/apps/jiangping/templates/delivery.html
+++ b/apps/jiangping/templates/delivery.html
@@ -112,7 +112,7 @@ let table = null;
 function buildUrl() {
     const supplierId = $('#supplierFilter').val();
     const poNo = $('#poNoFilter').val().trim();
-    let url = '/delivery/api/reconciliation?';
+    let url = BASE_URL + '/delivery/api/reconciliation?';
     if (supplierId) url += 'supplier_id=' + supplierId + '&';
     if (poNo) url += 'po_no=' + encodeURIComponent(poNo) + '&';
     return url;
@@ -229,7 +229,7 @@ $(document).ready(function () {
         $('#btnSaveDelivery').prop('disabled', true).html('<span class="spinner-border spinner-border-sm me-1"></span>保存中...');
 
         $.ajax({
-            url: '/delivery/api/record',
+            url: BASE_URL + '/delivery/api/record',
             type: 'POST',
             contentType: 'application/json',
             data: JSON.stringify({

--- a/apps/jiangping/templates/delivery_mgmt.html
+++ b/apps/jiangping/templates/delivery_mgmt.html
@@ -1,0 +1,803 @@
+{% extends 'base.html' %}
+{% block title %}交货管理 - 采购管理系统{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h2 class="mb-0"><i class="bi bi-truck me-2"></i>交货管理</h2>
+    <div>
+        <button class="btn btn-warning me-2" id="btn-add-note">
+            <i class="bi bi-plus-circle me-1"></i>新增交货单
+        </button>
+        <button class="btn btn-info me-2" id="btn-ocr-upload">
+            <i class="bi bi-camera me-1"></i>PDF/图片导入
+        </button>
+        <button class="btn btn-primary me-2" data-bs-toggle="modal" data-bs-target="#importModal">
+            <i class="bi bi-upload me-1"></i>导入 Excel
+        </button>
+        <a href="{{ url_for('export.export_delivery_excel') }}"
+           id="btn-export" class="btn btn-success">
+            <i class="bi bi-file-earmark-excel me-1"></i>导出 Excel
+        </a>
+    </div>
+</div>
+
+<!-- Filter card -->
+<div class="card mb-3">
+    <div class="card-body">
+        <div class="row g-2 align-items-end">
+            <div class="col-md-3">
+                <label class="form-label mb-1">供应商</label>
+                <select id="filter-supplier" class="form-select form-select-sm">
+                    <option value="">全部供应商</option>
+                    {% for s in suppliers %}
+                    <option value="{{ s.id }}">{{ s.short_name or s.name }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="col-md-2">
+                <label class="form-label mb-1">日期从</label>
+                <input type="date" id="filter-date-from" class="form-control form-control-sm">
+            </div>
+            <div class="col-md-2">
+                <label class="form-label mb-1">日期至</label>
+                <input type="date" id="filter-date-to" class="form-control form-control-sm">
+            </div>
+            <div class="col-md-3">
+                <label class="form-label mb-1">采购单号</label>
+                <input type="text" id="filter-po-no" class="form-control form-control-sm" placeholder="输入采购单号搜索...">
+            </div>
+            <div class="col-md-2">
+                <button id="btn-query" class="btn btn-primary btn-sm w-100">
+                    <i class="bi bi-search me-1"></i>查询
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- DataTable -->
+<div class="card">
+    <div class="card-body p-0 table-scroll-wrapper">
+        <table id="delivery-table" class="table table-bordered table-hover mb-0" style="font-size: 0.85rem;">
+            <thead class="table-dark">
+                <tr>
+                    <th>日期</th>
+                    <th>供应商</th>
+                    <th>送货单号</th>
+                    <th>货号</th>
+                    <th>货号名称</th>
+                    <th>数量</th>
+                    <th>单位RMB</th>
+                    <th>单价RMB</th>
+                    <th>金额RMB</th>
+                    <th>采购单号</th>
+                    <th>操作</th>
+                </tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+    </div>
+</div>
+
+<!-- Import Excel modal -->
+<div class="modal fade" id="importModal" tabindex="-1">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title"><i class="bi bi-upload me-2"></i>导入交货 Excel</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <form action="{{ url_for('delivery_mgmt.import_excel') }}" method="POST" enctype="multipart/form-data">
+                <div class="modal-body">
+                    <p class="text-muted small">支持导入按供应商分sheet的交货Excel文件（.xls/.xlsx），每个sheet名为供应商简称，表头格式：日期、送货单号、货号、货号名称、数量、单位RMB、单价RMB、金额RMB、备注（采购单号）</p>
+                    <div class="mb-3">
+                        <label class="form-label">选择 Excel 文件</label>
+                        <input type="file" name="file" class="form-control" accept=".xls,.xlsx" required>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">取消</button>
+                    <button type="submit" class="btn btn-primary"><i class="bi bi-upload me-1"></i>开始导入</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<!-- OCR upload modal -->
+<div class="modal fade" id="ocrModal" tabindex="-1">
+    <div class="modal-dialog modal-xl">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title"><i class="bi bi-camera me-2"></i>PDF/图片识别导入</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <!-- Step 1: Upload -->
+                <div id="ocr-step1">
+                    <div class="mb-3">
+                        <label class="form-label">选择 PDF 或图片文件</label>
+                        <input type="file" id="ocr-file" class="form-control" accept=".pdf,.jpg,.jpeg,.png,.bmp,.tiff,.tif">
+                    </div>
+                    <button type="button" id="btn-ocr-start" class="btn btn-primary w-100">
+                        <i class="bi bi-cpu me-1"></i>开始识别
+                    </button>
+                    <div id="ocr-loading" class="text-center py-4 d-none">
+                        <div class="spinner-border text-primary" role="status"></div>
+                        <div class="mt-2">正在识别中，请稍候...</div>
+                    </div>
+                </div>
+                <!-- Step 2: Preview & Edit -->
+                <div id="ocr-step2" class="d-none">
+                    <div class="row g-3 mb-3">
+                        <div class="col-md-4">
+                            <label class="form-label">供应商 <span class="text-danger">*</span></label>
+                            <select id="ocr-supplier" class="form-select">
+                                <option value="">请选择</option>
+                                {% for s in suppliers %}
+                                <option value="{{ s.id }}">{{ s.short_name or s.name }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                        <div class="col-md-4">
+                            <label class="form-label">交货日期 <span class="text-danger">*</span></label>
+                            <input type="date" id="ocr-date" class="form-control">
+                        </div>
+                        <div class="col-md-4">
+                            <label class="form-label">送货单号</label>
+                            <input type="text" id="ocr-delivery-no" class="form-control">
+                        </div>
+                    </div>
+                    <div class="mb-2">
+                        <a data-bs-toggle="collapse" href="#ocr-raw" class="small text-muted">查看 OCR 原始文本</a>
+                        <div class="collapse" id="ocr-raw">
+                            <pre id="ocr-raw-text" class="bg-light p-2 small" style="max-height:150px;overflow:auto;"></pre>
+                        </div>
+                    </div>
+                    <h6>识别结果 <button type="button" class="btn btn-sm btn-outline-primary ms-2" id="btn-ocr-add-row"><i class="bi bi-plus me-1"></i>添加行</button></h6>
+                    <div class="table-responsive">
+                        <table class="table table-bordered table-sm">
+                            <thead class="table-light">
+                                <tr>
+                                    <th style="width:140px">采购单号</th>
+                                    <th style="width:100px">货号</th>
+                                    <th style="width:200px">货号名称 <span class="text-danger">*</span></th>
+                                    <th style="width:90px">数量</th>
+                                    <th style="width:80px">单位</th>
+                                    <th style="width:100px">单价RMB</th>
+                                    <th style="width:110px">金额RMB</th>
+                                    <th style="width:50px"></th>
+                                </tr>
+                            </thead>
+                            <tbody id="ocr-items-body"></tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">取消</button>
+                <button type="button" id="btn-ocr-save" class="btn btn-primary d-none">
+                    <i class="bi bi-save me-1"></i>保存
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Add/Edit delivery note modal -->
+<div class="modal fade" id="noteModal" tabindex="-1">
+    <div class="modal-dialog modal-xl">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="noteModalTitle"><i class="bi bi-plus-circle me-2"></i>新增交货单</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <div class="row g-3 mb-3">
+                    <div class="col-md-4">
+                        <label class="form-label">供应商 <span class="text-danger">*</span></label>
+                        <select id="note-supplier" class="form-select">
+                            <option value="">请选择</option>
+                            {% for s in suppliers %}
+                            <option value="{{ s.id }}">{{ s.short_name or s.name }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label">交货日期 <span class="text-danger">*</span></label>
+                        <input type="date" id="note-date" class="form-control">
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label">送货单号</label>
+                        <input type="text" id="note-delivery-no" class="form-control" placeholder="送货单号">
+                    </div>
+                </div>
+                <hr>
+                <h6>明细列表 <button type="button" class="btn btn-sm btn-outline-primary ms-2" id="btn-add-row"><i class="bi bi-plus me-1"></i>添加行</button></h6>
+                <div class="table-responsive">
+                    <table class="table table-bordered table-sm" id="note-items-table">
+                        <thead class="table-light">
+                            <tr>
+                                <th style="width:140px">采购单号</th>
+                                <th style="width:200px">货号名称 <span class="text-danger">*</span></th>
+                                <th style="width:100px">货号</th>
+                                <th style="width:90px">数量</th>
+                                <th style="width:80px">单位RMB</th>
+                                <th style="width:100px">单价RMB</th>
+                                <th style="width:110px">金额RMB</th>
+                                <th style="width:50px"></th>
+                            </tr>
+                        </thead>
+                        <tbody id="note-items-body"></tbody>
+                    </table>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">取消</button>
+                <button type="button" id="btn-save-note" class="btn btn-primary">
+                    <i class="bi bi-save me-1"></i>保存
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Edit item modal -->
+<div class="modal fade" id="editItemModal" tabindex="-1">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title"><i class="bi bi-pencil me-2"></i>编辑明细</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <input type="hidden" id="edit-item-id">
+                <div class="row g-3">
+                    <div class="col-md-6">
+                        <label class="form-label">货号</label>
+                        <input type="text" id="edit-product-code" class="form-control">
+                    </div>
+                    <div class="col-md-6">
+                        <label class="form-label">货号名称 <span class="text-danger">*</span></label>
+                        <input type="text" id="edit-product-name" class="form-control">
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label">数量</label>
+                        <input type="number" id="edit-quantity" class="form-control" step="any">
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label">单位</label>
+                        <input type="text" id="edit-unit" class="form-control">
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label">单价</label>
+                        <input type="number" id="edit-unit-price" class="form-control" step="any">
+                    </div>
+                    <div class="col-md-6">
+                        <label class="form-label">金额</label>
+                        <input type="number" id="edit-amount" class="form-control" step="any">
+                    </div>
+                    <div class="col-md-6">
+                        <label class="form-label">采购单号</label>
+                        <input type="text" id="edit-po-no" class="form-control">
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">取消</button>
+                <button type="button" id="btn-save-edit" class="btn btn-primary">
+                    <i class="bi bi-save me-1"></i>保存
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+var table;
+
+function getFilterParams() {
+    return {
+        supplier_id: $('#filter-supplier').val(),
+        date_from:   $('#filter-date-from').val(),
+        date_to:     $('#filter-date-to').val(),
+        po_no:       $('#filter-po-no').val()
+    };
+}
+
+function buildQueryString(params) {
+    return Object.entries(params)
+        .filter(function(e) { return e[1]; })
+        .map(function(e) { return encodeURIComponent(e[0]) + '=' + encodeURIComponent(e[1]); })
+        .join('&');
+}
+
+function addItemRow() {
+    var row = '<tr>' +
+        '<td><input type="text" class="form-control form-control-sm item-po" placeholder="如FDJA20260001"></td>' +
+        '<td><select class="form-select form-select-sm item-name-select d-none"><option value="">--选择物料--</option></select>' +
+            '<input type="text" class="form-control form-control-sm item-name" required></td>' +
+        '<td><input type="text" class="form-control form-control-sm item-code"></td>' +
+        '<td><input type="number" class="form-control form-control-sm item-qty" step="any" value="0"></td>' +
+        '<td><input type="text" class="form-control form-control-sm item-unit" value="PCS"></td>' +
+        '<td><input type="number" class="form-control form-control-sm item-price" step="any" value="0"></td>' +
+        '<td><input type="number" class="form-control form-control-sm item-amount" step="any" value="0"></td>' +
+        '<td><button type="button" class="btn btn-sm btn-outline-danger remove-row"><i class="bi bi-trash"></i></button></td>' +
+        '</tr>';
+    $('#note-items-body').append(row);
+}
+
+$(document).ready(function () {
+    table = $('#delivery-table').DataTable({
+        ajax: {
+            url: '{{ url_for("delivery_mgmt.api_list") }}',
+            data: function () { return getFilterParams(); },
+            dataSrc: 'data'
+        },
+        columns: [
+            {
+                data: 'delivery_date',
+                render: function (d, type, row) {
+                    if (!d) return '';
+                    if (row.is_first) return '<strong>' + d + '</strong>';
+                    return '';
+                }
+            },
+            {
+                data: 'supplier',
+                render: function (d, type, row) {
+                    return row.is_first ? '<strong>' + d + '</strong>' : '';
+                }
+            },
+            {
+                data: 'delivery_no',
+                render: function (d, type, row) {
+                    if (!d) return '';
+                    return '<strong>' + d + '</strong>';
+                }
+            },
+            { data: 'product_code' },
+            { data: 'product_name' },
+            {
+                data: 'quantity',
+                className: 'text-end',
+                render: function (d) {
+                    if (!d) return '';
+                    return d % 1 === 0 ? d.toFixed(0) : d.toFixed(2);
+                }
+            },
+            { data: 'unit' },
+            {
+                data: 'unit_price',
+                className: 'text-end',
+                render: function (d) { return d ? d.toFixed(4) : ''; }
+            },
+            {
+                data: 'amount',
+                className: 'text-end',
+                render: function (d) { return d ? d.toLocaleString('zh-CN', {minimumFractionDigits: 2, maximumFractionDigits: 2}) : ''; }
+            },
+            { data: 'po_no' },
+            {
+                data: null,
+                orderable: false,
+                className: 'text-center',
+                render: function (data, type, row) {
+                    return '<button class="btn btn-sm btn-outline-primary me-1 btn-edit" title="编辑">' +
+                        '<i class="bi bi-pencil"></i></button>' +
+                        '<button class="btn btn-sm btn-outline-danger btn-del-item" title="删除">' +
+                        '<i class="bi bi-trash"></i></button>';
+                }
+            }
+        ],
+        language: { url: 'https://cdn.datatables.net/plug-ins/1.13.8/i18n/zh.json' },
+        ordering: false,
+        pageLength: 50,
+        createdRow: function (row, data) {
+            if (data.is_first) {
+                $(row).css('border-top', '2px solid #adb5bd');
+            }
+        }
+    });
+
+    // Query
+    $('#btn-query').on('click', function () {
+        var qs = buildQueryString(getFilterParams());
+        $('#btn-export').attr('href', '{{ url_for("export.export_delivery_excel") }}' + (qs ? '?' + qs : ''));
+        table.ajax.reload();
+    });
+    $('#filter-po-no').on('keydown', function (e) {
+        if (e.key === 'Enter') $('#btn-query').trigger('click');
+    });
+
+    // ========== CREATE ==========
+    $('#btn-add-note').on('click', function () {
+        $('#note-supplier').val('');
+        $('#note-date').val(new Date().toISOString().split('T')[0]);
+        $('#note-delivery-no').val('');
+        $('#note-items-body').empty();
+        addItemRow();
+        new bootstrap.Modal(document.getElementById('noteModal')).show();
+    });
+
+    $('#btn-add-row').on('click', addItemRow);
+
+    $('#note-items-body').on('click', '.remove-row', function () {
+        $(this).closest('tr').remove();
+    });
+
+    // Auto-calc amount when qty or price changes
+    $('#note-items-body').on('input', '.item-qty, .item-price', function () {
+        var row = $(this).closest('tr');
+        var qty = parseFloat(row.find('.item-qty').val()) || 0;
+        var price = parseFloat(row.find('.item-price').val()) || 0;
+        row.find('.item-amount').val((qty * price).toFixed(2));
+    });
+
+    $('#btn-save-note').on('click', function () {
+        var supplierId = $('#note-supplier').val();
+        var date = $('#note-date').val();
+        if (!supplierId) { alert('请选择供应商'); return; }
+        if (!date) { alert('请选择日期'); return; }
+
+        var items = [];
+        var valid = true;
+        $('#note-items-body tr').each(function () {
+            var sel = $(this).find('.item-name-select');
+            var name = sel.hasClass('d-none') ? $(this).find('.item-name').val().trim() : (sel.val() || $(this).find('.item-name').val().trim());
+            if (!name) { valid = false; return false; }
+            items.push({
+                product_code: $(this).find('.item-code').val().trim(),
+                product_name: name,
+                quantity: parseFloat($(this).find('.item-qty').val()) || 0,
+                unit: $(this).find('.item-unit').val().trim() || 'PCS',
+                unit_price: parseFloat($(this).find('.item-price').val()) || 0,
+                amount: parseFloat($(this).find('.item-amount').val()) || 0,
+                po_no: $(this).find('.item-po').val().trim(),
+            });
+        });
+        if (!valid) { alert('请填写所有货号名称'); return; }
+        if (items.length === 0) { alert('请添加至少一条明细'); return; }
+
+        $('#btn-save-note').prop('disabled', true);
+        $.ajax({
+            url: '{{ url_for("delivery_mgmt.api_create") }}',
+            type: 'POST',
+            contentType: 'application/json',
+            data: JSON.stringify({
+                supplier_id: parseInt(supplierId),
+                delivery_date: date,
+                delivery_no: $('#note-delivery-no').val().trim(),
+                items: items
+            }),
+            success: function (res) {
+                if (res.success) {
+                    bootstrap.Modal.getInstance(document.getElementById('noteModal')).hide();
+                    table.ajax.reload();
+                } else {
+                    alert(res.error || '保存失败');
+                }
+            },
+            error: function () { alert('请求失败'); },
+            complete: function () { $('#btn-save-note').prop('disabled', false); }
+        });
+    });
+
+    // ========== EDIT ==========
+    $('#delivery-table').on('click', '.btn-edit', function () {
+        var data = table.row($(this).closest('tr')).data();
+        $('#edit-item-id').val(data.item_id);
+        $('#edit-product-code').val(data.product_code);
+        $('#edit-product-name').val(data.product_name);
+        $('#edit-quantity').val(data.quantity);
+        $('#edit-unit').val(data.unit);
+        $('#edit-unit-price').val(data.unit_price);
+        $('#edit-amount').val(data.amount);
+        $('#edit-po-no').val(data.po_no);
+        new bootstrap.Modal(document.getElementById('editItemModal')).show();
+    });
+
+    // Auto-calc amount in edit modal
+    $('#edit-quantity, #edit-unit-price').on('input', function () {
+        var qty = parseFloat($('#edit-quantity').val()) || 0;
+        var price = parseFloat($('#edit-unit-price').val()) || 0;
+        $('#edit-amount').val((qty * price).toFixed(2));
+    });
+
+    $('#btn-save-edit').on('click', function () {
+        var itemId = $('#edit-item-id').val();
+        var name = $('#edit-product-name').val().trim();
+        if (!name) { alert('请填写货号名称'); return; }
+
+        $('#btn-save-edit').prop('disabled', true);
+        $.ajax({
+            url: '/delivery-mgmt/api/item/' + itemId,
+            type: 'PUT',
+            contentType: 'application/json',
+            data: JSON.stringify({
+                product_code: $('#edit-product-code').val().trim(),
+                product_name: name,
+                quantity: parseFloat($('#edit-quantity').val()) || 0,
+                unit: $('#edit-unit').val().trim() || 'PCS',
+                unit_price: parseFloat($('#edit-unit-price').val()) || 0,
+                amount: parseFloat($('#edit-amount').val()) || 0,
+                po_no: $('#edit-po-no').val().trim(),
+            }),
+            success: function (res) {
+                if (res.success) {
+                    bootstrap.Modal.getInstance(document.getElementById('editItemModal')).hide();
+                    table.ajax.reload();
+                } else {
+                    alert(res.error || '保存失败');
+                }
+            },
+            error: function () { alert('请求失败'); },
+            complete: function () { $('#btn-save-edit').prop('disabled', false); }
+        });
+    });
+
+    // ========== DELETE ITEM ==========
+    $('#delivery-table').on('click', '.btn-del-item', function () {
+        var data = table.row($(this).closest('tr')).data();
+        if (!confirm('确定删除该明细？\n' + data.product_name)) return;
+        $.ajax({
+            url: '/delivery-mgmt/api/item/' + data.item_id,
+            type: 'DELETE',
+            success: function (res) {
+                if (res.success) table.ajax.reload();
+                else alert('删除失败');
+            },
+            error: function () { alert('请求失败'); }
+        });
+    });
+
+    // ========== DELETE NOTE ==========
+    $('#delivery-table').on('click', '.btn-del-note', function () {
+        var data = table.row($(this).closest('tr')).data();
+        if (!confirm('确定删除整个交货单 ' + data.delivery_no + ' 及所有明细？')) return;
+        $.ajax({
+            url: '/delivery-mgmt/api/note/' + data.note_id,
+            type: 'DELETE',
+            success: function (res) {
+                if (res.success) table.ajax.reload();
+                else alert('删除失败');
+            },
+            error: function () { alert('请求失败'); }
+        });
+    });
+
+    // ========== OCR UPLOAD ==========
+    $('#btn-ocr-upload').on('click', function () {
+        $('#ocr-step1').show();
+        $('#ocr-step2').addClass('d-none');
+        $('#btn-ocr-save').addClass('d-none');
+        $('#ocr-loading').addClass('d-none');
+        $('#ocr-file').val('');
+        new bootstrap.Modal(document.getElementById('ocrModal')).show();
+    });
+
+    function addOcrItemRow(item) {
+        var row = '<tr>' +
+            '<td><input type="text" class="form-control form-control-sm item-po" value="' + (item.po_no || '') + '"></td>' +
+            '<td><input type="text" class="form-control form-control-sm item-code" value="' + (item.product_code || '') + '"></td>' +
+            '<td><input type="text" class="form-control form-control-sm item-name" value="' + (item.product_name || '') + '"></td>' +
+            '<td><input type="number" class="form-control form-control-sm item-qty" step="any" value="' + (item.quantity || 0) + '"></td>' +
+            '<td><input type="text" class="form-control form-control-sm item-unit" value="' + (item.unit || 'PCS') + '"></td>' +
+            '<td><input type="number" class="form-control form-control-sm item-price" step="any" value="' + (item.unit_price || 0) + '"></td>' +
+            '<td><input type="number" class="form-control form-control-sm item-amount" step="any" value="' + (item.amount || 0) + '"></td>' +
+            '<td><button type="button" class="btn btn-sm btn-outline-danger remove-row"><i class="bi bi-trash"></i></button></td>' +
+            '</tr>';
+        $('#ocr-items-body').append(row);
+    }
+
+    $('#btn-ocr-add-row').on('click', function () {
+        addOcrItemRow({});
+    });
+
+    $('#ocr-items-body').on('click', '.remove-row', function () {
+        $(this).closest('tr').remove();
+    });
+
+    // Auto-calc amount in OCR table
+    $('#ocr-items-body').on('input', '.item-qty, .item-price', function () {
+        var row = $(this).closest('tr');
+        var qty = parseFloat(row.find('.item-qty').val()) || 0;
+        var price = parseFloat(row.find('.item-price').val()) || 0;
+        row.find('.item-amount').val((qty * price).toFixed(2));
+    });
+
+    // Auto-match purchase data when po_no or product_name changes in OCR table
+    $('#ocr-items-body').on('change', '.item-po, .item-name, .item-code', function () {
+        var row = $(this).closest('tr');
+        var poNo = row.find('.item-po').val().trim();
+        var productName = row.find('.item-name').val().trim();
+        var productCode = row.find('.item-code').val().trim();
+        if (!poNo) return;
+        $.ajax({
+            url: '{{ url_for("delivery_mgmt.api_match_purchase") }}',
+            type: 'POST',
+            contentType: 'application/json',
+            data: JSON.stringify({ po_no: poNo, product_name: productName, product_code: productCode }),
+            success: function (res) {
+                if (res.found) {
+                    row.find('.item-unit').val(res.unit);
+                    row.find('.item-price').val(res.unit_price);
+                    var qty = parseFloat(row.find('.item-qty').val()) || 0;
+                    row.find('.item-amount').val((qty * res.unit_price).toFixed(2));
+                }
+            }
+        });
+    });
+
+    // When 采购单号 changes in note modal, fetch purchase items and show dropdown
+    $('#note-items-body').on('change', '.item-po', function () {
+        var row = $(this).closest('tr');
+        var poNo = row.find('.item-po').val().trim();
+        var sel = row.find('.item-name-select');
+        var inp = row.find('.item-name');
+        if (!poNo) {
+            sel.addClass('d-none');
+            inp.removeClass('d-none');
+            return;
+        }
+        $.ajax({
+            url: '/delivery-mgmt/api/purchase-items?po_no=' + encodeURIComponent(poNo),
+            type: 'GET',
+            success: function (res) {
+                if (res.items && res.items.length > 0) {
+                    sel.empty().append('<option value="">--选择物料--</option>');
+                    res.items.forEach(function (item) {
+                        var label = (item.product_code ? item.product_code + ' - ' : '') + item.product_name + ' (数量:' + item.quantity + ')';
+                        sel.append('<option value="' + item.product_name + '" ' +
+                            'data-code="' + item.product_code + '" ' +
+                            'data-unit="' + item.unit + '" ' +
+                            'data-price="' + item.unit_price + '">' + label + '</option>');
+                    });
+                    sel.removeClass('d-none');
+                    inp.addClass('d-none');
+                } else {
+                    sel.addClass('d-none');
+                    inp.removeClass('d-none');
+                }
+            }
+        });
+    });
+
+    // When a product is selected from dropdown, fill in the row
+    $('#note-items-body').on('change', '.item-name-select', function () {
+        var row = $(this).closest('tr');
+        var opt = $(this).find(':selected');
+        var name = opt.val();
+        if (!name) return;
+        row.find('.item-name').val(name);
+        row.find('.item-code').val(opt.data('code') || '');
+        row.find('.item-unit').val(opt.data('unit') || 'PCS');
+        row.find('.item-price').val(opt.data('price') || 0);
+        var qty = parseFloat(row.find('.item-qty').val()) || 0;
+        row.find('.item-amount').val((qty * (opt.data('price') || 0)).toFixed(2));
+    });
+
+    // Auto-calc when qty changes in note modal (re-calc with current price)
+    $('#note-items-body').on('input', '.item-qty', function () {
+        var row = $(this).closest('tr');
+        var qty = parseFloat(row.find('.item-qty').val()) || 0;
+        var price = parseFloat(row.find('.item-price').val()) || 0;
+        row.find('.item-amount').val((qty * price).toFixed(2));
+    });
+
+    $('#btn-ocr-start').on('click', function () {
+        var fileInput = document.getElementById('ocr-file');
+        if (!fileInput.files.length) { alert('请选择文件'); return; }
+
+        var formData = new FormData();
+        formData.append('file', fileInput.files[0]);
+
+        $('#btn-ocr-start').prop('disabled', true);
+        $('#ocr-loading').removeClass('d-none');
+
+        $.ajax({
+            url: '{{ url_for("delivery_mgmt.api_parse") }}',
+            type: 'POST',
+            data: formData,
+            processData: false,
+            contentType: false,
+            success: function (res) {
+                if (res.error) {
+                    alert(res.error);
+                    return;
+                }
+                // Fill form
+                $('#ocr-date').val(res.delivery_date || new Date().toISOString().split('T')[0]);
+                $('#ocr-delivery-no').val(res.delivery_no || '');
+                $('#ocr-raw-text').text(res.raw_text || '');
+
+                // Try to match supplier
+                if (res.supplier) {
+                    var matched = false;
+                    $('#ocr-supplier option').each(function () {
+                        if ($(this).text().indexOf(res.supplier) >= 0 || res.supplier.indexOf($(this).text()) >= 0) {
+                            $('#ocr-supplier').val($(this).val());
+                            matched = true;
+                            return false;
+                        }
+                    });
+                }
+
+                // Fill items
+                $('#ocr-items-body').empty();
+                if (res.items && res.items.length > 0) {
+                    res.items.forEach(function (item) {
+                        addOcrItemRow(item);
+                    });
+                } else {
+                    addOcrItemRow({});
+                }
+
+                $('#ocr-step1').hide();
+                $('#ocr-step2').removeClass('d-none');
+                $('#btn-ocr-save').removeClass('d-none');
+            },
+            error: function (xhr) {
+                var msg = '识别失败';
+                try { msg = JSON.parse(xhr.responseText).error || msg; } catch(e) {}
+                alert(msg);
+            },
+            complete: function () {
+                $('#btn-ocr-start').prop('disabled', false);
+                $('#ocr-loading').addClass('d-none');
+            }
+        });
+    });
+
+    $('#btn-ocr-save').on('click', function () {
+        var supplierId = $('#ocr-supplier').val();
+        var date = $('#ocr-date').val();
+        if (!supplierId) { alert('请选择供应商'); return; }
+        if (!date) { alert('请选择日期'); return; }
+
+        var items = [];
+        var valid = true;
+        $('#ocr-items-body tr').each(function () {
+            var name = $(this).find('.item-name').val().trim();
+            if (!name) { valid = false; return false; }
+            items.push({
+                product_code: $(this).find('.item-code').val().trim(),
+                product_name: name,
+                quantity: parseFloat($(this).find('.item-qty').val()) || 0,
+                unit: $(this).find('.item-unit').val().trim() || 'PCS',
+                unit_price: parseFloat($(this).find('.item-price').val()) || 0,
+                amount: parseFloat($(this).find('.item-amount').val()) || 0,
+                po_no: $(this).find('.item-po').val().trim(),
+            });
+        });
+        if (!valid) { alert('请填写所有货号名称'); return; }
+        if (items.length === 0) { alert('请添加至少一条明细'); return; }
+
+        $('#btn-ocr-save').prop('disabled', true);
+        $.ajax({
+            url: '{{ url_for("delivery_mgmt.api_create") }}',
+            type: 'POST',
+            contentType: 'application/json',
+            data: JSON.stringify({
+                supplier_id: parseInt(supplierId),
+                delivery_date: date,
+                delivery_no: $('#ocr-delivery-no').val().trim(),
+                items: items
+            }),
+            success: function (res) {
+                if (res.success) {
+                    bootstrap.Modal.getInstance(document.getElementById('ocrModal')).hide();
+                    table.ajax.reload();
+                } else {
+                    alert(res.error || '保存失败');
+                }
+            },
+            error: function () { alert('请求失败'); },
+            complete: function () { $('#btn-ocr-save').prop('disabled', false); }
+        });
+    });
+});
+</script>
+{% endblock %}

--- a/apps/jiangping/templates/delivery_mgmt.html
+++ b/apps/jiangping/templates/delivery_mgmt.html
@@ -513,7 +513,7 @@ $(document).ready(function () {
 
         $('#btn-save-edit').prop('disabled', true);
         $.ajax({
-            url: '/delivery-mgmt/api/item/' + itemId,
+            url: BASE_URL + '/delivery-mgmt/api/item/' + itemId,
             type: 'PUT',
             contentType: 'application/json',
             data: JSON.stringify({
@@ -543,7 +543,7 @@ $(document).ready(function () {
         var data = table.row($(this).closest('tr')).data();
         if (!confirm('确定删除该明细？\n' + data.product_name)) return;
         $.ajax({
-            url: '/delivery-mgmt/api/item/' + data.item_id,
+            url: BASE_URL + '/delivery-mgmt/api/item/' + data.item_id,
             type: 'DELETE',
             success: function (res) {
                 if (res.success) table.ajax.reload();
@@ -558,7 +558,7 @@ $(document).ready(function () {
         var data = table.row($(this).closest('tr')).data();
         if (!confirm('确定删除整个交货单 ' + data.delivery_no + ' 及所有明细？')) return;
         $.ajax({
-            url: '/delivery-mgmt/api/note/' + data.note_id,
+            url: BASE_URL + '/delivery-mgmt/api/note/' + data.note_id,
             type: 'DELETE',
             success: function (res) {
                 if (res.success) table.ajax.reload();
@@ -643,7 +643,7 @@ $(document).ready(function () {
             return;
         }
         $.ajax({
-            url: '/delivery-mgmt/api/purchase-items?po_no=' + encodeURIComponent(poNo),
+            url: BASE_URL + '/delivery-mgmt/api/purchase-items?po_no=' + encodeURIComponent(poNo),
             type: 'GET',
             success: function (res) {
                 if (res.items && res.items.length > 0) {

--- a/apps/jiangping/templates/purchase_detail.html
+++ b/apps/jiangping/templates/purchase_detail.html
@@ -1,0 +1,112 @@
+{% extends 'base.html' %}
+{% block title %}采购单 {{ order.po_no }} - 采购管理系统{% endblock %}
+
+{% block content %}
+<!-- Header -->
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h2 class="mb-0"><i class="bi bi-file-text me-2"></i>采购单详情</h2>
+    <a href="{{ url_for('purchase.list_purchases') }}" class="btn btn-secondary">
+        <i class="bi bi-arrow-left me-1"></i>返回列表
+    </a>
+</div>
+
+<!-- Order info -->
+<div class="card mb-4">
+    <div class="card-header bg-primary text-white fw-bold">
+        采购单号：{{ order.po_no }}
+    </div>
+    <div class="card-body">
+        <div class="row g-3">
+            <div class="col-md-3">
+                <span class="text-muted">供应商</span>
+                <div class="fw-semibold">
+                    {{ order.supplier.short_name or order.supplier.name if order.supplier else '—' }}
+                </div>
+            </div>
+            <div class="col-md-2">
+                <span class="text-muted">日期</span>
+                <div class="fw-semibold">
+                    {{ order.po_date.strftime('%Y-%m-%d') if order.po_date else '—' }}
+                </div>
+            </div>
+            <div class="col-md-2">
+                <span class="text-muted">交货期</span>
+                <div class="fw-semibold">
+                    {{ order.delivery_date.strftime('%Y-%m-%d') if order.delivery_date else '—' }}
+                </div>
+            </div>
+            <div class="col-md-2">
+                <span class="text-muted">收货人</span>
+                <div class="fw-semibold">{{ order.receiver or '—' }}</div>
+            </div>
+            <div class="col-md-3">
+                <span class="text-muted">合计金额 (RMB)</span>
+                <div class="fw-semibold text-success fs-5">
+                    {{ '%.2f'|format(order.total_amount|float) }}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Items table -->
+<div class="card">
+    <div class="card-header fw-bold">
+        <i class="bi bi-list-ul me-1"></i>明细列表（共 {{ items|length }} 项）
+    </div>
+    <div class="card-body p-0">
+        <div class="table-responsive">
+            <table class="table table-bordered table-hover table-sm mb-0">
+                <thead class="table-dark">
+                    <tr>
+                        <th class="text-center" style="width:45px;">#</th>
+                        <th>物料编号</th>
+                        <th>货号</th>
+                        <th>货品名称</th>
+                        <th>规格</th>
+                        <th class="text-end">数量</th>
+                        <th>单位</th>
+                        <th class="text-end">单价</th>
+                        <th class="text-end">金额</th>
+                        <th>备注</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for item in items %}
+                    <tr>
+                        <td class="text-center text-muted">{{ loop.index }}</td>
+                        <td>{{ item.material_code or '' }}</td>
+                        <td>{{ item.product_code or '' }}</td>
+                        <td>{{ item.product_name or '' }}</td>
+                        <td>{{ item.specification or '' }}</td>
+                        <td class="text-end">{{ item.quantity }}</td>
+                        <td>{{ item.unit or '' }}</td>
+                        <td class="text-end">{{ '%.4f'|format(item.unit_price|float) }}</td>
+                        <td class="text-end">{{ '%.2f'|format(item.amount|float) }}</td>
+                        <td>{{ item.remarks or '' }}</td>
+                    </tr>
+                    {% else %}
+                    <tr>
+                        <td colspan="10" class="text-center text-muted py-4">暂无明细数据</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+                {% if items %}
+                <tfoot class="table-light fw-bold">
+                    <tr>
+                        <td colspan="5" class="text-end">合计</td>
+                        <td class="text-end">{{ items|sum(attribute='quantity') }}</td>
+                        <td></td>
+                        <td></td>
+                        <td class="text-end text-success">
+                            {{ '%.2f'|format(order.total_amount|float) }}
+                        </td>
+                        <td></td>
+                    </tr>
+                </tfoot>
+                {% endif %}
+            </table>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/apps/jiangping/templates/purchases.html
+++ b/apps/jiangping/templates/purchases.html
@@ -1,0 +1,486 @@
+{% extends 'base.html' %}
+{% block title %}采购管理 - 采购管理系统{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h2 class="mb-0"><i class="bi bi-cart me-2"></i>采购管理</h2>
+    <div>
+        <button class="btn btn-warning me-2" id="btn-add-order">
+            <i class="bi bi-plus-circle me-1"></i>新增采购单
+        </button>
+        <button class="btn btn-primary me-2" data-bs-toggle="modal" data-bs-target="#importModal">
+            <i class="bi bi-upload me-1"></i>导入 Excel
+        </button>
+        <a href="{{ url_for('export.export_excel') }}?{{ request.query_string.decode() }}"
+           id="btn-export" class="btn btn-success">
+            <i class="bi bi-file-earmark-excel me-1"></i>导出 Excel
+        </a>
+    </div>
+</div>
+
+<!-- Filter card -->
+<div class="card mb-3">
+    <div class="card-body">
+        <div class="row g-2 align-items-end">
+            <div class="col-md-2">
+                <label class="form-label mb-1">年份</label>
+                <select id="filter-year" class="form-select form-select-sm">
+                    <option value="">全部年份</option>
+                    {% for y in years %}
+                    <option value="{{ y }}">{{ y }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="col-md-2">
+                <label class="form-label mb-1">供应商</label>
+                <select id="filter-supplier" class="form-select form-select-sm">
+                    <option value="">全部供应商</option>
+                    {% for s in suppliers %}
+                    <option value="{{ s.id }}">{{ s.short_name or s.name }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="col-md-2">
+                <label class="form-label mb-1">日期从</label>
+                <input type="date" id="filter-date-from" class="form-control form-control-sm">
+            </div>
+            <div class="col-md-2">
+                <label class="form-label mb-1">日期至</label>
+                <input type="date" id="filter-date-to" class="form-control form-control-sm">
+            </div>
+            <div class="col-md-2">
+                <label class="form-label mb-1">采购单号</label>
+                <input type="text" id="filter-po-no" class="form-control form-control-sm" placeholder="输入单号搜索...">
+            </div>
+            <div class="col-md-2">
+                <button id="btn-query" class="btn btn-primary btn-sm w-100">
+                    <i class="bi bi-search me-1"></i>查询
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- DataTable -->
+<div class="card">
+    <div class="card-body p-0 table-scroll-wrapper">
+        <table id="purchases-table" class="table table-bordered table-hover mb-0" style="font-size: 0.85rem;">
+            <thead class="table-dark">
+                <tr>
+                    <th>日期</th>
+                    <th>采购单号</th>
+                    <th>货号</th>
+                    <th>货品名称</th>
+                    <th>数量</th>
+                    <th>单位RMB</th>
+                    <th>单价RMB</th>
+                    <th>金额RMB</th>
+                    <th>交货期</th>
+                    <th>备注</th>
+                    <th>欠数</th>
+                    <th>操作</th>
+                </tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+    </div>
+</div>
+
+<!-- Import Excel modal -->
+<div class="modal fade" id="importModal" tabindex="-1">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title"><i class="bi bi-upload me-2"></i>导入 Excel</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <form action="{{ url_for('purchase.import_excel') }}" method="POST" enctype="multipart/form-data">
+                <div class="modal-body">
+                    <p class="text-muted small">支持导入按供应商分sheet的采购Excel文件（.xls/.xlsx），每个sheet名为供应商简称，表头格式：PO期、PO.NO、货号、货品名称、数量、单位RMB、单价RMB、金额RMB、交货期、备注</p>
+                    <div class="mb-3">
+                        <label class="form-label">选择 Excel 文件</label>
+                        <input type="file" name="file" class="form-control" accept=".xls,.xlsx" required>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">取消</button>
+                    <button type="submit" class="btn btn-primary"><i class="bi bi-upload me-1"></i>开始导入</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<!-- Add order modal -->
+<div class="modal fade" id="orderModal" tabindex="-1">
+    <div class="modal-dialog modal-xl">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title"><i class="bi bi-plus-circle me-2"></i>新增采购单</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <div class="row g-3 mb-3">
+                    <div class="col-md-3">
+                        <label class="form-label">供应商 <span class="text-danger">*</span></label>
+                        <select id="order-supplier" class="form-select">
+                            <option value="">请选择</option>
+                            {% for s in suppliers %}
+                            <option value="{{ s.id }}">{{ s.short_name or s.name }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label">采购单号 <span class="text-danger">*</span></label>
+                        <input type="text" id="order-po-no" class="form-control" placeholder="如 FDJA20260001">
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label">日期</label>
+                        <input type="date" id="order-date" class="form-control">
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label">交货期</label>
+                        <input type="date" id="order-delivery-date" class="form-control">
+                    </div>
+                </div>
+                <hr>
+                <h6>明细列表 <button type="button" class="btn btn-sm btn-outline-primary ms-2" id="btn-add-row"><i class="bi bi-plus me-1"></i>添加行</button></h6>
+                <div class="table-responsive">
+                    <table class="table table-bordered table-sm">
+                        <thead class="table-light">
+                            <tr>
+                                <th style="width:100px">货号</th>
+                                <th style="width:200px">货品名称 <span class="text-danger">*</span></th>
+                                <th style="width:90px">数量</th>
+                                <th style="width:80px">单位RMB</th>
+                                <th style="width:100px">单价RMB</th>
+                                <th style="width:110px">金额RMB</th>
+                                <th style="width:120px">备注</th>
+                                <th style="width:50px"></th>
+                            </tr>
+                        </thead>
+                        <tbody id="order-items-body"></tbody>
+                    </table>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">取消</button>
+                <button type="button" id="btn-save-order" class="btn btn-primary">
+                    <i class="bi bi-save me-1"></i>保存
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Edit item modal -->
+<div class="modal fade" id="editItemModal" tabindex="-1">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title"><i class="bi bi-pencil me-2"></i>编辑明细</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <input type="hidden" id="edit-item-id">
+                <div class="row g-3">
+                    <div class="col-md-6">
+                        <label class="form-label">货号</label>
+                        <input type="text" id="edit-product-code" class="form-control">
+                    </div>
+                    <div class="col-md-6">
+                        <label class="form-label">货品名称 <span class="text-danger">*</span></label>
+                        <input type="text" id="edit-product-name" class="form-control">
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label">数量</label>
+                        <input type="number" id="edit-quantity" class="form-control" step="1">
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label">单位RMB</label>
+                        <input type="text" id="edit-unit" class="form-control">
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label">单价RMB</label>
+                        <input type="number" id="edit-unit-price" class="form-control" step="any">
+                    </div>
+                    <div class="col-md-6">
+                        <label class="form-label">金额RMB</label>
+                        <input type="number" id="edit-amount" class="form-control" step="any">
+                    </div>
+                    <div class="col-md-6">
+                        <label class="form-label">备注</label>
+                        <input type="text" id="edit-remarks" class="form-control">
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">取消</button>
+                <button type="button" id="btn-save-edit" class="btn btn-primary">
+                    <i class="bi bi-save me-1"></i>保存
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+var table;
+
+function getFilterParams() {
+    return {
+        year:        $('#filter-year').val(),
+        supplier_id: $('#filter-supplier').val(),
+        date_from:   $('#filter-date-from').val(),
+        date_to:     $('#filter-date-to').val(),
+        po_no:       $('#filter-po-no').val()
+    };
+}
+
+function buildQueryString(params) {
+    return Object.entries(params)
+        .filter(function(e) { return e[1]; })
+        .map(function(e) { return encodeURIComponent(e[0]) + '=' + encodeURIComponent(e[1]); })
+        .join('&');
+}
+
+function addItemRow() {
+    var row = '<tr>' +
+        '<td><input type="text" class="form-control form-control-sm item-code"></td>' +
+        '<td><input type="text" class="form-control form-control-sm item-name" required></td>' +
+        '<td><input type="number" class="form-control form-control-sm item-qty" step="1" value="0"></td>' +
+        '<td><input type="text" class="form-control form-control-sm item-unit" value="PCS"></td>' +
+        '<td><input type="number" class="form-control form-control-sm item-price" step="any" value="0"></td>' +
+        '<td><input type="number" class="form-control form-control-sm item-amount" step="any" value="0"></td>' +
+        '<td><input type="text" class="form-control form-control-sm item-remarks"></td>' +
+        '<td><button type="button" class="btn btn-sm btn-outline-danger remove-row"><i class="bi bi-trash"></i></button></td>' +
+        '</tr>';
+    $('#order-items-body').append(row);
+}
+
+$(document).ready(function () {
+    table = $('#purchases-table').DataTable({
+        ajax: {
+            url: '{{ url_for("purchase.api_list") }}',
+            data: function () { return getFilterParams(); },
+            dataSrc: 'data'
+        },
+        columns: [
+            {
+                data: 'po_date',
+                render: function (d) {
+                    return d || '';
+                }
+            },
+            {
+                data: 'po_no',
+                render: function (d, type, row) {
+                    if (!d) return '';
+                    return '<a href="/purchases/' + row.order_id + '" class="text-decoration-none">' + d + '</a>';
+                }
+            },
+            { data: 'product_code' },
+            { data: 'product_name' },
+            { data: 'quantity', className: 'text-end' },
+            { data: 'unit' },
+            {
+                data: 'unit_price',
+                className: 'text-end',
+                render: function (d) { return d ? d.toFixed(4) : ''; }
+            },
+            {
+                data: 'amount',
+                className: 'text-end',
+                render: function (d) { return d ? d.toLocaleString('zh-CN', {minimumFractionDigits: 2, maximumFractionDigits: 2}) : ''; }
+            },
+            { data: 'delivery_date' },
+            { data: 'remarks' },
+            {
+                data: 'outstanding',
+                className: 'text-end',
+                render: function (d, type, row) {
+                    if (d === undefined || d === null) return '';
+                    if (d > 0) return '<span class="text-danger fw-bold">' + (d % 1 === 0 ? d.toFixed(0) : d.toFixed(2)) + '</span>';
+                    if (d === 0 && row.delivered_qty > 0) return '<span class="text-success">已送完</span>';
+                    return '';
+                }
+            },
+            {
+                data: null,
+                orderable: false,
+                className: 'text-center',
+                render: function (data, type, row) {
+                    return '<button class="btn btn-sm btn-outline-primary me-1 btn-edit" title="编辑">' +
+                        '<i class="bi bi-pencil"></i></button>' +
+                        '<button class="btn btn-sm btn-outline-danger btn-del" title="删除">' +
+                        '<i class="bi bi-trash"></i></button>';
+                }
+            }
+        ],
+        language: { url: 'https://cdn.datatables.net/plug-ins/1.13.8/i18n/zh.json' },
+        ordering: false,
+        pageLength: 50,
+        createdRow: function (row, data) {
+            if (data.is_first) {
+                $(row).css('border-top', '2px solid #adb5bd');
+            }
+        }
+    });
+
+    // Query
+    $('#btn-query').on('click', function () {
+        var qs = buildQueryString(getFilterParams());
+        $('#btn-export').attr('href', '/export/excel' + (qs ? '?' + qs : ''));
+        table.ajax.reload();
+    });
+
+    // ========== CREATE ==========
+    $('#btn-add-order').on('click', function () {
+        $('#order-supplier').val('');
+        $('#order-po-no').val('');
+        $('#order-date').val(new Date().toISOString().split('T')[0]);
+        $('#order-delivery-date').val('');
+        $('#order-items-body').empty();
+        addItemRow();
+        new bootstrap.Modal(document.getElementById('orderModal')).show();
+    });
+
+    $('#btn-add-row').on('click', addItemRow);
+
+    $('#order-items-body').on('click', '.remove-row', function () {
+        $(this).closest('tr').remove();
+    });
+
+    // Auto-calc amount
+    $('#order-items-body').on('input', '.item-qty, .item-price', function () {
+        var row = $(this).closest('tr');
+        var qty = parseFloat(row.find('.item-qty').val()) || 0;
+        var price = parseFloat(row.find('.item-price').val()) || 0;
+        row.find('.item-amount').val((qty * price).toFixed(2));
+    });
+
+    $('#btn-save-order').on('click', function () {
+        var supplierId = $('#order-supplier').val();
+        var poNo = $('#order-po-no').val().trim();
+        if (!supplierId) { alert('请选择供应商'); return; }
+        if (!poNo) { alert('请输入采购单号'); return; }
+
+        var items = [];
+        var valid = true;
+        $('#order-items-body tr').each(function () {
+            var name = $(this).find('.item-name').val().trim();
+            if (!name) { valid = false; return false; }
+            items.push({
+                product_code: $(this).find('.item-code').val().trim(),
+                product_name: name,
+                quantity: parseInt($(this).find('.item-qty').val()) || 0,
+                unit: $(this).find('.item-unit').val().trim() || 'PCS',
+                unit_price: parseFloat($(this).find('.item-price').val()) || 0,
+                amount: parseFloat($(this).find('.item-amount').val()) || 0,
+                remarks: $(this).find('.item-remarks').val().trim(),
+            });
+        });
+        if (!valid) { alert('请填写所有货品名称'); return; }
+        if (items.length === 0) { alert('请添加至少一条明细'); return; }
+
+        $('#btn-save-order').prop('disabled', true);
+        $.ajax({
+            url: '{{ url_for("purchase.api_create") }}',
+            type: 'POST',
+            contentType: 'application/json',
+            data: JSON.stringify({
+                supplier_id: parseInt(supplierId),
+                po_no: poNo,
+                po_date: $('#order-date').val(),
+                delivery_date: $('#order-delivery-date').val(),
+                items: items
+            }),
+            success: function (res) {
+                if (res.success) {
+                    bootstrap.Modal.getInstance(document.getElementById('orderModal')).hide();
+                    table.ajax.reload();
+                } else {
+                    alert(res.error || '保存失败');
+                }
+            },
+            error: function (xhr) {
+                var msg = '请求失败';
+                try { msg = JSON.parse(xhr.responseText).error || msg; } catch(e) {}
+                alert(msg);
+            },
+            complete: function () { $('#btn-save-order').prop('disabled', false); }
+        });
+    });
+
+    // ========== EDIT ==========
+    $('#purchases-table').on('click', '.btn-edit', function () {
+        var data = table.row($(this).closest('tr')).data();
+        $('#edit-item-id').val(data.item_id);
+        $('#edit-product-code').val(data.product_code);
+        $('#edit-product-name').val(data.product_name);
+        $('#edit-quantity').val(data.quantity);
+        $('#edit-unit').val(data.unit);
+        $('#edit-unit-price').val(data.unit_price);
+        $('#edit-amount').val(data.amount);
+        $('#edit-remarks').val(data.remarks);
+        new bootstrap.Modal(document.getElementById('editItemModal')).show();
+    });
+
+    // Auto-calc amount in edit modal
+    $('#edit-quantity, #edit-unit-price').on('input', function () {
+        var qty = parseFloat($('#edit-quantity').val()) || 0;
+        var price = parseFloat($('#edit-unit-price').val()) || 0;
+        $('#edit-amount').val((qty * price).toFixed(2));
+    });
+
+    $('#btn-save-edit').on('click', function () {
+        var itemId = $('#edit-item-id').val();
+        var name = $('#edit-product-name').val().trim();
+        if (!name) { alert('请填写货品名称'); return; }
+
+        $('#btn-save-edit').prop('disabled', true);
+        $.ajax({
+            url: '/purchases/api/item/' + itemId,
+            type: 'PUT',
+            contentType: 'application/json',
+            data: JSON.stringify({
+                product_code: $('#edit-product-code').val().trim(),
+                product_name: name,
+                quantity: parseInt($('#edit-quantity').val()) || 0,
+                unit: $('#edit-unit').val().trim() || 'PCS',
+                unit_price: parseFloat($('#edit-unit-price').val()) || 0,
+                amount: parseFloat($('#edit-amount').val()) || 0,
+                remarks: $('#edit-remarks').val().trim(),
+            }),
+            success: function (res) {
+                if (res.success) {
+                    bootstrap.Modal.getInstance(document.getElementById('editItemModal')).hide();
+                    table.ajax.reload();
+                } else {
+                    alert(res.error || '保存失败');
+                }
+            },
+            error: function () { alert('请求失败'); },
+            complete: function () { $('#btn-save-edit').prop('disabled', false); }
+        });
+    });
+
+    // ========== DELETE ==========
+    $('#purchases-table').on('click', '.btn-del', function () {
+        var data = table.row($(this).closest('tr')).data();
+        if (!confirm('确定删除该明细？\n' + data.product_name)) return;
+        $.ajax({
+            url: '/purchases/api/item/' + data.item_id,
+            type: 'DELETE',
+            success: function (res) {
+                if (res.success) table.ajax.reload();
+                else alert('删除失败');
+            },
+            error: function () { alert('请求失败'); }
+        });
+    });
+});
+</script>
+{% endblock %}

--- a/apps/jiangping/templates/purchases.html
+++ b/apps/jiangping/templates/purchases.html
@@ -278,7 +278,7 @@ $(document).ready(function () {
                 data: 'po_no',
                 render: function (d, type, row) {
                     if (!d) return '';
-                    return '<a href="/purchases/' + row.order_id + '" class="text-decoration-none">' + d + '</a>';
+                    return '<a href="' + BASE_URL + '/purchases/' + row.order_id + '" class="text-decoration-none">' + d + '</a>';
                 }
             },
             { data: 'product_code' },
@@ -332,7 +332,7 @@ $(document).ready(function () {
     // Query
     $('#btn-query').on('click', function () {
         var qs = buildQueryString(getFilterParams());
-        $('#btn-export').attr('href', '/export/excel' + (qs ? '?' + qs : ''));
+        $('#btn-export').attr('href', BASE_URL + '/export/excel' + (qs ? '?' + qs : ''));
         table.ajax.reload();
     });
 
@@ -442,7 +442,7 @@ $(document).ready(function () {
 
         $('#btn-save-edit').prop('disabled', true);
         $.ajax({
-            url: '/purchases/api/item/' + itemId,
+            url: BASE_URL + '/purchases/api/item/' + itemId,
             type: 'PUT',
             contentType: 'application/json',
             data: JSON.stringify({
@@ -472,7 +472,7 @@ $(document).ready(function () {
         var data = table.row($(this).closest('tr')).data();
         if (!confirm('确定删除该明细？\n' + data.product_name)) return;
         $.ajax({
-            url: '/purchases/api/item/' + data.item_id,
+            url: BASE_URL + '/purchases/api/item/' + data.item_id,
             type: 'DELETE',
             success: function (res) {
                 if (res.success) table.ajax.reload();

--- a/apps/jiangping/templates/suppliers.html
+++ b/apps/jiangping/templates/suppliers.html
@@ -1,0 +1,172 @@
+{% extends 'base.html' %}
+{% block title %}供应商管理 - 采购管理系统{% endblock %}
+
+{% block content %}
+<h2>供应商管理</h2>
+<p class="text-muted">查看和管理所有供应商信息。</p>
+
+<div class="card">
+    <div class="card-body">
+        <table id="suppliersTable" class="table table-striped table-hover align-middle">
+            <thead class="table-dark">
+                <tr>
+                    <th>简称</th>
+                    <th>全称</th>
+                    <th>联系人</th>
+                    <th>电话</th>
+                    <th>订单数</th>
+                    <th>总金额 (RMB)</th>
+                    <th>操作</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for s, order_count, total_amount in suppliers %}
+                <tr>
+                    <td>{{ s.short_name or '' }}</td>
+                    <td>{{ s.name }}</td>
+                    <td>{{ s.contact or '' }}</td>
+                    <td>{{ s.tel or '' }}</td>
+                    <td>{{ order_count }}</td>
+                    <td>{{ '%.2f'|format(total_amount|float) }}</td>
+                    <td>
+                        <button class="btn btn-sm btn-outline-primary btn-edit"
+                                data-id="{{ s.id }}"
+                                data-name="{{ s.name }}"
+                                data-short-name="{{ s.short_name or '' }}"
+                                data-contact="{{ s.contact or '' }}"
+                                data-tel="{{ s.tel or '' }}"
+                                data-fax="{{ s.fax or '' }}"
+                                data-address="{{ s.address or '' }}"
+                                data-bs-toggle="modal"
+                                data-bs-target="#editModal">
+                            <i class="bi bi-pencil"></i> 编辑
+                        </button>
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<!-- Edit Modal -->
+<div class="modal fade" id="editModal" tabindex="-1" aria-labelledby="editModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="editModalLabel">编辑供应商</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <input type="hidden" id="editSupplierId">
+                <div class="row g-3">
+                    <div class="col-md-6">
+                        <label for="editName" class="form-label">全称 <span class="text-danger">*</span></label>
+                        <input type="text" class="form-control" id="editName" placeholder="供应商全称">
+                    </div>
+                    <div class="col-md-6">
+                        <label for="editShortName" class="form-label">简称</label>
+                        <input type="text" class="form-control" id="editShortName" placeholder="供应商简称">
+                    </div>
+                    <div class="col-md-6">
+                        <label for="editContact" class="form-label">联系人</label>
+                        <input type="text" class="form-control" id="editContact" placeholder="联系人姓名">
+                    </div>
+                    <div class="col-md-6">
+                        <label for="editTel" class="form-label">电话</label>
+                        <input type="text" class="form-control" id="editTel" placeholder="联系电话">
+                    </div>
+                    <div class="col-md-6">
+                        <label for="editFax" class="form-label">传真</label>
+                        <input type="text" class="form-control" id="editFax" placeholder="传真号码">
+                    </div>
+                    <div class="col-md-6">
+                        <label for="editAddress" class="form-label">地址</label>
+                        <input type="text" class="form-control" id="editAddress" placeholder="供应商地址">
+                    </div>
+                </div>
+                <div id="editError" class="alert alert-danger mt-3 d-none"></div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">取消</button>
+                <button type="button" class="btn btn-primary" id="saveSupplierBtn">
+                    <i class="bi bi-save me-1"></i>保存
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+$(document).ready(function () {
+    // Initialize DataTables with Chinese language
+    $('#suppliersTable').DataTable({
+        language: {
+            url: 'https://cdn.datatables.net/plug-ins/1.13.8/i18n/zh.json'
+        },
+        order: [[0, 'asc']],
+        columnDefs: [
+            { orderable: false, targets: 6 }
+        ]
+    });
+
+    // Populate modal when edit button is clicked
+    $(document).on('click', '.btn-edit', function () {
+        var btn = $(this);
+        $('#editSupplierId').val(btn.data('id'));
+        $('#editName').val(btn.data('name'));
+        $('#editShortName').val(btn.data('short-name'));
+        $('#editContact').val(btn.data('contact'));
+        $('#editTel').val(btn.data('tel'));
+        $('#editFax').val(btn.data('fax'));
+        $('#editAddress').val(btn.data('address'));
+        $('#editError').addClass('d-none').text('');
+    });
+
+    // Save supplier via AJAX POST
+    $('#saveSupplierBtn').on('click', function () {
+        var supplierId = $('#editSupplierId').val();
+        var name = $('#editName').val().trim();
+
+        if (!name) {
+            $('#editError').removeClass('d-none').text('供应商全称不能为空。');
+            return;
+        }
+
+        var payload = {
+            name:       name,
+            short_name: $('#editShortName').val().trim(),
+            contact:    $('#editContact').val().trim(),
+            tel:        $('#editTel').val().trim(),
+            fax:        $('#editFax').val().trim(),
+            address:    $('#editAddress').val().trim()
+        };
+
+        $('#saveSupplierBtn').prop('disabled', true).html('<span class="spinner-border spinner-border-sm me-1"></span>保存中...');
+
+        $.ajax({
+            url: '/suppliers/' + supplierId + '/update',
+            method: 'POST',
+            contentType: 'application/json',
+            data: JSON.stringify(payload),
+            success: function (resp) {
+                if (resp.success) {
+                    location.reload();
+                } else {
+                    $('#editError').removeClass('d-none').text('保存失败，请重试。');
+                    $('#saveSupplierBtn').prop('disabled', false).html('<i class="bi bi-save me-1"></i>保存');
+                }
+            },
+            error: function (xhr) {
+                var msg = '保存失败，请重试。';
+                try { msg = JSON.parse(xhr.responseText).error || msg; } catch(e) {}
+                $('#editError').removeClass('d-none').text(msg);
+                $('#saveSupplierBtn').prop('disabled', false).html('<i class="bi bi-save me-1"></i>保存');
+            }
+        });
+    });
+});
+</script>
+{% endblock %}

--- a/apps/jiangping/templates/suppliers.html
+++ b/apps/jiangping/templates/suppliers.html
@@ -147,7 +147,7 @@ $(document).ready(function () {
         $('#saveSupplierBtn').prop('disabled', true).html('<span class="spinner-border spinner-border-sm me-1"></span>保存中...');
 
         $.ajax({
-            url: '/suppliers/' + supplierId + '/update',
+            url: BASE_URL + '/suppliers/' + supplierId + '/update',
             method: 'POST',
             contentType: 'application/json',
             data: JSON.stringify(payload),

--- a/apps/jiangping/templates/upload.html
+++ b/apps/jiangping/templates/upload.html
@@ -1,0 +1,315 @@
+{% extends 'base.html' %}
+{% block title %}PDF导入 - 采购管理系统{% endblock %}
+
+{% block extra_css %}
+<style>
+  #drop-zone {
+    border: 2px dashed #6c757d;
+    border-radius: 12px;
+    transition: border-color 0.2s, background-color 0.2s;
+    cursor: pointer;
+    min-height: 180px;
+  }
+  #drop-zone.dragover {
+    border-color: #0d6efd;
+    background-color: #e8f0fe;
+  }
+  #drop-zone:hover {
+    border-color: #0d6efd;
+  }
+  #file-input {
+    display: none;
+  }
+  #preview-section {
+    display: none;
+  }
+  .table-preview th {
+    white-space: nowrap;
+  }
+  .spinner-overlay {
+    display: none;
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.35);
+    z-index: 9999;
+    align-items: center;
+    justify-content: center;
+  }
+  .spinner-overlay.active {
+    display: flex;
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+<h2 class="mb-1">PDF导入</h2>
+<p class="text-muted mb-4">上传采购订单PDF文件，系统将自动解析并导入数据。</p>
+
+<!-- Upload Zone -->
+<div class="card mb-4">
+  <div class="card-body p-4">
+    <div id="drop-zone" class="d-flex flex-column align-items-center justify-content-center text-center p-5"
+         onclick="document.getElementById('file-input').click()">
+      <i class="bi bi-file-earmark-pdf text-danger" style="font-size: 3.5rem;"></i>
+      <p class="mt-3 mb-1 fw-semibold fs-5">点击选择或拖拽PDF文件至此处</p>
+      <p class="text-muted small">支持单个或批量上传 · 仅限 .pdf 格式</p>
+      <button type="button" class="btn btn-outline-primary btn-sm mt-2"
+              onclick="event.stopPropagation(); document.getElementById('file-input').click()">
+        <i class="bi bi-folder2-open me-1"></i>浏览文件
+      </button>
+    </div>
+    <input type="file" id="file-input" accept=".pdf" multiple>
+  </div>
+</div>
+
+<!-- Alert area -->
+<div id="alert-area"></div>
+
+<!-- Preview Section -->
+<div id="preview-section">
+  <div class="card">
+    <div class="card-header d-flex align-items-center justify-content-between">
+      <span class="fw-semibold fs-5"><i class="bi bi-eye me-2"></i>解析预览</span>
+      <span id="warning-badge" class="badge bg-warning text-dark d-none"></span>
+    </div>
+    <div class="card-body">
+      <!-- Header info row -->
+      <div class="row g-3 mb-3">
+        <div class="col-sm-6 col-md-3">
+          <label class="form-label text-muted small mb-1">采购单号</label>
+          <div id="info-po-no" class="fw-semibold"></div>
+        </div>
+        <div class="col-sm-6 col-md-3">
+          <label class="form-label text-muted small mb-1">日期</label>
+          <div id="info-po-date"></div>
+        </div>
+        <div class="col-sm-6 col-md-3">
+          <label class="form-label text-muted small mb-1">供应商</label>
+          <div id="info-supplier"></div>
+        </div>
+        <div class="col-sm-6 col-md-3">
+          <label class="form-label text-muted small mb-1">交货期</label>
+          <div id="info-delivery-date"></div>
+        </div>
+      </div>
+
+      <!-- Items Table -->
+      <div class="table-responsive">
+        <table class="table table-bordered table-hover table-sm align-middle table-preview">
+          <thead class="table-light">
+            <tr>
+              <th>#</th>
+              <th>物料编号</th>
+              <th>货号</th>
+              <th>货品名称</th>
+              <th>规格</th>
+              <th class="text-end">数量</th>
+              <th>单位</th>
+              <th class="text-end">单价</th>
+              <th class="text-end">金额</th>
+            </tr>
+          </thead>
+          <tbody id="preview-tbody"></tbody>
+          <tfoot>
+            <tr class="table-secondary fw-semibold">
+              <td colspan="8" class="text-end">合计</td>
+              <td class="text-end" id="preview-total"></td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+
+      <!-- Action buttons -->
+      <div class="d-flex gap-2 justify-content-end mt-3">
+        <button type="button" class="btn btn-secondary" id="btn-cancel">
+          <i class="bi bi-x-circle me-1"></i>取消
+        </button>
+        <button type="button" class="btn btn-primary" id="btn-save">
+          <i class="bi bi-save me-1"></i>保存入库
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Loading Spinner -->
+<div class="spinner-overlay" id="spinner-overlay">
+  <div class="text-center text-white">
+    <div class="spinner-border mb-2" style="width:3rem;height:3rem;" role="status"></div>
+    <div>正在解析PDF，请稍候…</div>
+  </div>
+</div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+(function () {
+  'use strict';
+
+  // ── State ──────────────────────────────────────────────────────────────────
+  let parsedData = null;
+
+  // ── Element refs ──────────────────────────────────────────────────────────
+  const dropZone       = document.getElementById('drop-zone');
+  const fileInput      = document.getElementById('file-input');
+  const alertArea      = document.getElementById('alert-area');
+  const previewSection = document.getElementById('preview-section');
+  const warningBadge   = document.getElementById('warning-badge');
+  const infoPono       = document.getElementById('info-po-no');
+  const infoPoDate     = document.getElementById('info-po-date');
+  const infoSupplier   = document.getElementById('info-supplier');
+  const infoDelivery   = document.getElementById('info-delivery-date');
+  const tbody          = document.getElementById('preview-tbody');
+  const totalCell      = document.getElementById('preview-total');
+  const btnSave        = document.getElementById('btn-save');
+  const btnCancel      = document.getElementById('btn-cancel');
+  const spinner        = document.getElementById('spinner-overlay');
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+  function showAlert(msg, type = 'danger') {
+    alertArea.innerHTML = `
+      <div class="alert alert-${type} alert-dismissible fade show" role="alert">
+        ${msg}
+        <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+      </div>`;
+  }
+
+  function clearAlert() { alertArea.innerHTML = ''; }
+
+  function fmtNum(v) {
+    const n = parseFloat(v);
+    return isNaN(n) ? '—' : n.toLocaleString('zh-CN', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  }
+
+  function showSpinner()  { spinner.classList.add('active'); }
+  function hideSpinner()  { spinner.classList.remove('active'); }
+
+  // ── Drag-drop events ──────────────────────────────────────────────────────
+  dropZone.addEventListener('dragover', e => {
+    e.preventDefault();
+    dropZone.classList.add('dragover');
+  });
+  dropZone.addEventListener('dragleave', () => dropZone.classList.remove('dragover'));
+  dropZone.addEventListener('drop', e => {
+    e.preventDefault();
+    dropZone.classList.remove('dragover');
+    const files = Array.from(e.dataTransfer.files).filter(f => f.name.toLowerCase().endsWith('.pdf'));
+    if (files.length === 0) { showAlert('请拖拽 PDF 文件'); return; }
+    uploadFile(files[0]);
+  });
+
+  fileInput.addEventListener('change', () => {
+    if (fileInput.files.length) uploadFile(fileInput.files[0]);
+    fileInput.value = '';   // reset so the same file can be re-selected
+  });
+
+  // ── Upload & Parse ────────────────────────────────────────────────────────
+  async function uploadFile(file) {
+    clearAlert();
+    previewSection.style.display = 'none';
+    parsedData = null;
+
+    const formData = new FormData();
+    formData.append('file', file);
+
+    showSpinner();
+    try {
+      const res  = await fetch('/upload/parse', { method: 'POST', body: formData });
+      const json = await res.json();
+      if (!res.ok || json.error) {
+        showAlert(json.error || '解析失败');
+        return;
+      }
+      parsedData = json;
+      renderPreview(json);
+    } catch (err) {
+      showAlert('网络错误：' + err.message);
+    } finally {
+      hideSpinner();
+    }
+  }
+
+  // ── Render Preview ────────────────────────────────────────────────────────
+  function renderPreview(data) {
+    // Header info
+    infoPono.textContent      = data.po_no        || '—';
+    infoPoDate.textContent    = data.po_date       || '—';
+    infoSupplier.textContent  = data.supplier_name || '—';
+    infoDelivery.textContent  = data.delivery_date || '—';
+
+    // Warning badge
+    if (data.warning) {
+      warningBadge.textContent = data.warning;
+      warningBadge.classList.remove('d-none');
+    } else {
+      warningBadge.textContent = '';
+      warningBadge.classList.add('d-none');
+    }
+
+    // Table rows
+    tbody.innerHTML = '';
+    const items = data.items || [];
+    let total = 0;
+    items.forEach((item, idx) => {
+      total += parseFloat(item.amount) || 0;
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td class="text-muted">${idx + 1}</td>
+        <td>${esc(item.material_code)}</td>
+        <td>${esc(item.product_code)}</td>
+        <td>${esc(item.product_name)}</td>
+        <td>${esc(item.specification)}</td>
+        <td class="text-end">${fmtNum(item.quantity)}</td>
+        <td>${esc(item.unit)}</td>
+        <td class="text-end">${fmtNum(item.unit_price)}</td>
+        <td class="text-end">${fmtNum(item.amount)}</td>`;
+      tbody.appendChild(tr);
+    });
+
+    totalCell.textContent = fmtNum(total);
+    previewSection.style.display = 'block';
+    previewSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
+  function esc(str) {
+    if (!str) return '—';
+    return String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+  }
+
+  // ── Save ──────────────────────────────────────────────────────────────────
+  btnSave.addEventListener('click', async () => {
+    if (!parsedData) return;
+    showSpinner();
+    try {
+      const res  = await fetch('/upload/save', {
+        method:  'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body:    JSON.stringify(parsedData),
+      });
+      const json = await res.json();
+      if (!res.ok || json.error) {
+        showAlert(json.error || '保存失败');
+        return;
+      }
+      showAlert(`<i class="bi bi-check-circle me-1"></i>${json.message}`, 'success');
+      previewSection.style.display = 'none';
+      parsedData = null;
+    } catch (err) {
+      showAlert('网络错误：' + err.message);
+    } finally {
+      hideSpinner();
+    }
+  });
+
+  // ── Cancel ────────────────────────────────────────────────────────────────
+  btnCancel.addEventListener('click', () => {
+    previewSection.style.display = 'none';
+    parsedData = null;
+    clearAlert();
+  });
+})();
+</script>
+{% endblock %}

--- a/apps/jiangping/templates/upload.html
+++ b/apps/jiangping/templates/upload.html
@@ -214,7 +214,7 @@
 
     showSpinner();
     try {
-      const res  = await fetch('/upload/parse', { method: 'POST', body: formData });
+      const res  = await fetch(BASE_URL + '/upload/parse', { method: 'POST', body: formData });
       const json = await res.json();
       if (!res.ok || json.error) {
         showAlert(json.error || '解析失败');
@@ -284,7 +284,7 @@
     if (!parsedData) return;
     showSpinner();
     try {
-      const res  = await fetch('/upload/save', {
+      const res  = await fetch(BASE_URL + '/upload/save', {
         method:  'POST',
         headers: { 'Content-Type': 'application/json' },
         body:    JSON.stringify(parsedData),

--- a/apps/jiangping/tests/test_pdf_parser.py
+++ b/apps/jiangping/tests/test_pdf_parser.py
@@ -1,0 +1,40 @@
+import os
+import pytest
+from parser.pdf_parser import parse_purchase_pdf
+
+TEST_PDF = r'C:\Users\1\OneDrive\Desktop\华登\江平\采购FDJA20260158-01.pdf'
+
+@pytest.mark.skipif(not os.path.exists(TEST_PDF), reason='Test PDF not found')
+class TestPdfParser:
+    def test_parse_header(self):
+        result = parse_purchase_pdf(TEST_PDF)
+        assert result['po_no'] == 'FDJA20260158'
+        assert '华茂' in result['supplier_name']
+        assert result['po_date'] == '2026-03-18'
+        assert result['delivery_date'] == '2026-03-31'
+        assert result['receiver'] == '江平'
+
+    def test_parse_items_count(self):
+        result = parse_purchase_pdf(TEST_PDF)
+        assert len(result['items']) == 11
+
+    def test_parse_first_item(self):
+        result = parse_purchase_pdf(TEST_PDF)
+        item = result['items'][0]
+        assert item['product_code'] == 'JWC2269'
+        assert 'XS' in item['product_name']
+        assert item['quantity'] == 5000
+        assert item['unit'] == 'PCS'
+        assert item['unit_price'] == 0.452
+        assert item['amount'] == 2260.0
+        assert item['material_code'] == '08010804'
+
+    def test_parse_total_amount(self):
+        result = parse_purchase_pdf(TEST_PDF)
+        total = sum(item['amount'] for item in result['items'])
+        assert total == 25247.0
+
+    def test_parse_specification(self):
+        result = parse_purchase_pdf(TEST_PDF)
+        item = result['items'][0]
+        assert '350G' in item['specification']

--- a/apps/jiangping/wsgi.py
+++ b/apps/jiangping/wsgi.py
@@ -1,0 +1,3 @@
+from app import create_app
+
+app = create_app()

--- a/docker-compose.cloud.yml
+++ b/docker-compose.cloud.yml
@@ -166,6 +166,27 @@ services:
     networks:
       - platform-net
 
+  jiangping:
+    build:
+      context: ./apps/jiangping
+      dockerfile: Dockerfile
+    environment:
+      - BASE_PATH=/jiangping
+      - DATA_PATH=/app/data
+      - UPLOAD_FOLDER=/app/uploads
+      - SECRET_KEY=${JIANGPING_SECRET_KEY:-huadeng-jiangping-2026}
+    volumes:
+      - ./apps/jiangping/data:/app/data
+      - ./apps/jiangping/uploads:/app/uploads
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5001/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+    networks:
+      - platform-net
+
 networks:
   platform-net:
     driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,3 +108,24 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
+
+  jiangping:
+    build:
+      context: ./apps/jiangping
+      dockerfile: Dockerfile
+    env_file:
+      - ./apps/jiangping/.env
+    volumes:
+      - "./apps/jiangping/data:/app/data"
+      - "./apps/jiangping/uploads:/app/uploads"
+    restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5001/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3

--- a/frontend/index.cloud.html
+++ b/frontend/index.cloud.html
@@ -68,6 +68,7 @@
   }
   .dept-icon.engineering { background: linear-gradient(135deg, #3b82f6, #06b6d4); }
   .dept-icon.production { background: linear-gradient(135deg, #f97316, #ea580c); }
+  .dept-icon.pmc { background: linear-gradient(135deg, #10b981, #059669); }
   .dept-icon.business { background: linear-gradient(135deg, #f59e0b, #ef4444); }
   .dept-name { font-size: 20px; font-weight: 600; color: #f1f5f9; }
   .dept-desc { font-size: 13px; color: #94a3b8; margin-top: 2px; }
@@ -171,11 +172,11 @@
 
     <div class="stats-bar">
       <div class="stat-card">
-        <div class="stat-value" id="statDepts">1</div>
+        <div class="stat-value" id="statDepts">2</div>
         <div class="stat-label">部门数量</div>
       </div>
       <div class="stat-card">
-        <div class="stat-value" id="statPlugins">4</div>
+        <div class="stat-value" id="statPlugins">5</div>
         <div class="stat-label">应用数量</div>
       </div>
       <div class="stat-card">
@@ -223,6 +224,30 @@
               <div class="plugin-info">
                 <div class="plugin-dot gray" id="figureMoldDot"></div>
                 <span class="plugin-name">模具手办采购订单</span>
+                <span class="plugin-tag">采购</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+    </div>
+
+      <!-- PMC跟仓管 -->
+      <div class="dept-card" onclick="showDept('pmc')">
+        <div class="dept-card-header">
+          <div class="dept-icon pmc">&#128230;</div>
+          <div>
+            <div class="dept-name">PMC跟仓管</div>
+            <div class="dept-desc">采购订单管理</div>
+          </div>
+        </div>
+        <div class="dept-card-body">
+          <div class="plugin-list" id="pmcPluginList">
+            <div class="plugin-item">
+              <div class="plugin-info">
+                <div class="plugin-dot gray" id="jiangpingDot"></div>
+                <span class="plugin-name">采购订单管理系统</span>
                 <span class="plugin-tag">采购</span>
               </div>
             </div>
@@ -331,10 +356,47 @@
   </div>
 
 
+  <!-- ===== PMC跟仓管详情 ===== -->
+  <div class="detail-view" id="pmcDetail">
+    <div class="back-btn" onclick="goHome()">&larr; 返回部门总览</div>
+    <div class="breadcrumb">
+      <a href="#" onclick="goHome()">控制台</a>
+      <span class="sep">/</span>
+      <span style="color:#10b981">PMC跟仓管</span>
+    </div>
+    <div class="page-title" style="display:flex;align-items:center;gap:14px;">
+      <div class="dept-icon pmc" style="width:40px;height:40px;font-size:18px;">&#128230;</div>
+      PMC跟仓管
+    </div>
+    <div class="page-subtitle">采购订单与送货管理</div>
+
+    <div class="detail-plugin-card">
+      <div class="detail-plugin-left">
+        <div class="detail-plugin-icon" style="background:linear-gradient(135deg,#10b981,#059669);">&#128196;</div>
+        <div>
+          <div class="detail-plugin-name">采购订单管理系统</div>
+          <div class="detail-plugin-desc">PDF采购单解析、送货单OCR识别、供应商管理、采购对账与数据分析</div>
+          <div class="feature-grid">
+            <div class="feature-tag">&#128196; PDF采购单解析</div>
+            <div class="feature-tag">&#128247; OCR送货单识别</div>
+            <div class="feature-tag">&#128101; 供应商管理</div>
+            <div class="feature-tag">&#128202; 数据分析仪表盘</div>
+            <div class="feature-tag">&#128230; Excel导入导出</div>
+            <div class="feature-tag">&#128176; 采购对账</div>
+          </div>
+        </div>
+      </div>
+      <div class="detail-plugin-right">
+        <div class="detail-plugin-status"><div class="plugin-dot gray" id="jiangpingDetailDot"></div> 检查中...</div>
+        <a href="/jiangping/" target="_blank" class="btn btn-primary">打开系统</a>
+      </div>
+    </div>
+  </div>
+
 </div>
 
 <script>
-var allDepts = ['engineering'];
+var allDepts = ['engineering', 'pmc'];
 
 function showDept(dept) {
   document.getElementById('homeView').classList.add('hidden');
@@ -359,6 +421,7 @@ async function checkHealth() {
       { name: 'zouhuo', url: '/zouhuo/health', dot: 'zouhuoDot', detailDot: 'zouhuoDetailDot' },
       { name: 'devProgress', url: '/new-product-schedule/health', dot: 'devProgressDot', detailDot: 'devProgressDetailDot' },
       { name: 'figureMold', url: '/figure-mold-cost-system/health', dot: 'figureMoldDot', detailDot: 'figureMoldDetailDot' },
+      { name: 'jiangping', url: '/jiangping/health', dot: 'jiangpingDot', detailDot: 'jiangpingDetailDot' },
     ];
     var healthy = 0;
     var total = checks.length;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -86,6 +86,7 @@
   .dept-icon.rr { background: linear-gradient(135deg, #22c55e, #16a085); }
   .dept-icon.printing3d { background: linear-gradient(135deg, #8b5cf6, #6366f1); }
   .dept-icon.production { background: linear-gradient(135deg, #f97316, #ea580c); }
+  .dept-icon.pmc { background: linear-gradient(135deg, #10b981, #059669); }
   .dept-name { font-size: 20px; font-weight: 600; color: #f1f5f9; }
   .dept-desc { font-size: 13px; color: #94a3b8; margin-top: 2px; }
   .dept-card-body { padding: 0 28px 24px; }
@@ -182,7 +183,7 @@
 
     <div class="stats-bar">
       <div class="stat-card">
-        <div class="stat-value" id="statDepts">4</div>
+        <div class="stat-value" id="statDepts">5</div>
         <div class="stat-label">部门数量</div>
       </div>
       <div class="stat-card">
@@ -290,6 +291,28 @@
                 <div class="plugin-dot green"></div>
                 <span class="plugin-name">印尼出货明细资料核对系统</span>
                 <span class="plugin-tag">出货</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- PMC跟仓管 -->
+      <div class="dept-card" onclick="showDept('pmc')">
+        <div class="dept-card-header">
+          <div class="dept-icon pmc">&#128230;</div>
+          <div>
+            <div class="dept-name">PMC跟仓管</div>
+            <div class="dept-desc">采购订单管理</div>
+          </div>
+        </div>
+        <div class="dept-card-body">
+          <div class="plugin-list" id="pmcPluginList">
+            <div class="plugin-item">
+              <div class="plugin-info">
+                <div class="plugin-dot green" id="dotJiangping"></div>
+                <span class="plugin-name">采购订单管理系统</span>
+                <span class="plugin-tag">采购</span>
               </div>
             </div>
           </div>
@@ -443,6 +466,43 @@
     </div>
   </div>
 
+  <!-- ===== PMC跟仓管详情 ===== -->
+  <div class="detail-view" id="pmcDetail">
+    <div class="back-btn" onclick="goHome()">&larr; 返回部门总览</div>
+    <div class="breadcrumb">
+      <a href="#" onclick="goHome()">控制台</a>
+      <span class="sep">/</span>
+      <span style="color:#10b981">PMC跟仓管</span>
+    </div>
+    <div class="page-title" style="display:flex;align-items:center;gap:14px;">
+      <div class="dept-icon pmc" style="width:40px;height:40px;font-size:18px;">&#128230;</div>
+      PMC跟仓管
+    </div>
+    <div class="page-subtitle">采购订单与送货管理</div>
+
+    <div class="detail-plugin-card">
+      <div class="detail-plugin-left">
+        <div class="detail-plugin-icon" style="background:linear-gradient(135deg,#10b981,#059669);">&#128196;</div>
+        <div>
+          <div class="detail-plugin-name">采购订单管理系统</div>
+          <div class="detail-plugin-desc">PDF采购单解析、送货单OCR识别、供应商管理、采购对账与数据分析</div>
+          <div class="feature-grid">
+            <div class="feature-tag">&#128196; PDF采购单解析</div>
+            <div class="feature-tag">&#128247; OCR送货单识别</div>
+            <div class="feature-tag">&#128101; 供应商管理</div>
+            <div class="feature-tag">&#128202; 数据分析仪表盘</div>
+            <div class="feature-tag">&#128230; Excel导入导出</div>
+            <div class="feature-tag">&#128176; 采购对账</div>
+          </div>
+        </div>
+      </div>
+      <div class="detail-plugin-right">
+        <div class="detail-plugin-status"><div class="plugin-dot green" id="dotJiangpingDetail"></div> 运行中</div>
+        <a href="/jiangping/" target="_blank" class="btn btn-primary">打开系统</a>
+      </div>
+    </div>
+  </div>
+
   <!-- ===== 工程部详情 ===== -->
   <div class="detail-view" id="engineeringDetail">
     <div class="back-btn" onclick="goHome()">&larr; 返回部门总览</div>
@@ -543,7 +603,7 @@
 </div>
 
 <script>
-var allDepts = ['business', 'engineering', 'indonesia', 'printing3d'];
+var allDepts = ['business', 'engineering', 'pmc', 'indonesia', 'printing3d'];
 
 function showDept(dept) {
   document.getElementById('homeView').classList.add('hidden');
@@ -568,6 +628,7 @@ async function checkHealth() {
       { name: 'newProductSchedule', url: '/new-product-schedule/health' },
       { name: 'figureMoldCost', url: '/figure-mold-cost-system/health' },
       { name: 'zouhuo', url: '/zouhuo/health' },
+      { name: 'jiangping', url: '/jiangping/health' },
     ];
     let healthy = 1;
     let total = 1 + checks.length;
@@ -588,6 +649,8 @@ async function checkHealth() {
     updateDot('dotFigureMoldCost', '/figure-mold-cost-system/health');
     updateDot('dotZouhuo', '/zouhuo/health');
     updateDot('dotZouhuoDetail', '/zouhuo/health');
+    updateDot('dotJiangping', '/jiangping/health');
+    updateDot('dotJiangpingDetail', '/jiangping/health');
   } catch(e) {
     statusEl.textContent = '连接失败';
   }

--- a/nginx/nginx.cloud.conf
+++ b/nginx/nginx.cloud.conf
@@ -61,6 +61,11 @@ http {
         keepalive 4;
     }
 
+    upstream jiangping_backend {
+        server jiangping:5001;
+        keepalive 4;
+    }
+
     server {
         listen 80;
         server_name _;
@@ -234,6 +239,25 @@ http {
         }
         location /figure-mold-cost-system/ {
             proxy_pass http://figure_mold_cost/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+        }
+
+        # ─── Standalone: 采购订单管理系统 (jiangping) ───
+        location = /jiangping {
+            return 301 /jiangping/;
+        }
+        location = /jiangping/health {
+            auth_basic off;
+            proxy_pass http://jiangping_backend/health;
+            proxy_set_header Host $host;
+        }
+        location /jiangping/ {
+            proxy_pass http://jiangping_backend/;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Summary
- Deploy **jiangping** (采购订单管理系统) as a new standalone Python/Flask app under **PMC跟仓管** department
- Features: PDF purchase order parsing, OCR delivery note recognition, supplier management, analytics dashboard, Excel import/export
- Configured for Docker with gunicorn, CPU-only PyTorch for easyocr, SQLite + bind mount persistence
- Added nginx reverse proxy at `/jiangping/` with health check endpoint
- Added PMC跟仓管 department to both portal dashboards (local + cloud)

## Bug fixes (self-review)
- Fixed gunicorn command syntax (added wsgi.py entry point)
- Fixed all hardcoded JavaScript fetch/ajax paths for `/jiangping/` sub-path routing
- Injected `BASE_URL` variable for correct URL prefixing behind reverse proxy
- Added `.gitignore` to exclude sensitive/generated files

## Test plan
- [ ] `docker compose up -d --build jiangping` builds successfully
- [ ] Health check at `/jiangping/health` returns OK
- [ ] PDF upload and parsing works
- [ ] All CRUD operations (purchases, suppliers, deliveries) work
- [ ] Dashboard charts load correctly
- [ ] Data persists after container restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)