### PR TITLE
fix(routing): base-path & CSP for quotation/liwenjuan/jiangping

### DIFF
--- a/apps/liwenjuan/static/main.js
+++ b/apps/liwenjuan/static/main.js
@@ -40,7 +40,7 @@ form.addEventListener('submit', async e => {
 
   const fd = new FormData(form);
   try {
-    const res  = await fetch('/run', { method: 'POST', body: fd });
+    const res  = await fetch(window.LIWENJUAN_RUN_URL || '/run', { method: 'POST', body: fd });
     const data = await res.json();
     if (!res.ok) throw new Error(data.error || 'Server error');
 

--- a/apps/liwenjuan/templates/index.html
+++ b/apps/liwenjuan/templates/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Finished Goods Check System</title>
-  <link rel="stylesheet" href="/static/style.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>
 
@@ -36,7 +36,7 @@
     </div>
     <div style="display:flex;flex-direction:column;gap:8px;align-items:stretch;">
       <button class="btn-run" type="submit" id="btn-run">Start Check</button>
-      <a class="btn-dl hidden" id="btn-dl" href="/download">Download Excel</a>
+      <a class="btn-dl hidden" id="btn-dl" href="{{ url_for('download') }}">Download Excel</a>
     </div>
   </form>
 
@@ -147,6 +147,7 @@
 
 </div><!-- /container -->
 
-<script src="/static/main.js"></script>
+<script>window.LIWENJUAN_RUN_URL = "{{ url_for('run') }}";</script>
+<script src="{{ url_for('static', filename='main.js') }}"></script>
 </body>
 </html>

--- a/apps/quotation/client/js/api.js
+++ b/apps/quotation/client/js/api.js
@@ -1,6 +1,9 @@
 /* API client — all calls go through this module */
 const api = (() => {
-  const BASE = '';
+  // Derive base path from current URL so the app works under any reverse-proxy
+  // prefix (e.g. nginx /quotation/ -> container /). location.pathname is the
+  // directory the page is served from; strip trailing file/slash to get '/quotation'.
+  const BASE = location.pathname.replace(/\/[^/]*$/, '');
 
   async function request(method, path, body) {
     const opts = {

--- a/nginx/nginx.cloud.conf
+++ b/nginx/nginx.cloud.conf
@@ -367,6 +367,12 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_http_version 1.1;
             proxy_set_header Connection "";
+            # Override CSP: jiangping templates load Bootstrap/jQuery/DataTables from CDNs
+            add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://code.jquery.com https://cdn.datatables.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdn.datatables.net; img-src 'self' data: blob:; font-src 'self' data: https://cdn.jsdelivr.net; connect-src 'self'; frame-ancestors 'self';" always;
+            add_header X-Frame-Options "SAMEORIGIN" always;
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header X-XSS-Protection "1; mode=block" always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         }
 
         # ─── Standalone: AI注塑啤机排产系统 (paiji) ───


### PR DESCRIPTION
## Summary
- **quotation**: derive BASE from `location.pathname` so `/quotation/api/*` works behind nginx prefix (was hardcoded `/api/*` → 404)
- **liwenjuan**: switch templates to `url_for()` so `/static/`, `/run`, `/download` respect Flask `SCRIPT_NAME` (was loading CSS/JS from `/static/style.css` → 404, no styling)
- **jiangping**: per-location CSP override allowing `cdn.jsdelivr.net` / `code.jquery.com` / `cdn.datatables.net` (Bootstrap + jQuery + DataTables blocked by global CSP — pre-existing breakage uncovered by smoke test)

## Test plan
- [x] Headless browser smoke test loads `/quotation/`, `/liwenjuan/`, `/jiangping/problems/` with no 404s on JS/CSS
- [x] `quotation/api/products` returns 200 instead of 404
- [x] `liwenjuan` page picks up styling
- [x] `jiangping` CSP no longer blocks CDN resources