### PR TITLE
fix(paiji,jiangping): review informational fixes

### DIFF
--- a/apps/jiangping/Dockerfile
+++ b/apps/jiangping/Dockerfile
@@ -26,4 +26,4 @@ EXPOSE 5001
 
 USER appuser
 
-CMD ["gunicorn", "--bind", "0.0.0.0:5001", "--workers", "2", "--timeout", "120", "wsgi:app"]
+CMD ["gunicorn", "--bind", "0.0.0.0:5001", "--workers", "1", "--threads", "2", "--timeout", "120", "wsgi:app"]

--- a/apps/jiangping/parser/delivery_parser.py
+++ b/apps/jiangping/parser/delivery_parser.py
@@ -7,9 +7,11 @@ Extracts: supplier, delivery_no, delivery_date, and line items
 
 import re
 import os
+import threading
 from datetime import datetime
 
 _paddle_reader = None
+_paddle_lock = threading.Lock()
 
 _MODELS_ROOT = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'models', 'paddleocr')
 
@@ -17,15 +19,17 @@ _MODELS_ROOT = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__fi
 def _get_reader():
     global _paddle_reader
     if _paddle_reader is None:
-        from paddleocr import PaddleOCR
-        _paddle_reader = PaddleOCR(
-            use_angle_cls=True,
-            lang='ch',
-            show_log=False,
-            det_model_dir=os.path.join(_MODELS_ROOT, 'det', 'ch', 'ch_PP-OCRv4_det_infer'),
-            rec_model_dir=os.path.join(_MODELS_ROOT, 'rec', 'ch', 'ch_PP-OCRv4_rec_infer'),
-            cls_model_dir=os.path.join(_MODELS_ROOT, 'cls', 'ch_ppocr_mobile_v2.0_cls_infer'),
-        )
+        with _paddle_lock:
+            if _paddle_reader is None:
+                from paddleocr import PaddleOCR
+                _paddle_reader = PaddleOCR(
+                    use_angle_cls=True,
+                    lang='ch',
+                    show_log=False,
+                    det_model_dir=os.path.join(_MODELS_ROOT, 'det', 'ch', 'ch_PP-OCRv4_det_infer'),
+                    rec_model_dir=os.path.join(_MODELS_ROOT, 'rec', 'ch', 'ch_PP-OCRv4_rec_infer'),
+                    cls_model_dir=os.path.join(_MODELS_ROOT, 'cls', 'ch_ppocr_mobile_v2.0_cls_infer'),
+                )
     return _paddle_reader
 
 

--- a/apps/paiji/server/db/init.js
+++ b/apps/paiji/server/db/init.js
@@ -213,16 +213,23 @@ function initDatabase() {
     )
   `);
 
-  // Migrations
-  try { db.prepare("ALTER TABLE orders ADD COLUMN order_notes TEXT DEFAULT ''").run(); } catch(e){}
-  try { db.prepare("ALTER TABLE schedule_items ADD COLUMN is_carry_over INTEGER DEFAULT 0").run(); } catch(e){}
+  // Migrations — only suppress "duplicate column" errors; log anything else
+  const migrate = (sql) => {
+    try { db.prepare(sql).run(); }
+    catch(e) { if (!e.message.includes('duplicate column')) console.error('Migration failed:', sql, e.message); }
+  };
+  migrate("ALTER TABLE orders ADD COLUMN order_notes TEXT DEFAULT ''");
+  migrate("ALTER TABLE schedule_items ADD COLUMN is_carry_over INTEGER DEFAULT 0");
   // 多车间支持
-  try { db.prepare("ALTER TABLE machines ADD COLUMN workshop TEXT DEFAULT 'B'").run(); } catch(e){}
-  try { db.prepare("ALTER TABLE orders ADD COLUMN workshop TEXT DEFAULT 'B'").run(); } catch(e){}
-  try { db.prepare("ALTER TABLE schedules ADD COLUMN notes TEXT").run(); } catch(e){}
-  try { db.prepare("ALTER TABLE schedules ADD COLUMN workshop TEXT DEFAULT 'B'").run(); } catch(e){}
-  try { db.prepare("ALTER TABLE history_records ADD COLUMN workshop TEXT DEFAULT 'B'").run(); } catch(e){}
-  try { db.prepare("ALTER TABLE mold_targets ADD COLUMN workshop TEXT DEFAULT 'B'").run(); } catch(e){}
+  migrate("ALTER TABLE machines ADD COLUMN workshop TEXT DEFAULT 'B'");
+  migrate("ALTER TABLE orders ADD COLUMN workshop TEXT DEFAULT 'B'");
+  migrate("ALTER TABLE schedules ADD COLUMN notes TEXT");
+  migrate("ALTER TABLE schedules ADD COLUMN workshop TEXT DEFAULT 'B'");
+  migrate("ALTER TABLE history_records ADD COLUMN workshop TEXT DEFAULT 'B'");
+  migrate("ALTER TABLE mold_targets ADD COLUMN workshop TEXT DEFAULT 'B'");
+
+  // Performance indexes
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_schedules_workshop_date ON schedules(workshop, schedule_date)`);
 
   console.log('数据库初始化完成，28台机数据已预置');
 }

--- a/apps/paiji/server/routes/orders.js
+++ b/apps/paiji/server/routes/orders.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const path = require('path');
 const fs = require('fs');
 const multer = require('multer');
+const ExcelJS = require('exceljs');
 const db = require('../db/connection');
 
 const upload = multer({ dest: path.join(__dirname, '..', 'uploads') });
@@ -124,7 +125,6 @@ router.delete('/', (req, res) => {
 
 // 下载订单导入模板
 router.get('/template', async (req, res) => {
-  const ExcelJS = require('exceljs');
   const wb = new ExcelJS.Workbook();
   const ws = wb.addWorksheet('订单模板');
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,6 +118,7 @@ services:
     volumes:
       - "./apps/jiangping/data:/app/data"
       - "./apps/jiangping/uploads:/app/uploads"
+    mem_limit: 1g
     restart: unless-stopped
     logging:
       driver: json-file


### PR DESCRIPTION
## Summary
- paiji migration error handling: only suppress "duplicate column", log real errors
- paiji: add missing DB index on schedules(workshop, schedule_date)
- paiji: move ExcelJS require to top-level (avoid per-request import overhead)
- jiangping: add threading.Lock for PaddleOCR lazy init (thread safety)
- jiangping: reduce gunicorn to 1 worker + 2 threads (halves model memory usage)
- jiangping: add mem_limit: 1g in docker-compose

## Context
Follows up on review findings from PR #54 and PR #56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)