### PR TITLE
fix: 业务 → 业务部

### DIFF
--- a/frontend/index.cloud.html
+++ b/frontend/index.cloud.html
@@ -278,7 +278,7 @@
         <div class="dept-card-header">
           <div class="dept-icon business">&#128176;</div>
           <div>
-            <div class="dept-name">业务</div>
+            <div class="dept-name">业务部</div>
           </div>
         </div>
         <div class="dept-card-body">
@@ -449,11 +449,11 @@
     <div class="breadcrumb">
       <a href="#" onclick="goHome()">控制台</a>
       <span class="sep">/</span>
-      <span style="color:#f59e0b">业务</span>
+      <span style="color:#f59e0b">业务部</span>
     </div>
     <div class="page-title" style="display:flex;align-items:center;gap:14px;">
       <div class="dept-icon business" style="width:40px;height:40px;font-size:18px;">&#128176;</div>
-      业务
+      业务部
     </div>
     <div class="page-subtitle">ZURU出货 · 报价管理 · TOMY排期核对</div>
 


### PR DESCRIPTION
## Summary
- Cloud 首页部门名从「业务」改为「业务部」，与 local 版本对齐

## Test plan
- [ ] Portal 首页部门卡片显示「业务部」
- [ ] 业务部详情页面包屑和标题显示「业务部」

🤖 Generated with [Claude Code](https://claude.com/claude-code)