### PR TITLE
fix: quotation plush export + tomy-paiqi blank page

### DIFF
--- a/apps/quotation/client/js/api.js
+++ b/apps/quotation/client/js/api.js
@@ -27,6 +27,7 @@ const api = (() => {
   }
 
   return {
+    BASE,
     // Products
     getProducts: () => request('GET', '/api/products'),
     createProduct: (data) => request('POST', '/api/products', data),

--- a/apps/quotation/client/js/app.js
+++ b/apps/quotation/client/js/app.js
@@ -247,7 +247,7 @@ const app = (() => {
     document.getElementById('btnTranslateAll').addEventListener('click', async () => {
       try {
         showToast('正在翻译，请稍候...', 'info');
-        const r = await fetch(`/api/versions/${currentVersionId}/translate-all`, { method: 'POST' });
+        const r = await fetch(`${api.BASE}/api/versions/${currentVersionId}/translate-all`, { method: 'POST' });
         const d = await r.json();
         if (!r.ok) throw new Error(d.error);
         showToast(`已翻译 ${d.translated} 条名称`, 'success');

--- a/apps/quotation/client/js/tabs/bd-decoration.js
+++ b/apps/quotation/client/js/tabs/bd-decoration.js
@@ -92,7 +92,7 @@ const tab_bd_decoration = {
           }
           try {
             // Painting is a singleton section — use PUT /sections/painting (no itemId)
-            await fetch(`/api/versions/${versionId}/sections/painting`, {
+            await fetch(`${api.BASE}/api/versions/${versionId}/sections/painting`, {
               method: 'PUT',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify(update),

--- a/apps/quotation/client/js/tabs/bd-purchase.js
+++ b/apps/quotation/client/js/tabs/bd-purchase.js
@@ -212,7 +212,7 @@ const tab_bd_purchase = {
     container.querySelector('#sewAutoTranslate')?.addEventListener('click', async () => {
       try {
         showToast('正在翻译...', 'info');
-        const r = await fetch(`/api/versions/${versionId}/translate-sewing`, { method: 'POST' });
+        const r = await fetch(`${api.BASE}/api/versions/${versionId}/translate-sewing`, { method: 'POST' });
         const d = await r.json();
         if (!r.ok) throw new Error(d.error);
         showToast(`已翻译 ${d.translated} 条`, 'success');

--- a/apps/quotation/client/js/tabs/vq-carton.js
+++ b/apps/quotation/client/js/tabs/vq-carton.js
@@ -94,7 +94,7 @@ const tab_vq_carton = {
         value: dim[field],
         onSave: async (val) => {
           try {
-            await fetch(`/api/versions/${versionId}/sections/dimensions`, {
+            await fetch(`${api.BASE}/api/versions/${versionId}/sections/dimensions`, {
               method: 'PUT',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify({ [field]: val }),

--- a/apps/quotation/client/js/tabs/vq-packaging.js
+++ b/apps/quotation/client/js/tabs/vq-packaging.js
@@ -94,7 +94,7 @@ const tab_vq_packaging = {
     container.querySelector('#vqPkgTranslate')?.addEventListener('click', async () => {
       try {
         showToast('正在翻译...', 'info');
-        const r = await fetch(`/api/versions/${versionId}/translate-all`, { method: 'POST' });
+        const r = await fetch(`${api.BASE}/api/versions/${versionId}/translate-all`, { method: 'POST' });
         const d = await r.json();
         if (!r.ok) throw new Error(d.error);
         showToast(`已翻译 ${d.translated} 条`, 'success');

--- a/apps/quotation/client/js/tabs/vq-purchase.js
+++ b/apps/quotation/client/js/tabs/vq-purchase.js
@@ -148,7 +148,7 @@ const tab_vq_purchase = {
     container.querySelector('#otherAutoTranslate')?.addEventListener('click', async () => {
       try {
         showToast('正在翻译...', 'info');
-        const r = await fetch(`/api/versions/${versionId}/translate-all`, { method: 'POST' });
+        const r = await fetch(`${api.BASE}/api/versions/${versionId}/translate-all`, { method: 'POST' });
         const d = await r.json();
         if (!r.ok) throw new Error(d.error);
         showToast(`已翻译 ${d.translated} 条`, 'success');

--- a/apps/quotation/client/js/tabs/vq-transport.js
+++ b/apps/quotation/client/js/tabs/vq-transport.js
@@ -108,7 +108,7 @@ const tab_vq_transport = {
         value: tc[field],
         onSave: async (val) => {
           try {
-            await fetch(`/api/versions/${versionId}/sections/transport`, {
+            await fetch(`${api.BASE}/api/versions/${versionId}/sections/transport`, {
               method: 'PUT',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify({ [field]: val }),

--- a/apps/quotation/server/services/excel-exporter.js
+++ b/apps/quotation/server/services/excel-exporter.js
@@ -718,12 +718,20 @@ function fixSharedFormulas(wb) {
 
 async function exportVersion(versionId) {
   const d = loadData(versionId);
+  const isPlush = d.version.format_type === 'plush';
+  const templatePath = isPlush ? TEMPLATE_PATH_PLUSH : TEMPLATE_PATH;
+
   const wb = new ExcelJS.Workbook();
-  await wb.xlsx.readFile(TEMPLATE_PATH);
+  await wb.xlsx.readFile(templatePath);
 
   fixSharedFormulas(wb);
 
-  {
+  if (isPlush) {
+    // Plush template: first sheet has a dynamic name (e.g. "3K报价-印尼-260321")
+    const ws = wb.worksheets[0];
+    if (!ws) throw new Error('Plush template has no worksheets');
+    fillPlush(ws, d);
+  } else {
     const vqWs  = wb.getWorksheet('Vendor Quotation');
     const bcdWs = wb.getWorksheet('Body Cost Breakdown');
     if (!vqWs)  throw new Error('Template missing "Vendor Quotation" sheet');

--- a/apps/tomy-paiqi/client/index.html
+++ b/apps/tomy-paiqi/client/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="./favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>client</title>
   </head>

--- a/apps/tomy-paiqi/client/src/App.tsx
+++ b/apps/tomy-paiqi/client/src/App.tsx
@@ -208,7 +208,7 @@ function App() {
     }
 
     try {
-      const response = await fetch('/api/process', {
+      const response = await fetch('./api/process', {
         method: 'POST',
         body: formData,
       })
@@ -228,7 +228,7 @@ function App() {
     if (!result?.sessionId) return
     setDownloading(true)
     try {
-      const response = await fetch(`/api/download/${result.sessionId}`)
+      const response = await fetch(`./api/download/${result.sessionId}`)
       if (!response.ok) {
         throw new Error(`下载失败: ${response.status} ${response.statusText}`)
       }

--- a/apps/tomy-paiqi/client/vite.config.ts
+++ b/apps/tomy-paiqi/client/vite.config.ts
@@ -4,6 +4,7 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  base: '/tomy-paiqi/',
   server: {
     proxy: {
       '/api': {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -150,3 +150,44 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
+
+  quotation:
+    build:
+      context: ./apps/quotation
+      dockerfile: Dockerfile
+    environment:
+      - PORT=3004
+      - NODE_ENV=production
+      - CORS_ORIGIN=${QUOTATION_CORS_ORIGIN:-http://localhost}
+    volumes:
+      - "./apps/quotation/server/data:/app/server/data"
+    restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('http').get('http://127.0.0.1:3004/health',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  tomy-paiqi:
+    build:
+      context: ./apps/tomy-paiqi
+      dockerfile: Dockerfile
+    environment:
+      - PORT=3006
+      - NODE_ENV=production
+    restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('http').get('http://127.0.0.1:3006/health',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"]
+      interval: 30s
+      timeout: 10s
+      retries: 3


### PR DESCRIPTION
## Summary
- **quotation**: `exportVersion()` always loaded injection template — `fillPlush()` was dead code. Plush data got garbled in wrong template layout. Also fixed 7 direct `fetch()` calls using absolute `/api/` paths (broken under `/quotation/` subpath).
- **tomy-paiqi**: Vite config missing `base: '/tomy-paiqi/'` causing all JS/CSS assets to 404 → blank page. Also fixed API fetch paths and favicon.
- **infra**: Added both services to local `docker-compose.yml` (were only in cloud config).

## Test plan
- [ ] Deploy to cloud: `docker compose -f docker-compose.cloud.yml up -d --build quotation tomy-paiqi && docker compose restart nginx`
- [ ] Verify tomy-paiqi loads at `/tomy-paiqi/` (was blank page before)
- [ ] Verify quotation plush export produces correct layout (was garbled before)
- [ ] Verify quotation translate/save functions work under `/quotation/` subpath

🤖 Generated with [Claude Code](https://claude.com/claude-code)