### PR TITLE
fix(build): use Aliyun mirrors for CN build reliability

### DIFF
--- a/apps/liwenjuan/Dockerfile
+++ b/apps/liwenjuan/Dockerfile
@@ -4,6 +4,10 @@ WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends curl gosu && rm -rf /var/lib/apt/lists/*
 
+# 阿里云 PyPI 镜像（pypi.org 在国内不稳定，会超时）
+ENV PIP_INDEX_URL=https://mirrors.aliyun.com/pypi/simple/
+ENV PIP_TRUSTED_HOST=mirrors.aliyun.com
+
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt gunicorn
 

--- a/apps/quotation/Dockerfile
+++ b/apps/quotation/Dockerfile
@@ -1,9 +1,15 @@
 FROM node:20-alpine
 
+# 阿里云 Alpine 镜像源（dl-cdn 在国内很慢）
+RUN sed -i 's|https\?://dl-cdn.alpinelinux.org|https://mirrors.aliyun.com|g' /etc/apk/repositories
+
 # better-sqlite3 requires native compilation
 RUN apk add --no-cache python3 make g++ su-exec
 
 WORKDIR /app
+
+# 阿里云 npm 镜像
+RUN npm config set registry https://registry.npmmirror.com
 
 # Install dependencies first (layer cache)
 COPY package*.json ./


### PR DESCRIPTION
PyPI/dl-cdn timeouts blocked PR #42 deploy. Switching to Aliyun mirrors which respond in <0.5s from the production server.