### PR TITLE
rename: 走货明细系统 → A-doc生成系統

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Always respond in 简体中文 (Simplified Chinese). Code, commands, file paths 
 RR Portal
 ├── apps/            — 独立应用（非 plugin_sdk）
 │   ├── task-api/    — 任务 API (Node.js)
-│   └── zouhuo/      — 走货明细系统 (Node.js)
+│   └── zouhuo/      — A-doc生成系統 (Node.js)
 ├── core/            — 核心服务 (FastAPI, 用户/权限/插件注册)
 ├── devops/          — DevOps 自动化（agent、脚本、部署模板）
 ├── frontend/        — 前端静态文件 (Nginx托管)
@@ -327,7 +327,7 @@ const data = JSON.parse(fs.readFileSync('data/data.json'));
 | App 名 | 显示名 | 部门 | 类型 | 路径 | GitHub Repo |
 |---------|--------|------|------|------|-------------|
 | rr-production (工程啤办单) | 工程啤办单 | Engineering | Standalone (Node.js) | /rr/ | https://github.com/hufan4308-blip/RR-production-system |
-| zouhuo | 走货明细系统 | Engineering | Standalone (Node.js) | /zouhuo/ | https://github.com/duanlei10/123 |
+| zouhuo | A-doc生成系統 | Engineering | Standalone (Node.js) | /zouhuo/ | https://github.com/duanlei10/123 |
 | task-api | 任务 API | — | Standalone (Node.js) | — | — |
 | new-product-schedule | 新产品开发进度表 | Engineering | Standalone (Node.js) | /new-product-schedule/ | https://github.com/hufan4308-blip/new-product-schedule |
 | figure-mold-cost-system | 模具手办采购订单 | Engineering | Standalone (Node.js) | /figure-mold-cost-system/ | https://github.com/hufan4308-blip/figure-mold-cost-system |

--- a/frontend/index.cloud.html
+++ b/frontend/index.cloud.html
@@ -208,7 +208,7 @@
             <div class="plugin-item">
               <div class="plugin-info">
                 <div class="plugin-dot gray" id="zouhuoDot"></div>
-                <span class="plugin-name">走货明细系统</span>
+                <span class="plugin-name">A-doc生成系統</span>
               </div>
             </div>
             <div class="plugin-item">
@@ -320,7 +320,7 @@
       <div class="dept-icon engineering" style="width:40px;height:40px;font-size:18px;">&#9881;</div>
       工程部
     </div>
-    <div class="page-subtitle">工程啤办单 · 走货明细 · 新产品排期 · 模具手办采购</div>
+    <div class="page-subtitle">工程啤办单 · A-doc生成 · 新产品排期 · 模具手办采购</div>
 
     <div class="detail-plugin-card">
       <div class="detail-plugin-left">
@@ -348,7 +348,7 @@
       <div class="detail-plugin-left">
         <div class="detail-plugin-icon" style="background:linear-gradient(135deg,#3b82f6,#06b6d4);">&#128196;</div>
         <div>
-          <div class="detail-plugin-name">走货明细系统</div>
+          <div class="detail-plugin-name">A-doc生成系統</div>
           <div class="detail-plugin-desc">上传Excel走货明细表，自动解析BOM表与外购清单，核价管理，A-DOC采购订单Word文档生成</div>
           <div class="feature-grid">
             <div class="feature-tag">&#128230; 走货明细解析</div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -238,7 +238,7 @@
           <div class="dept-icon engineering">&#9881;</div>
           <div>
             <div class="dept-name">工程部</div>
-            <div class="dept-desc">工程啤办单 · 走货明细 · 新产品排期 · 模具手办采购</div>
+            <div class="dept-desc">工程啤办单 · A-doc生成 · 新产品排期 · 模具手办采购</div>
           </div>
         </div>
         <div class="dept-card-body">
@@ -253,8 +253,8 @@
             <div class="plugin-item">
               <div class="plugin-info">
                 <div class="plugin-dot green" id="dotZouhuo"></div>
-                <span class="plugin-name">走货明细系统</span>
-                <span class="plugin-tag">走货</span>
+                <span class="plugin-name">A-doc生成系統</span>
+                <span class="plugin-tag">A-doc</span>
               </div>
             </div>
             <div class="plugin-item">
@@ -574,7 +574,7 @@
       <div class="dept-icon engineering" style="width:40px;height:40px;font-size:18px;">&#9881;</div>
       工程部
     </div>
-    <div class="page-subtitle">工程啤办单 · 走货明细 · 新产品排期 · 模具手办采购</div>
+    <div class="page-subtitle">工程啤办单 · A-doc生成 · 新产品排期 · 模具手办采购</div>
 
     <div class="detail-plugin-card">
       <div class="detail-plugin-left">
@@ -602,7 +602,7 @@
       <div class="detail-plugin-left">
         <div class="detail-plugin-icon" style="background:linear-gradient(135deg,#3b82f6,#06b6d4);">&#128196;</div>
         <div>
-          <div class="detail-plugin-name">走货明细系统</div>
+          <div class="detail-plugin-name">A-doc生成系統</div>
           <div class="detail-plugin-desc">上传Excel走货明细表，自动解析BOM表与外购清单，核价管理，A-DOC采购订单Word文档生成</div>
           <div class="feature-grid">
             <div class="feature-tag">&#128230; 走货明细解析</div>


### PR DESCRIPTION
## Summary
- Portal 首页显示名从「走货明细系统」改为「A-doc生成系統」
- 涉及 `index.cloud.html`、`index.html`、`CLAUDE.md` app registry

## Test plan
- [ ] 打开 Portal 首页，确认工程部卡片显示「A-doc生成系統」
- [ ] 进入工程部详情页，确认插件名和副标题已更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)