### PR TITLE
feat: simplify homepage department cards and fix display names [RRD-26]

### DIFF
--- a/frontend/index.cloud.html
+++ b/frontend/index.cloud.html
@@ -194,7 +194,6 @@
           <div class="dept-icon engineering">&#9881;</div>
           <div>
             <div class="dept-name">工程部</div>
-            <div class="dept-desc">工程啤办单 · 走货明细 · 新产品排期 · 模具手办采购</div>
           </div>
         </div>
         <div class="dept-card-body">
@@ -203,28 +202,24 @@
               <div class="plugin-info">
                 <div class="plugin-dot gray" id="rrDot"></div>
                 <span class="plugin-name">工程啤办单</span>
-                <span class="plugin-tag">生产</span>
               </div>
             </div>
             <div class="plugin-item">
               <div class="plugin-info">
                 <div class="plugin-dot gray" id="zouhuoDot"></div>
                 <span class="plugin-name">走货明细系统</span>
-                <span class="plugin-tag">走货</span>
               </div>
             </div>
             <div class="plugin-item">
               <div class="plugin-info">
                 <div class="plugin-dot gray" id="devProgressDot"></div>
                 <span class="plugin-name">新产品开发进度表</span>
-                <span class="plugin-tag">排期</span>
               </div>
             </div>
             <div class="plugin-item">
               <div class="plugin-info">
                 <div class="plugin-dot gray" id="figureMoldDot"></div>
                 <span class="plugin-name">模具手办采购订单</span>
-                <span class="plugin-tag">采购</span>
               </div>
             </div>
           </div>
@@ -237,7 +232,6 @@
           <div class="dept-icon pmc">&#128230;</div>
           <div>
             <div class="dept-name">PMC跟仓管</div>
-            <div class="dept-desc">采购订单管理</div>
           </div>
         </div>
         <div class="dept-card-body">
@@ -246,7 +240,6 @@
               <div class="plugin-info">
                 <div class="plugin-dot gray" id="jiangpingDot"></div>
                 <span class="plugin-name">采购订单管理系统</span>
-                <span class="plugin-tag">采购</span>
               </div>
             </div>
           </div>
@@ -259,7 +252,6 @@
           <div class="dept-icon production">&#9881;</div>
           <div>
             <div class="dept-name">生产部</div>
-            <div class="dept-desc">AI注塑啤机排产</div>
           </div>
         </div>
         <div class="dept-card-body">
@@ -267,8 +259,7 @@
             <div class="plugin-item">
               <div class="plugin-info">
                 <div class="plugin-dot gray" id="paijiDot"></div>
-                <span class="plugin-name">AI注塑啤机排产系统</span>
-                <span class="plugin-tag">排产</span>
+                <span class="plugin-name">注塑啤机排产系统</span>
               </div>
             </div>
           </div>
@@ -280,8 +271,7 @@
         <div class="dept-card-header">
           <div class="dept-icon business">&#128176;</div>
           <div>
-            <div class="dept-name">Business</div>
-            <div class="dept-desc">ZURU出货助手</div>
+            <div class="dept-name">业务</div>
           </div>
         </div>
         <div class="dept-card-body">
@@ -290,7 +280,6 @@
               <div class="plugin-info">
                 <div class="plugin-dot gray" id="zuruDot"></div>
                 <span class="plugin-name">ZURU出货助手</span>
-                <span class="plugin-tag">出货</span>
               </div>
             </div>
           </div>
@@ -303,7 +292,6 @@
           <div class="dept-icon pmc">&#128202;</div>
           <div>
             <div class="dept-name">总部</div>
-            <div class="dept-desc">生产经营数据统计</div>
           </div>
         </div>
         <div class="dept-card-body">
@@ -311,8 +299,7 @@
             <div class="plugin-item">
               <div class="plugin-info">
                 <div class="plugin-dot gray" id="businessDataDot"></div>
-                <span class="plugin-name">生产经营数据系统</span>
-                <span class="plugin-tag">统计</span>
+                <span class="plugin-name">生产结余数据系统</span>
               </div>
             </div>
           </div>
@@ -432,13 +419,13 @@
       <div class="dept-icon production" style="width:40px;height:40px;font-size:18px;">&#9881;</div>
       生产部
     </div>
-    <div class="page-subtitle">AI注塑啤机排产管理</div>
+    <div class="page-subtitle">注塑啤机排产管理</div>
 
     <div class="detail-plugin-card">
       <div class="detail-plugin-left">
         <div class="detail-plugin-icon" style="background:linear-gradient(135deg,#f97316,#ea580c);">&#129302;</div>
         <div>
-          <div class="detail-plugin-name">AI注塑啤机排产系统</div>
+          <div class="detail-plugin-name">注塑啤机排产系统</div>
           <div class="detail-plugin-desc">智能排产引擎，基于历史数据自动匹配机台，支持多车间、PDF/Excel订单导入、排机单导出</div>
           <div class="feature-grid">
             <div class="feature-tag">&#129302; 智能排机</div>
@@ -463,13 +450,13 @@
     <div class="breadcrumb">
       <a href="#" onclick="goHome()">控制台</a>
       <span class="sep">/</span>
-      <span style="color:#f59e0b">Business</span>
+      <span style="color:#f59e0b">业务</span>
     </div>
     <div class="page-title" style="display:flex;align-items:center;gap:14px;">
       <div class="dept-icon business" style="width:40px;height:40px;font-size:18px;">&#128176;</div>
-      Business
+      业务
     </div>
-    <div class="page-subtitle">ZURU出货匹配与标记</div>
+    <div class="page-subtitle">ZURU出货管理</div>
 
     <div class="detail-plugin-card">
       <div class="detail-plugin-left">
@@ -504,13 +491,13 @@
       <div class="dept-icon pmc" style="width:40px;height:40px;font-size:18px;">&#128202;</div>
       总部
     </div>
-    <div class="page-subtitle">生产经营数据统计与分析</div>
+    <div class="page-subtitle">生产结余数据统计与分析</div>
 
     <div class="detail-plugin-card">
       <div class="detail-plugin-left">
         <div class="detail-plugin-icon" style="background:linear-gradient(135deg,#7F41C0,#57B894);">&#128202;</div>
         <div>
-          <div class="detail-plugin-name">生产经营数据系统</div>
+          <div class="detail-plugin-name">生产结余数据系统</div>
           <div class="detail-plugin-desc">啤机部/印喷部/装配部三部门经营数据录入、自动结余计算、三工汇总报表、Excel导入导出</div>
           <div class="feature-grid">
             <div class="feature-tag">&#128202; 结余计算</div>


### PR DESCRIPTION
## Summary

- 移除首頁所有 department cards 的 `dept-desc` 副標題（5 個）
- 移除首頁所有 `plugin-tag` spans（8 個）
- 名稱修正：`Business` → `业务`（dept card、breadcrumb、page title）
- 名稱修正：`AI注塑啤机排产系统` → `注塑啤机排产系统`（首頁 + detail page）
- 名稱修正：`生产经营数据系统` → `生产结余数据系统`（首頁 + detail page）
- Detail page 副標題修正：注塑啤机排产管理、ZURU出货管理、生产结余数据统计与分析

## Files Changed

- `frontend/index.cloud.html` — 只修改此一文件

## Test Plan

- [ ] 首頁載入，5 個 department cards 不顯示 dept-desc 副標題
- [ ] 首頁 plugin items 不顯示 plugin-tag 標籤
- [ ] Business card 顯示「业务」
- [ ] 生産部 plugin name 顯示「注塑啤机排产系统」（無 AI 前綴）
- [ ] 总部 plugin name 顯示「生产结余数据系统」
- [ ] 點入 Business detail page → breadcrumb 和 title 顯示「业务」
- [ ] 點入 detail pages → 副標題正確

Resolves: RRD-26

🤖 Generated with [Claude Code](https://claude.com/claude-code)