### PR TITLE
feat: add peise (配色库存) inventory app

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,7 @@ curl http://localhost:<port>/health
 | quotation 套客表系统 | Node.js | 3004 | /quotation/ |
 | tomy-paiqi TOMY排期核对系统 | Node.js/React | 3006 | /tomy-paiqi/ |
 | liwenjuan 成品核对系统 | Flask | 5004 | /liwenjuan/ |
+| peise 配色库存管理 | Flask | 5006 | /peise/ |
 
 ## 插件类型
 
@@ -344,6 +345,7 @@ const data = JSON.parse(fs.readFileSync('data/data.json'));
 | quotation | 套客表系统 | 业务部 | Standalone (Node.js) | /quotation/ | — |
 | tomy-paiqi | TOMY排期核对系统 | 业务部 | Standalone (Node.js/React) | /tomy-paiqi/ | — |
 | liwenjuan | 成品核对系统 | PMC跟仓管 | Standalone (Python/Flask) | /liwenjuan/ | — |
+| peise | 配色库存管理 | PMC跟仓管 | Standalone (Python/Flask) | /peise/ | https://github.com/fxxaxxx/peisecangku |
 
 ### 旧插件（已删除）
 

--- a/apps/peise/.env.example
+++ b/apps/peise/.env.example
@@ -1,0 +1,11 @@
+# 复制为 .env 并填入真实值 (放在服务器的 apps/peise/.env,不提交到仓库)
+
+# 必填: Google AI Studio API key (https://aistudio.google.com/app/apikey)
+GEMINI_API_KEY=
+
+# 可选: 境内部署用 Cloudflare Worker 反向代理绕墙
+# 不设则直连 generativelanguage.googleapis.com (国内服务器会超时)
+GEMINI_BASE_URL=https://gemini-proxy.hufan4308.workers.dev
+
+# 可选: 默认 gemini-2.5-flash (免费层 10 RPM / 250 RPD)
+# GEMINI_MODEL=gemini-2.5-flash

--- a/apps/peise/.gitignore
+++ b/apps/peise/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+.pytest_cache/
+instance/
+*.xlsx
+!tests/fixtures/*.xlsx
+*_dump.txt
+.env

--- a/apps/peise/Dockerfile
+++ b/apps/peise/Dockerfile
@@ -4,8 +4,6 @@ WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
-    libglib2.0-0 \
-    libgl1 \
     && rm -rf /var/lib/apt/lists/*
 
 ENV PIP_INDEX_URL=https://mirrors.aliyun.com/pypi/simple/
@@ -21,8 +19,8 @@ RUN mkdir -p /app/instance/backups
 RUN addgroup --system appgroup && adduser --system --ingroup appgroup appuser && \
     chown -R appuser:appgroup /app
 
-EXPOSE 5000
+EXPOSE 5006
 
 USER appuser
 
-CMD ["gunicorn", "--bind", "0.0.0.0:5000", "--workers", "2", "--threads", "2", "--timeout", "120", "run:app"]
+CMD ["gunicorn", "--bind", "0.0.0.0:5006", "--workers", "2", "--threads", "2", "--timeout", "120", "run:app"]

--- a/apps/peise/Dockerfile
+++ b/apps/peise/Dockerfile
@@ -1,0 +1,28 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    libglib2.0-0 \
+    libgl1 \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PIP_INDEX_URL=https://mirrors.aliyun.com/pypi/simple/
+ENV PIP_TRUSTED_HOST=mirrors.aliyun.com
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+RUN mkdir -p /app/instance/backups
+
+RUN addgroup --system appgroup && adduser --system --ingroup appgroup appuser && \
+    chown -R appuser:appgroup /app
+
+EXPOSE 5000
+
+USER appuser
+
+CMD ["gunicorn", "--bind", "0.0.0.0:5000", "--workers", "2", "--threads", "2", "--timeout", "120", "run:app"]

--- a/apps/peise/README.md
+++ b/apps/peise/README.md
@@ -1,0 +1,30 @@
+# 配色库存管理系统
+
+单人本地使用的颜料/油漆库存管理 Web 应用。
+
+## 启动
+
+    pip install -r requirements.txt
+    python run.py
+
+浏览器访问 http://127.0.0.1:5000
+
+## 功能
+
+- 颜料档案（品牌/色号/色样/规格/低库存阈值）
+- 当前库存与低库存预警
+- 出入库流水（入库 / 出库 / 盘点）
+- 调色配方（可行性检查、按配方一键出库）
+- Excel 导入 / 导出 / 模板下载
+
+## 测试
+
+    python -m pytest -v
+
+## 数据存储
+
+SQLite 文件位于 `instance/peise.db`。定期备份该文件即可。
+
+## 技术栈
+
+Flask · SQLAlchemy · Pandas · openpyxl · Bootstrap 5 · DataTables · Chart.js

--- a/apps/peise/app/__init__.py
+++ b/apps/peise/app/__init__.py
@@ -1,0 +1,48 @@
+from flask import Flask
+from .config import Config
+from .extensions import db
+
+def create_app(config_class=Config):
+    app = Flask(__name__, instance_relative_config=True)
+    app.config.from_object(config_class)
+
+    import os
+    os.makedirs(app.instance_path, exist_ok=True)
+
+    db.init_app(app)
+
+    from .routes import dashboard, pigments, transactions
+    app.register_blueprint(dashboard.bp)
+    app.register_blueprint(pigments.bp, url_prefix="/pigments")
+    app.register_blueprint(transactions.bp, url_prefix="/transactions")
+
+    @app.route("/health")
+    def _health():
+        return {"status": "ok"}, 200
+
+    from . import models  # noqa: F401
+    with app.app_context():
+        db.create_all()
+        _migrate_uq_brand_code_partial()
+
+    return app
+
+
+def _migrate_uq_brand_code_partial():
+    """把旧版全行唯一的 uq_brand_code 迁移成部分唯一索引(WHERE code != '')。
+
+    早期版本定义为 UniqueConstraint,SQLite 实际落成无 WHERE 的 UNIQUE INDEX;
+    支持多个待填色粉(code='')共存就得改成部分索引。幂等。"""
+    from sqlalchemy import text
+    conn = db.session.connection()
+    row = conn.execute(text(
+        "SELECT sql FROM sqlite_master WHERE type='index' AND name='uq_brand_code'"
+    )).fetchone()
+    current_sql = (row[0] if row else "") or ""
+    if " WHERE " in current_sql.upper():
+        return  # 已经是部分索引
+    conn.execute(text("DROP INDEX IF EXISTS uq_brand_code"))
+    conn.execute(text(
+        "CREATE UNIQUE INDEX uq_brand_code ON pigment(brand, code) WHERE code != ''"
+    ))
+    db.session.commit()

--- a/apps/peise/app/__init__.py
+++ b/apps/peise/app/__init__.py
@@ -1,4 +1,8 @@
+import os
+
 from flask import Flask
+from werkzeug.middleware.proxy_fix import ProxyFix
+
 from .config import Config
 from .extensions import db
 
@@ -6,7 +10,9 @@ def create_app(config_class=Config):
     app = Flask(__name__, instance_relative_config=True)
     app.config.from_object(config_class)
 
-    import os
+    # 让 url_for() 在 nginx 子路径反代下生成正确链接（X-Forwarded-Prefix）
+    app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_prefix=1)
+
     os.makedirs(app.instance_path, exist_ok=True)
 
     db.init_app(app)

--- a/apps/peise/app/config.py
+++ b/apps/peise/app/config.py
@@ -1,0 +1,6 @@
+import os
+
+class Config:
+    SECRET_KEY = os.environ.get("SECRET_KEY", "dev-key-change-me")
+    SQLALCHEMY_DATABASE_URI = "sqlite:///peise.db"
+    SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/apps/peise/app/extensions.py
+++ b/apps/peise/app/extensions.py
@@ -1,0 +1,3 @@
+from flask_sqlalchemy import SQLAlchemy
+
+db = SQLAlchemy()

--- a/apps/peise/app/models.py
+++ b/apps/peise/app/models.py
@@ -1,0 +1,52 @@
+from datetime import datetime
+from sqlalchemy import Index, text as _sa_text
+from .extensions import db
+
+class Pigment(db.Model):
+    __tablename__ = "pigment"
+    id = db.Column(db.Integer, primary_key=True)
+    brand = db.Column(db.String(64), nullable=False)
+    code = db.Column(db.String(64), nullable=False, default="")
+    name = db.Column(db.String(128), nullable=False)
+    hex = db.Column(db.String(7), nullable=False, default="#000000")
+    color_family = db.Column(db.String(32), nullable=False, default="其他")
+    spec_value = db.Column(db.Float, nullable=False, default=0)
+    spec_unit = db.Column(db.String(8), nullable=False, default="ml")
+    min_stock = db.Column(db.Float, nullable=False, default=1)
+    purchase_code = db.Column(db.String(64), nullable=False, default="")
+    unit_price = db.Column(db.Float, nullable=False, default=0)
+    notes = db.Column(db.Text, default="")
+    is_archived = db.Column(db.Boolean, nullable=False, default=False)
+    created_at = db.Column(db.DateTime, default=datetime.now)
+
+    stock = db.relationship("Stock", uselist=False, back_populates="pigment",
+                            cascade="all, delete-orphan")
+    transactions = db.relationship("Transaction", back_populates="pigment",
+                                   cascade="all, delete-orphan")
+
+    # 部分唯一索引:仅当 code 非空时才强制 (brand, code) 唯一,
+    # 允许多条 OCR 自动新建的待填色粉(code='')共存。
+    __table_args__ = (
+        Index("uq_brand_code", "brand", "code",
+              unique=True,
+              sqlite_where=_sa_text("code != ''")),
+    )
+
+class Stock(db.Model):
+    __tablename__ = "stock"
+    pigment_id = db.Column(db.Integer, db.ForeignKey("pigment.id"), primary_key=True)
+    quantity = db.Column(db.Float, nullable=False, default=0)
+    updated_at = db.Column(db.DateTime, default=datetime.now, onupdate=datetime.now)
+    pigment = db.relationship("Pigment", back_populates="stock")
+
+class Transaction(db.Model):
+    __tablename__ = "transaction"
+    id = db.Column(db.Integer, primary_key=True)
+    pigment_id = db.Column(db.Integer, db.ForeignKey("pigment.id"), nullable=False)
+    type = db.Column(db.String(8), nullable=False)
+    quantity = db.Column(db.Float, nullable=False)
+    unit_price = db.Column(db.Float, nullable=True)
+    occurred_at = db.Column(db.DateTime, default=datetime.now)
+    note = db.Column(db.Text, default="")
+    pigment = db.relationship("Pigment", back_populates="transactions")
+

--- a/apps/peise/app/routes/dashboard.py
+++ b/apps/peise/app/routes/dashboard.py
@@ -1,0 +1,32 @@
+from flask import Blueprint, render_template
+from sqlalchemy import func
+from app.extensions import db
+from app.models import Pigment, Stock, Transaction
+from datetime import datetime
+
+bp = Blueprint("dashboard", __name__)
+
+@bp.route("/")
+def index():
+    total_pigments = Pigment.query.filter_by(is_archived=False).count()
+    total_bottles = db.session.query(func.coalesce(func.sum(Stock.quantity), 0)).scalar()
+
+    low_stock_rows = (db.session.query(Pigment, Stock)
+                      .join(Stock, Stock.pigment_id == Pigment.id)
+                      .filter(Pigment.is_archived == False,
+                              Stock.quantity <= Pigment.min_stock)
+                      .all())
+
+    month_start = datetime.now().replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    month_tx_count = Transaction.query.filter(Transaction.occurred_at >= month_start).count()
+
+    family_rows = (db.session.query(Pigment.color_family, func.count(Pigment.id))
+                   .filter(Pigment.is_archived == False)
+                   .group_by(Pigment.color_family).all())
+
+    return render_template("dashboard.html",
+                           total_pigments=total_pigments,
+                           total_bottles=total_bottles,
+                           low_stock=low_stock_rows,
+                           month_tx_count=month_tx_count,
+                           family_data=family_rows)

--- a/apps/peise/app/routes/pigments.py
+++ b/apps/peise/app/routes/pigments.py
@@ -1,0 +1,118 @@
+from flask import Blueprint, render_template, request, redirect, url_for, flash
+from app.extensions import db
+from app.models import Pigment, Stock, Transaction
+
+bp = Blueprint("pigments", __name__)
+
+@bp.route("/")
+def index():
+    show_archived = request.args.get("archived") == "1"
+    q = Pigment.query
+    if not show_archived:
+        q = q.filter_by(is_archived=False)
+    pigments = q.order_by(Pigment.brand, Pigment.code).all()
+    return render_template("pigments/index.html", pigments=pigments, show_archived=show_archived)
+
+def _form_to_pigment(p):
+    p.code = request.form["code"].strip()
+    p.purchase_code = request.form.get("purchase_code", "").strip()
+    p.unit_price = float(request.form.get("unit_price", 0) or 0)
+    # 确保必填字段有默认值(品牌、色名等已不再从表单传入)
+    if not p.name:
+        p.name = p.code
+    p.spec_unit = "kg"
+
+
+@bp.route("/new", methods=["GET", "POST"])
+def new():
+    if request.method == "POST":
+        p = Pigment(brand="")
+        _form_to_pigment(p)
+        qty = round(float(request.form.get("quantity", 0) or 0), 6)
+        p.stock = Stock(quantity=qty)
+        db.session.add(p)
+        try:
+            db.session.commit()
+            flash("已添加", "success")
+            return redirect(url_for("pigments.index"))
+        except Exception as e:
+            db.session.rollback()
+            flash(f"保存失败:{e}", "danger")
+    return render_template("pigments/form.html", pigment=None)
+
+@bp.route("/<int:pid>")
+def detail(pid):
+    p = Pigment.query.get_or_404(pid)
+    txs = (Transaction.query.filter_by(pigment_id=pid)
+           .order_by(Transaction.occurred_at.desc()).all())
+    return render_template("pigments/detail.html", pigment=p, transactions=txs)
+
+@bp.route("/<int:pid>/edit", methods=["GET", "POST"])
+def edit(pid):
+    p = Pigment.query.get_or_404(pid)
+    if request.method == "POST":
+        _form_to_pigment(p)
+        qty = round(float(request.form.get("quantity", 0) or 0), 6)
+        if p.stock is None:
+            p.stock = Stock(quantity=qty)
+        else:
+            p.stock.quantity = qty
+        try:
+            db.session.commit()
+            flash("已更新", "success")
+            return redirect(url_for("pigments.index"))
+        except Exception as e:
+            db.session.rollback()
+            flash(f"保存失败:{e}", "danger")
+    return render_template("pigments/form.html", pigment=p)
+
+@bp.route("/<int:pid>/delete", methods=["POST"])
+def delete(pid):
+    p = Pigment.query.get_or_404(pid)
+    if p.transactions:
+        p.is_archived = True
+        db.session.commit()
+        flash("有流水记录,已归档", "warning")
+    else:
+        db.session.delete(p)
+        db.session.commit()
+        flash("已删除", "success")
+    return redirect(url_for("pigments.index"))
+
+
+from flask import send_file
+import io as _io
+from app.services.excel_io import export_pigments_to_bytes, template_bytes, import_pigments_from_bytes
+
+@bp.route("/export.xlsx")
+def export_excel():
+    data = export_pigments_to_bytes()
+    return send_file(_io.BytesIO(data),
+                     mimetype="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                     as_attachment=True, download_name="pigments.xlsx")
+
+@bp.route("/template.xlsx")
+def template_excel():
+    data = template_bytes()
+    return send_file(_io.BytesIO(data),
+                     mimetype="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                     as_attachment=True, download_name="pigments_template.xlsx")
+
+@bp.route("/import", methods=["GET", "POST"])
+def import_excel():
+    if request.method == "POST":
+        f = request.files.get("file")
+        if not f:
+            flash("请选择文件", "warning")
+            return redirect(url_for("pigments.import_excel"))
+        try:
+            report = import_pigments_from_bytes(f.read())
+            flash(
+                f"新增 {report['created']},更新 {report['updated']},"
+                f"归档 {report.get('archived', 0)},失败 {len(report['errors'])}",
+                "success",
+            )
+            return render_template("pigments/import.html", report=report)
+        except Exception as e:
+            flash(f"导入失败:{e}", "danger")
+    return render_template("pigments/import.html", report=None)

--- a/apps/peise/app/routes/transactions.py
+++ b/apps/peise/app/routes/transactions.py
@@ -1,0 +1,259 @@
+from datetime import datetime
+
+from flask import Blueprint, render_template, request, redirect, url_for, flash, current_app
+from app.extensions import db
+from app.models import Pigment, Stock, Transaction
+from app.services.inventory import stock_in, stock_out, InsufficientStock
+
+bp = Blueprint("transactions", __name__)
+
+
+def _pigments():
+    return Pigment.query.filter_by(is_archived=False).order_by(Pigment.code).all()
+
+
+@bp.route("/in")
+def in_list():
+    pid = request.args.get("pigment_id", type=int)
+    q = Transaction.query.filter_by(type="in")
+    if pid:
+        q = q.filter_by(pigment_id=pid)
+    txs = q.order_by(Transaction.occurred_at.desc()).limit(500).all()
+    return render_template("transactions/in_index.html", transactions=txs)
+
+
+@bp.route("/out")
+def out_list():
+    pid = request.args.get("pigment_id", type=int)
+    q = Transaction.query.filter_by(type="out")
+    if pid:
+        q = q.filter_by(pigment_id=pid)
+    txs = q.order_by(Transaction.occurred_at.desc()).limit(500).all()
+    return render_template("transactions/out_index.html", transactions=txs)
+
+
+@bp.route("/in/new", methods=["GET", "POST"])
+def in_new():
+    if request.method == "POST":
+        try:
+            pid = int(request.form["pigment_id"])
+            qty = float(request.form["quantity"])
+            price = request.form.get("unit_price")
+            note = request.form.get("note", "")
+            stock_in(pid, qty, unit_price=float(price) if price else None, note=note)
+            flash("已入库", "success")
+            return redirect(url_for("transactions.in_list"))
+        except Exception as e:
+            flash(f"失败:{e}", "danger")
+    return render_template("transactions/in_form.html",
+                           pigments=_pigments(),
+                           preselect=request.args.get("pigment_id", type=int))
+
+
+@bp.route("/out/new", methods=["GET", "POST"])
+def out_new():
+    if request.method == "POST":
+        try:
+            pid = int(request.form["pigment_id"])
+            qty_g = float(request.form["quantity"])  # 输入克
+            qty = round(qty_g / 1000.0, 6)
+            note = request.form.get("note", "")
+            if note:
+                note = f"{qty_g}g / {note}"
+            else:
+                note = f"{qty_g}g"
+            stock_out(pid, qty, note=note)
+            flash("已出库", "success")
+            return redirect(url_for("transactions.out_list"))
+        except InsufficientStock as e:
+            flash(str(e), "danger")
+        except Exception as e:
+            flash(f"失败:{e}", "danger")
+    return render_template("transactions/out_form.html",
+                           pigments=_pigments(),
+                           preselect=request.args.get("pigment_id", type=int))
+
+
+def _ocr_upload(tx_type: str):
+    template = f"transactions/{tx_type}_ocr.html"
+    if request.method == "POST" and request.files.get("file"):
+        from app.services.ocr import parse_image, build_pigment_lookup
+        from app.services.ocr_llm import parse_image_llm, LLMOCRError
+        data = request.files["file"].read()
+        lookup = build_pigment_lookup()
+        rows = None
+        try:
+            rows = parse_image_llm(data, lookup)
+        except LLMOCRError as e:
+            current_app.logger.warning("LLM OCR 失败, 回退 Paddle: %s", e)
+        except Exception as e:
+            current_app.logger.warning("LLM OCR 异常, 回退 Paddle: %s", e)
+        fallback_used = False
+        if rows is None:
+            fallback_used = True
+            try:
+                rows = parse_image(data, lookup)
+            except Exception as e:
+                flash(f"识别失败:{e}", "danger")
+                return render_template(template, rows=None, pigments=_pigments())
+        code_map = {p.id: p.code for p in Pigment.query.filter_by(is_archived=False).all()}
+        for r in rows:
+            r["pigment_code"] = code_map.get(r.get("pigment_id"), "")
+        if fallback_used:
+            flash("LLM 识别不可用,已用本地 OCR 兜底(可能精度较低)", "warning")
+        return render_template(template, rows=rows, pigments=_pigments())
+    return render_template(template, rows=None, pigments=_pigments())
+
+
+@bp.route("/in/ocr", methods=["GET", "POST"])
+def in_ocr():
+    return _ocr_upload("in")
+
+
+@bp.route("/out/ocr", methods=["GET", "POST"])
+def out_ocr():
+    return _ocr_upload("out")
+
+
+@bp.route("/in/ocr/submit", methods=["POST"])
+def in_ocr_submit():
+    return _ocr_submit("in")
+
+
+@bp.route("/out/ocr/submit", methods=["POST"])
+def out_ocr_submit():
+    return _ocr_submit("out")
+
+
+def _ocr_submit(tx_type: str):
+    qtys = request.form.getlist("quantity[]")
+    success = failed = 0
+    errors = []
+    # 出库:用 pigment_code[] 搜索/手动输入模式;未匹配的自动新建占位色粉,允许负库存
+    if tx_type == "out":
+        codes = request.form.getlist("pigment_code[]")
+        auto_created = 0
+        for i, (code_text, qty) in enumerate(zip(codes, qtys)):
+            code_text = (code_text or "").strip()
+            if not code_text or not qty or float(qty) <= 0:
+                continue
+            pigment = (Pigment.query
+                       .filter_by(is_archived=False)
+                       .filter((Pigment.code == code_text) | (Pigment.purchase_code == code_text))
+                       .first())
+            auto_new = False
+            if pigment is None:
+                # 未匹配:自动新建占位,code 留空待复核,code_text 写入 purchase_code
+                pigment = Pigment(
+                    brand="未分类", code="", name=code_text[:128] or "待填",
+                    purchase_code=code_text,
+                    notes="OCR 自动新建,待复核",
+                )
+                db.session.add(pigment)
+                db.session.flush()
+                auto_new = True
+                auto_created += 1
+            try:
+                qty_g = float(qty)
+                stock_out(pigment.id, round(qty_g / 1000.0, 6),
+                          note=f"拍照识别 {qty_g}g" + ("(自动新建待复核)" if auto_new else ""),
+                          allow_negative=auto_new)
+                success += 1
+            except Exception as e:
+                db.session.rollback()
+                failed += 1
+                errors.append(f"第{i+1}行:{e}")
+        msg = f"已记录 {success} 条"
+        if auto_created:
+            msg += f"(其中 {auto_created} 条自动新建待复核)"
+        if errors:
+            flash(f"{msg},失败 {failed}:{'; '.join(errors[:5])}", "warning")
+        else:
+            flash(msg, "success")
+        return redirect(url_for("transactions.out_list"))
+    # 入库:pigment_id[] 非空且为有效整数 → 已匹配,直接入库;否则按 new_code/purchase_code 自动新建
+    pids = request.form.getlist("pigment_id[]")
+    prices = request.form.getlist("unit_price[]")
+    new_codes = request.form.getlist("new_code[]")
+    purchase_codes = request.form.getlist("purchase_code[]")
+    auto_created = 0
+    for i, (pid, qty) in enumerate(zip(pids, qtys)):
+        if not qty or float(qty) <= 0:
+            continue
+        price = prices[i] if i < len(prices) else ""
+        matched_id = None
+        if pid and pid.strip().isdigit():
+            matched_id = int(pid.strip())
+        if matched_id is not None:
+            try:
+                stock_in(matched_id, float(qty),
+                         unit_price=float(price) if price else None,
+                         note="拍照识别")
+                success += 1
+            except Exception as e:
+                failed += 1
+                errors.append(f"第{i+1}行:{e}")
+            continue
+        # 未匹配:自动新建。new_code 填了就用作 code,否则留空待复核
+        new_code = new_codes[i].strip() if i < len(new_codes) else ""
+        purchase_code = purchase_codes[i].strip() if i < len(purchase_codes) else ""
+        code = new_code
+        if code:
+            base, n = code, 1
+            while Pigment.query.filter_by(brand="未分类", code=code).first():
+                n += 1
+                code = f"{base}-{n}"
+        display_name = code or purchase_code or f"待填-{datetime.now():%H%M%S}"
+        try:
+            pigment = Pigment(
+                brand="未分类",
+                code=code,
+                name=display_name,
+                purchase_code=purchase_code,
+                unit_price=float(price) if price else 0,
+                notes="OCR 自动新建,待复核" if not code else "",
+            )
+            db.session.add(pigment)
+            db.session.flush()
+            stock_in(pigment.id, float(qty),
+                     unit_price=float(price) if price else None,
+                     note="拍照识别(自动新建)")
+            success += 1
+            auto_created += 1
+        except Exception as e:
+            db.session.rollback()
+            failed += 1
+            errors.append(f"第{i+1}行:{e}")
+    msg = f"已记录 {success} 条"
+    if auto_created:
+        msg += f"(其中 {auto_created} 条自动新建待复核)"
+    if errors:
+        flash(f"{msg},失败 {failed}:{'; '.join(errors[:5])}", "warning")
+    else:
+        flash(msg, "success")
+    return redirect(url_for(f"transactions.{tx_type}_list"))
+
+
+@bp.route("/<int:tx_id>/delete", methods=["POST"])
+def delete(tx_id):
+    tx = Transaction.query.get_or_404(tx_id)
+    stock = Stock.query.get(tx.pigment_id)
+    target_list = "in_list" if tx.type == "in" else "out_list"
+    try:
+        if stock is None:
+            stock = Stock(pigment_id=tx.pigment_id, quantity=0)
+            db.session.add(stock)
+        if tx.type == "in":
+            if stock.quantity < tx.quantity:
+                flash(f"删除失败:库存不足以扣回 {tx.quantity}(当前 {stock.quantity})", "danger")
+                return redirect(url_for(f"transactions.{target_list}"))
+            stock.quantity = round(stock.quantity - tx.quantity, 6)
+        elif tx.type == "out":
+            stock.quantity = round(stock.quantity + tx.quantity, 6)
+        db.session.delete(tx)
+        db.session.commit()
+        flash("已删除并回滚库存", "success")
+    except Exception as e:
+        db.session.rollback()
+        flash(f"删除失败:{e}", "danger")
+    return redirect(url_for(f"transactions.{target_list}"))

--- a/apps/peise/app/services/excel_io.py
+++ b/apps/peise/app/services/excel_io.py
@@ -1,0 +1,118 @@
+import io
+import pandas as pd
+from app.models import Pigment, Stock
+from app.extensions import db
+
+COLUMNS = ["色粉编号", "进货色粉编号", "数量", "单位", "单价", "金额", "备注"]
+
+
+def _fmt_num(v: float) -> float:
+    return round(float(v or 0), 6)
+
+
+def export_pigments_to_bytes() -> bytes:
+    rows = []
+    for p in (Pigment.query.filter_by(is_archived=False)
+              .order_by(Pigment.code).all()):
+        qty = _fmt_num(p.stock.quantity if p.stock else 0)
+        price = _fmt_num(p.unit_price)
+        rows.append({
+            "色粉编号": p.code,
+            "进货色粉编号": p.purchase_code or "",
+            "数量": qty,
+            "单位": "KG",
+            "单价": price,
+            "金额": round(qty * price, 2),
+            "备注": p.notes or "",
+        })
+    df = pd.DataFrame(rows, columns=COLUMNS)
+    buf = io.BytesIO()
+    df.to_excel(buf, index=False, engine="openpyxl")
+    return buf.getvalue()
+
+
+def template_bytes() -> bytes:
+    df = pd.DataFrame(columns=COLUMNS)
+    buf = io.BytesIO()
+    df.to_excel(buf, index=False, engine="openpyxl")
+    return buf.getvalue()
+
+
+REQUIRED = ["色粉编号"]
+
+
+def _cell_str(v) -> str:
+    """Excel 空单元格是 NaN,str(NaN)='nan';这里统一返回干净字符串。"""
+    if v is None:
+        return ""
+    try:
+        if pd.isna(v):
+            return ""
+    except (TypeError, ValueError):
+        pass
+    return str(v).strip()
+
+
+def import_pigments_from_bytes(data: bytes) -> dict:
+    """Excel 是 brand="" 正规色粉库的真源:
+    - Excel 里出现的 code → 更新/新建,并取消归档
+    - 不在 Excel 里的 brand="" 老色粉 → 归档(不删除,保留流水)
+    - brand="未分类" 的 OCR 自动新建色粉不动,留给用户复核
+    """
+    df = pd.read_excel(io.BytesIO(data), engine="openpyxl")
+    for col in REQUIRED:
+        if col not in df.columns:
+            raise ValueError(f"缺少必要列:{col}")
+    created = updated = 0
+    errors = []
+    seen_codes: set[str] = set()
+    for idx, row in df.iterrows():
+        try:
+            code = _cell_str(row["色粉编号"])
+            if not code:
+                continue
+            seen_codes.add(code)
+            p = Pigment.query.filter_by(brand="", code=code).first()
+            is_new = p is None
+            if is_new:
+                p = Pigment(brand="", code=code, name=code, spec_unit="kg")
+                db.session.add(p)
+            p.purchase_code = _cell_str(row.get("进货色粉编号"))
+            try:
+                p.unit_price = float(row.get("单价") or 0)
+            except (TypeError, ValueError):
+                p.unit_price = 0
+            if "备注" in df.columns:
+                p.notes = _cell_str(row.get("备注"))
+            try:
+                qty = float(row.get("数量") or 0)
+            except (TypeError, ValueError):
+                qty = 0
+            if p.stock is None:
+                p.stock = Stock(quantity=qty)
+            else:
+                p.stock.quantity = qty
+            p.is_archived = False
+            db.session.flush()
+            if is_new:
+                created += 1
+            else:
+                updated += 1
+        except Exception as e:
+            errors.append({"row": int(idx) + 2, "reason": str(e)})
+    # 归档 Excel 里没出现的 brand="" 老色粉
+    archived = 0
+    if seen_codes:
+        stale = (Pigment.query
+                 .filter_by(brand="", is_archived=False)
+                 .filter(~Pigment.code.in_(seen_codes))
+                 .all())
+        for p in stale:
+            p.is_archived = True
+            archived += 1
+    try:
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        raise
+    return {"created": created, "updated": updated, "archived": archived, "errors": errors}

--- a/apps/peise/app/services/inventory.py
+++ b/apps/peise/app/services/inventory.py
@@ -1,0 +1,69 @@
+from datetime import datetime
+from app.extensions import db
+from app.models import Pigment, Stock, Transaction
+
+class InsufficientStock(Exception):
+    pass
+
+def _ensure_stock(pigment_id: int) -> Stock:
+    stock = Stock.query.get(pigment_id)
+    if stock is None:
+        stock = Stock(pigment_id=pigment_id, quantity=0)
+        db.session.add(stock)
+    return stock
+
+def stock_in(pigment_id: int, quantity: float, unit_price: float | None = None,
+             note: str = "", occurred_at: datetime | None = None) -> Transaction:
+    if quantity <= 0:
+        raise ValueError("quantity must be positive")
+    try:
+        stock = _ensure_stock(pigment_id)
+        stock.quantity += quantity
+        tx = Transaction(pigment_id=pigment_id, type="in", quantity=quantity,
+                         unit_price=unit_price, note=note,
+                         occurred_at=occurred_at or datetime.now())
+        db.session.add(tx)
+        db.session.commit()
+        return tx
+    except Exception:
+        db.session.rollback()
+        raise
+
+def stock_out(pigment_id: int, quantity: float, note: str = "",
+              occurred_at: datetime | None = None,
+              allow_negative: bool = False) -> Transaction:
+    if quantity <= 0:
+        raise ValueError("quantity must be positive")
+    try:
+        stock = _ensure_stock(pigment_id)
+        if not allow_negative and stock.quantity < quantity:
+            raise InsufficientStock(f"库存不足:当前 {stock.quantity},需要 {quantity}")
+        stock.quantity -= quantity
+        tx = Transaction(pigment_id=pigment_id, type="out", quantity=quantity,
+                         note=note, occurred_at=occurred_at or datetime.now())
+        db.session.add(tx)
+        db.session.commit()
+        return tx
+    except Exception:
+        db.session.rollback()
+        raise
+
+def stock_adjust(pigment_id: int, target_quantity: float, note: str = "",
+                 occurred_at: datetime | None = None) -> Transaction:
+    if target_quantity < 0:
+        raise ValueError("target_quantity must be >= 0")
+    try:
+        stock = _ensure_stock(pigment_id)
+        delta = target_quantity - stock.quantity
+        direction = "+" if delta >= 0 else "-"
+        stock.quantity = target_quantity
+        tx = Transaction(pigment_id=pigment_id, type="adjust",
+                         quantity=abs(delta),
+                         note=f"{direction}{abs(delta)} {note}".strip(),
+                         occurred_at=occurred_at or datetime.now())
+        db.session.add(tx)
+        db.session.commit()
+        return tx
+    except Exception:
+        db.session.rollback()
+        raise

--- a/apps/peise/app/services/ocr.py
+++ b/apps/peise/app/services/ocr.py
@@ -1,0 +1,260 @@
+"""PaddleOCR 单据识别服务。
+
+输入图片字节,返回按行聚合的解析结果:
+[{"raw": "原始拼接文本", "pigment_id": 12 or None, "quantity": 5.0, "unit_price": 12.5}, ...]
+
+命中"配方""明细""料号"等起始标记后开始收集;遇到"合计""总计"等停止。
+未命中任何起始标记时退化为全表解析。
+"""
+from __future__ import annotations
+
+import io
+import re
+import threading
+
+from PIL import Image, ImageOps
+import numpy as np
+
+_ocr_lock = threading.Lock()
+_ocr_engine = None
+
+
+def _get_engine():
+    global _ocr_engine
+    if _ocr_engine is None:
+        with _ocr_lock:
+            if _ocr_engine is None:
+                from paddleocr import PaddleOCR
+                _ocr_engine = PaddleOCR(use_angle_cls=True, lang="ch", show_log=False)
+    return _ocr_engine
+
+
+def _ocr_array(arr):
+    result = _get_engine().ocr(arr, cls=True)
+    if not result:
+        return []
+    page = result[0] or []
+    items = []
+    for entry in page:
+        bbox, (text, conf) = entry[0], entry[1]
+        ys = [p[1] for p in bbox]
+        xs = [p[0] for p in bbox]
+        items.append({
+            "text": text.strip(),
+            "conf": float(conf),
+            "y": sum(ys) / 4,
+            "x_min": min(xs),
+            "x_max": max(xs),
+            "h": max(ys) - min(ys),
+        })
+    return items
+
+
+def _score(items):
+    """命中起始标记 +100;否则按总字符数 × 平均置信度。"""
+    joined = "".join(it["text"] for it in items)
+    bonus = 100 if any(m in joined for m in START_MARKERS) else 0
+    if not items:
+        return 0
+    avg_conf = sum(it["conf"] for it in items) / len(items)
+    return bonus + len(joined) * avg_conf
+
+
+def _raw_ocr(image_bytes: bytes):
+    """自动尝试 4 个方向,选分数最高的。"""
+    img = ImageOps.exif_transpose(Image.open(io.BytesIO(image_bytes))).convert("RGB")
+    best_items, best_score = [], -1
+    for angle in (0, 90, 180, 270):
+        rotated = img if angle == 0 else img.rotate(-angle, expand=True)
+        items = _ocr_array(np.array(rotated))
+        s = _score(items)
+        if s > best_score:
+            best_score, best_items = s, items
+    return best_items
+
+
+def _group_rows(items):
+    items = sorted(items, key=lambda it: it["y"])
+    rows = []
+    for it in items:
+        h = max(it["h"], 10)
+        placed = False
+        for row in rows:
+            avg_y = sum(x["y"] for x in row) / len(row)
+            if abs(it["y"] - avg_y) < h * 0.8:
+                row.append(it)
+                placed = True
+                break
+        if not placed:
+            rows.append([it])
+    return [sorted(r, key=lambda it: it["x_min"]) for r in rows]
+
+
+NUM_RE = re.compile(r"\d+(?:,\d{3})*(?:\.\d+)?")
+
+
+def _first_marker_pos(rows, markers):
+    for i, row in enumerate(rows):
+        raw = " ".join(it["text"] for it in row)
+        if any(m in raw for m in markers):
+            return i
+    return None
+START_MARKERS = ("配方", "明细", "料号", "产品编号", "序号",
+                 "货号", "品名", "产品名称", "品号", "色粉编号")
+STOP_MARKERS = ("合计", "总计", "数量合计", "总重", "车间", "制单",
+                "约定", "条款", "签收", "客户如", "如有",
+                "备注:", "备注:", "开户", "材质:", "材质:", "每份:", "每份:")
+SKIP_KEYWORDS = ("ADD", "TEL", "FAX", "Date", "电话", "地址", "手机",
+                 "公司", "客户:", "送货单号", "制表", "开户行", "主任",
+                 "送货单", "发货单", "收货单", "出库单", "入库单", "订货单",
+                 "客户名称", "供应商", "NO.", "NO:", "单号")
+UNIT_TOKENS = {"kg", "g", "克", "千克", "公斤", "只", "包", "袋", "桶"}
+SPLIT_RE = re.compile(r"[\s/\-、,,:]+")
+
+
+def _lookup_token(token, pigment_lookup):
+    """直查 → 去 A/B 冲淡前缀 → 返回命中的 id 或 None。"""
+    if not token:
+        return None
+    if token in pigment_lookup:
+        return pigment_lookup[token]
+    if token[0] in ("a", "b") and len(token) > 1:
+        stripped = token[1:]
+        if stripped in pigment_lookup:
+            return pigment_lookup[stripped]
+    return None
+
+
+def _parse_row(row, pigment_lookup):
+    raw = " ".join(it["text"] for it in row)
+    pigment_id = None
+    match_idx = -1
+    purchase_code = ""
+    for idx, it in enumerate(row):
+        token = it["text"].strip()
+        low = token.lower()
+        hit = _lookup_token(low, pigment_lookup)
+        if hit is None:
+            for sub in SPLIT_RE.split(low):
+                hit = _lookup_token(sub, pigment_lookup)
+                if hit is not None:
+                    break
+        if hit is not None:
+            pigment_id = hit
+            match_idx = idx
+            if not purchase_code:
+                purchase_code = token
+            break
+        # 未匹配时取最左 token 作为进货色粉编号候选(含中文也接受)
+        if (not purchase_code and 1 <= len(token) <= 20
+                and low not in UNIT_TOKENS
+                and not any(m in token for m in START_MARKERS)
+                and not token.startswith((".", "-"))):
+            purchase_code = token
+    # 数字从色号 token 之后收集;未匹配时假定首 token 为色号
+    if match_idx >= 0:
+        num_source = row[match_idx + 1:]
+    elif len(row) >= 2:
+        num_source = row[1:]
+    else:
+        num_source = row
+    nums = [float(m.replace(",", "")) for it in num_source for m in NUM_RE.findall(it["text"])]
+    if pigment_id is None and not nums:
+        return None
+    # 格式推断:
+    # ≥3 个数字 → 「…数量 单价 金额」取倒数第三、第二
+    # 恰好 2 个 → 若后者 ≈ 前者 × 正整数(2-1000),视为「单价 金额」,反推数量
+    # 其他      → 首个为数量,次个为单价
+    if len(nums) >= 3:
+        quantity = nums[-3]
+        unit_price = nums[-2]
+    elif len(nums) == 2 and nums[0] > 0:
+        ratio = nums[1] / nums[0]
+        nearest = round(ratio)
+        if 2 <= nearest <= 1000 and abs(ratio - nearest) < 0.02:
+            quantity = float(nearest)
+            unit_price = nums[0]
+        else:
+            quantity = nums[0]
+            unit_price = nums[1]
+    elif nums:
+        quantity = nums[0]
+        unit_price = 0.0
+    else:
+        quantity = 0.0
+        unit_price = 0.0
+    return {
+        "raw": raw,
+        "pigment_id": pigment_id,
+        "purchase_code": purchase_code,
+        "quantity": quantity,
+        "unit_price": unit_price,
+    }
+
+
+def parse_image(image_bytes: bytes, pigment_lookup: dict[str, int]) -> list[dict]:
+    items = _raw_ocr(image_bytes)
+    rows = _group_rows(items)
+    # 倒序检测:若"合计/总计"出现在"配方"之前,说明行序被翻转(例如图片 180° 旋转),
+    # 整体倒序一遍,让起始标记重回顶部。
+    stop_pos = _first_marker_pos(rows, ("合计", "总计"))
+    start_pos = _first_marker_pos(rows, START_MARKERS)
+    if stop_pos is not None and start_pos is not None and stop_pos < start_pos:
+        rows = [list(reversed(r)) for r in reversed(rows)]
+    parsed = []
+    started = False
+    for row in rows:
+        raw = " ".join(it["text"] for it in row)
+        if not started:
+            if any(m in raw for m in START_MARKERS):
+                started = True
+            else:
+                continue
+        if any(m in raw for m in STOP_MARKERS):
+            break
+        if any(k in raw for k in SKIP_KEYWORDS):
+            continue
+        r = _parse_row(row, pigment_lookup)
+        if r is not None and _is_valid(r):
+            parsed.append(r)
+    if not started:
+        for row in rows:
+            raw = " ".join(it["text"] for it in row)
+            if any(k in raw for k in SKIP_KEYWORDS):
+                continue
+            if any(m in raw for m in STOP_MARKERS):
+                break
+            r = _parse_row(row, pigment_lookup)
+            if r is not None and _is_valid(r):
+                parsed.append(r)
+    return parsed
+
+
+def _is_valid(r):
+    """过滤掉明显错误的行:数量/单价超合理范围,或无色号候选;
+    也排除"纯数字 purchase_code 恰好等于数量"的情况(说明本行缺真正编号)。"""
+    if r["pigment_id"] is None and not r["purchase_code"]:
+        return False
+    if r["quantity"] <= 0 or r["quantity"] >= 100000:
+        return False
+    if r["unit_price"] >= 1000000:
+        return False
+    pc = r["purchase_code"]
+    if r["pigment_id"] is None and pc and pc.isdigit():
+        try:
+            if float(pc) == r["quantity"]:
+                return False
+        except ValueError:
+            pass
+    return True
+
+
+def build_pigment_lookup() -> dict[str, int]:
+    from app.models import Pigment
+    lookup = {}
+    for p in Pigment.query.filter_by(is_archived=False).all():
+        if p.code:
+            lookup[p.code.lower()] = p.id
+        if p.purchase_code:
+            lookup[p.purchase_code.lower()] = p.id
+    return lookup

--- a/apps/peise/app/services/ocr.py
+++ b/apps/peise/app/services/ocr.py
@@ -1,257 +1,32 @@
-"""PaddleOCR 单据识别服务。
+"""PaddleOCR 备援 — 云端镜像禁用。
 
-输入图片字节,返回按行聚合的解析结果:
-[{"raw": "原始拼接文本", "pigment_id": 12 or None, "quantity": 5.0, "unit_price": 12.5}, ...]
+云端镜像不带 PaddleOCR (paddlepaddle ~600MB + paddleocr ~100MB 太重，
+跟 ECS 4 GiB RAM / 3 Mbps 带宽不匹配)。OCR 路径只走 Gemini via Cloudflare
+Worker proxy。Gemini 失败时不再静默回退，让用户知道需要复盘 Gemini 配置。
 
-命中"配方""明细""料号"等起始标记后开始收集;遇到"合计""总计"等停止。
-未命中任何起始标记时退化为全表解析。
+要在本地启用真正的 PaddleOCR 路径：
+1. requirements.txt 加 `paddlepaddle` 和 `paddleocr`
+2. Dockerfile 装回 `libglib2.0-0 libgl1`
+3. 把本文件恢复成 git history 里 PaddleOCR 实现版本
 """
 from __future__ import annotations
 
-import io
-import re
-import threading
 
-from PIL import Image, ImageOps
-import numpy as np
-
-_ocr_lock = threading.Lock()
-_ocr_engine = None
+class OCRDisabledError(RuntimeError):
+    """本地 PaddleOCR 备援被调用但镜像里没装。"""
 
 
-def _get_engine():
-    global _ocr_engine
-    if _ocr_engine is None:
-        with _ocr_lock:
-            if _ocr_engine is None:
-                from paddleocr import PaddleOCR
-                _ocr_engine = PaddleOCR(use_angle_cls=True, lang="ch", show_log=False)
-    return _ocr_engine
-
-
-def _ocr_array(arr):
-    result = _get_engine().ocr(arr, cls=True)
-    if not result:
-        return []
-    page = result[0] or []
-    items = []
-    for entry in page:
-        bbox, (text, conf) = entry[0], entry[1]
-        ys = [p[1] for p in bbox]
-        xs = [p[0] for p in bbox]
-        items.append({
-            "text": text.strip(),
-            "conf": float(conf),
-            "y": sum(ys) / 4,
-            "x_min": min(xs),
-            "x_max": max(xs),
-            "h": max(ys) - min(ys),
-        })
-    return items
-
-
-def _score(items):
-    """命中起始标记 +100;否则按总字符数 × 平均置信度。"""
-    joined = "".join(it["text"] for it in items)
-    bonus = 100 if any(m in joined for m in START_MARKERS) else 0
-    if not items:
-        return 0
-    avg_conf = sum(it["conf"] for it in items) / len(items)
-    return bonus + len(joined) * avg_conf
-
-
-def _raw_ocr(image_bytes: bytes):
-    """自动尝试 4 个方向,选分数最高的。"""
-    img = ImageOps.exif_transpose(Image.open(io.BytesIO(image_bytes))).convert("RGB")
-    best_items, best_score = [], -1
-    for angle in (0, 90, 180, 270):
-        rotated = img if angle == 0 else img.rotate(-angle, expand=True)
-        items = _ocr_array(np.array(rotated))
-        s = _score(items)
-        if s > best_score:
-            best_score, best_items = s, items
-    return best_items
-
-
-def _group_rows(items):
-    items = sorted(items, key=lambda it: it["y"])
-    rows = []
-    for it in items:
-        h = max(it["h"], 10)
-        placed = False
-        for row in rows:
-            avg_y = sum(x["y"] for x in row) / len(row)
-            if abs(it["y"] - avg_y) < h * 0.8:
-                row.append(it)
-                placed = True
-                break
-        if not placed:
-            rows.append([it])
-    return [sorted(r, key=lambda it: it["x_min"]) for r in rows]
-
-
-NUM_RE = re.compile(r"\d+(?:,\d{3})*(?:\.\d+)?")
-
-
-def _first_marker_pos(rows, markers):
-    for i, row in enumerate(rows):
-        raw = " ".join(it["text"] for it in row)
-        if any(m in raw for m in markers):
-            return i
-    return None
-START_MARKERS = ("配方", "明细", "料号", "产品编号", "序号",
-                 "货号", "品名", "产品名称", "品号", "色粉编号")
-STOP_MARKERS = ("合计", "总计", "数量合计", "总重", "车间", "制单",
-                "约定", "条款", "签收", "客户如", "如有",
-                "备注:", "备注:", "开户", "材质:", "材质:", "每份:", "每份:")
-SKIP_KEYWORDS = ("ADD", "TEL", "FAX", "Date", "电话", "地址", "手机",
-                 "公司", "客户:", "送货单号", "制表", "开户行", "主任",
-                 "送货单", "发货单", "收货单", "出库单", "入库单", "订货单",
-                 "客户名称", "供应商", "NO.", "NO:", "单号")
-UNIT_TOKENS = {"kg", "g", "克", "千克", "公斤", "只", "包", "袋", "桶"}
-SPLIT_RE = re.compile(r"[\s/\-、,,:]+")
-
-
-def _lookup_token(token, pigment_lookup):
-    """直查 → 去 A/B 冲淡前缀 → 返回命中的 id 或 None。"""
-    if not token:
-        return None
-    if token in pigment_lookup:
-        return pigment_lookup[token]
-    if token[0] in ("a", "b") and len(token) > 1:
-        stripped = token[1:]
-        if stripped in pigment_lookup:
-            return pigment_lookup[stripped]
-    return None
-
-
-def _parse_row(row, pigment_lookup):
-    raw = " ".join(it["text"] for it in row)
-    pigment_id = None
-    match_idx = -1
-    purchase_code = ""
-    for idx, it in enumerate(row):
-        token = it["text"].strip()
-        low = token.lower()
-        hit = _lookup_token(low, pigment_lookup)
-        if hit is None:
-            for sub in SPLIT_RE.split(low):
-                hit = _lookup_token(sub, pigment_lookup)
-                if hit is not None:
-                    break
-        if hit is not None:
-            pigment_id = hit
-            match_idx = idx
-            if not purchase_code:
-                purchase_code = token
-            break
-        # 未匹配时取最左 token 作为进货色粉编号候选(含中文也接受)
-        if (not purchase_code and 1 <= len(token) <= 20
-                and low not in UNIT_TOKENS
-                and not any(m in token for m in START_MARKERS)
-                and not token.startswith((".", "-"))):
-            purchase_code = token
-    # 数字从色号 token 之后收集;未匹配时假定首 token 为色号
-    if match_idx >= 0:
-        num_source = row[match_idx + 1:]
-    elif len(row) >= 2:
-        num_source = row[1:]
-    else:
-        num_source = row
-    nums = [float(m.replace(",", "")) for it in num_source for m in NUM_RE.findall(it["text"])]
-    if pigment_id is None and not nums:
-        return None
-    # 格式推断:
-    # ≥3 个数字 → 「…数量 单价 金额」取倒数第三、第二
-    # 恰好 2 个 → 若后者 ≈ 前者 × 正整数(2-1000),视为「单价 金额」,反推数量
-    # 其他      → 首个为数量,次个为单价
-    if len(nums) >= 3:
-        quantity = nums[-3]
-        unit_price = nums[-2]
-    elif len(nums) == 2 and nums[0] > 0:
-        ratio = nums[1] / nums[0]
-        nearest = round(ratio)
-        if 2 <= nearest <= 1000 and abs(ratio - nearest) < 0.02:
-            quantity = float(nearest)
-            unit_price = nums[0]
-        else:
-            quantity = nums[0]
-            unit_price = nums[1]
-    elif nums:
-        quantity = nums[0]
-        unit_price = 0.0
-    else:
-        quantity = 0.0
-        unit_price = 0.0
-    return {
-        "raw": raw,
-        "pigment_id": pigment_id,
-        "purchase_code": purchase_code,
-        "quantity": quantity,
-        "unit_price": unit_price,
-    }
-
-
-def parse_image(image_bytes: bytes, pigment_lookup: dict[str, int]) -> list[dict]:
-    items = _raw_ocr(image_bytes)
-    rows = _group_rows(items)
-    # 倒序检测:若"合计/总计"出现在"配方"之前,说明行序被翻转(例如图片 180° 旋转),
-    # 整体倒序一遍,让起始标记重回顶部。
-    stop_pos = _first_marker_pos(rows, ("合计", "总计"))
-    start_pos = _first_marker_pos(rows, START_MARKERS)
-    if stop_pos is not None and start_pos is not None and stop_pos < start_pos:
-        rows = [list(reversed(r)) for r in reversed(rows)]
-    parsed = []
-    started = False
-    for row in rows:
-        raw = " ".join(it["text"] for it in row)
-        if not started:
-            if any(m in raw for m in START_MARKERS):
-                started = True
-            else:
-                continue
-        if any(m in raw for m in STOP_MARKERS):
-            break
-        if any(k in raw for k in SKIP_KEYWORDS):
-            continue
-        r = _parse_row(row, pigment_lookup)
-        if r is not None and _is_valid(r):
-            parsed.append(r)
-    if not started:
-        for row in rows:
-            raw = " ".join(it["text"] for it in row)
-            if any(k in raw for k in SKIP_KEYWORDS):
-                continue
-            if any(m in raw for m in STOP_MARKERS):
-                break
-            r = _parse_row(row, pigment_lookup)
-            if r is not None and _is_valid(r):
-                parsed.append(r)
-    return parsed
-
-
-def _is_valid(r):
-    """过滤掉明显错误的行:数量/单价超合理范围,或无色号候选;
-    也排除"纯数字 purchase_code 恰好等于数量"的情况(说明本行缺真正编号)。"""
-    if r["pigment_id"] is None and not r["purchase_code"]:
-        return False
-    if r["quantity"] <= 0 or r["quantity"] >= 100000:
-        return False
-    if r["unit_price"] >= 1000000:
-        return False
-    pc = r["purchase_code"]
-    if r["pigment_id"] is None and pc and pc.isdigit():
-        try:
-            if float(pc) == r["quantity"]:
-                return False
-        except ValueError:
-            pass
-    return True
+def parse_image(image_bytes: bytes, pigment_lookup) -> list[dict]:
+    raise OCRDisabledError(
+        "本地 PaddleOCR 备援已禁用（云端镜像未安装）。"
+        "请检查 GEMINI_API_KEY 是否配置、Gemini API / Cloudflare Worker 代理是否可达。"
+    )
 
 
 def build_pigment_lookup() -> dict[str, int]:
+    """色粉编号 → DB id 索引，Gemini 路径和 PaddleOCR 路径都用。"""
     from app.models import Pigment
-    lookup = {}
+    lookup: dict[str, int] = {}
     for p in Pigment.query.filter_by(is_archived=False).all():
         if p.code:
             lookup[p.code.lower()] = p.id

--- a/apps/peise/app/services/ocr_llm.py
+++ b/apps/peise/app/services/ocr_llm.py
@@ -1,0 +1,130 @@
+"""通过 Google AI Studio 的 Gemini 多模态模型识别送货单/出入库单。
+
+调用 generativelanguage.googleapis.com 的 generateContent,让模型直接返回 JSON 数组,
+字段与 Paddle 版保持一致,方便 _ocr_upload 直接拿去渲染模板。
+
+环境变量:
+  GEMINI_API_KEY   - 必填,在 https://aistudio.google.com/app/apikey 免费领
+  GEMINI_MODEL     - 可选,默认 gemini-2.5-flash(免费层 10 RPM / 250 RPD)
+  GEMINI_BASE_URL  - 可选,默认 https://generativelanguage.googleapis.com
+                     境内部署可设置为 Cloudflare Worker 反向代理地址
+                     (如 https://gemini-proxy.xxx.workers.dev)
+"""
+from __future__ import annotations
+
+import base64
+import json
+import os
+import re
+
+import requests
+
+DEFAULT_BASE_URL = "https://generativelanguage.googleapis.com"
+DEFAULT_MODEL = "gemini-2.5-flash"
+
+SYSTEM_PROMPT = """你是一个送货单/出入库单识别助手。
+给你一张图片,请只返回 JSON 数组,格式:
+[{"purchase_code": "色粉/进货编号", "name": "品名或颜色", "quantity": 数字, "unit_price": 数字}]
+
+规则:
+- 只返回商品明细行,跳过表头、合计/总计、公司抬头、日期、备注、大写金额等。
+- quantity 是数字(不带单位),unit_price 去掉 ¥/￥/Y 符号和千分位逗号。
+- purchase_code 取最能唯一定位商品的编号(如 FK-20、89047色种、94387);若只有名称则编号留空。
+- 如果图片里没有商品行,返回 []。
+"""
+
+
+class LLMOCRError(Exception):
+    pass
+
+
+def parse_image_llm(
+    image_bytes: bytes,
+    pigment_lookup: dict[str, int],
+    timeout: int = 60,
+) -> list[dict]:
+    api_key = os.environ.get("GEMINI_API_KEY", "").strip()
+    if not api_key:
+        raise LLMOCRError("GEMINI_API_KEY 未设置")
+    model = (os.environ.get("GEMINI_MODEL", "").strip() or DEFAULT_MODEL)
+    base = (os.environ.get("GEMINI_BASE_URL", "").strip().rstrip("/") or DEFAULT_BASE_URL)
+    url = f"{base}/v1beta/models/{model}:generateContent"
+
+    b64 = base64.b64encode(image_bytes).decode("ascii")
+    payload = {
+        "systemInstruction": {"parts": [{"text": SYSTEM_PROMPT}]},
+        "contents": [{
+            "role": "user",
+            "parts": [
+                {"text": "请识别并严格按 JSON 数组返回。"},
+                {"inlineData": {"mimeType": "image/png", "data": b64}},
+            ],
+        }],
+        "generationConfig": {
+            "temperature": 0,
+            "responseMimeType": "application/json",
+        },
+    }
+    headers = {"Content-Type": "application/json", "x-goog-api-key": api_key}
+    try:
+        resp = requests.post(url, json=payload, headers=headers, timeout=timeout)
+    except requests.RequestException as e:
+        raise LLMOCRError(f"网络错误:{e}") from e
+    if resp.status_code != 200:
+        raise LLMOCRError(f"HTTP {resp.status_code}: {resp.text[:500]}")
+    try:
+        data = resp.json()
+        content = data["candidates"][0]["content"]["parts"][0]["text"]
+    except (KeyError, ValueError, IndexError, TypeError) as e:
+        raise LLMOCRError(f"响应结构异常:{e} / {resp.text[:300]}") from e
+
+    rows = _extract_json_array(content)
+    return [_normalize_row(r, pigment_lookup) for r in rows if isinstance(r, dict)]
+
+
+_FENCE_RE = re.compile(r"```(?:json)?\s*(.+?)\s*```", re.DOTALL)
+
+
+def _extract_json_array(content: str):
+    m = _FENCE_RE.search(content)
+    if m:
+        content = m.group(1)
+    start = content.find("[")
+    end = content.rfind("]")
+    if start < 0 or end <= start:
+        raise LLMOCRError(f"响应里找不到 JSON 数组:{content[:300]}")
+    try:
+        return json.loads(content[start:end + 1])
+    except json.JSONDecodeError as e:
+        raise LLMOCRError(f"JSON 解析失败:{e}") from e
+
+
+def _to_float(v) -> float:
+    if v is None:
+        return 0.0
+    s = str(v).strip().replace(",", "").replace("￥", "").replace("¥", "")
+    s = re.sub(r"[^0-9.\-]", "", s)
+    try:
+        return float(s) if s else 0.0
+    except ValueError:
+        return 0.0
+
+
+def _normalize_row(r: dict, pigment_lookup: dict[str, int]) -> dict:
+    code = str(r.get("purchase_code") or "").strip()
+    name = str(r.get("name") or "").strip()
+    qty = _to_float(r.get("quantity"))
+    price = _to_float(r.get("unit_price"))
+    pigment_id = None
+    if code:
+        low = code.lower()
+        pigment_id = pigment_lookup.get(low)
+        if pigment_id is None and low.startswith(("a", "b")) and len(low) > 1:
+            pigment_id = pigment_lookup.get(low[1:])
+    return {
+        "raw": f"{code} {name} {qty} {price}".strip(),
+        "pigment_id": pigment_id,
+        "purchase_code": code,
+        "quantity": qty,
+        "unit_price": price,
+    }

--- a/apps/peise/app/static/css/app.css
+++ b/apps/peise/app/static/css/app.css
@@ -1,0 +1,9 @@
+.color-swatch {
+  display: inline-block;
+  width: 20px; height: 20px;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  vertical-align: middle;
+  margin-right: 4px;
+}
+.sidebar .nav-link:hover { background: rgba(255,255,255,.1); }

--- a/apps/peise/app/static/js/app.js
+++ b/apps/peise/app/static/js/app.js
@@ -1,0 +1,17 @@
+$(function () {
+  $('.dt').DataTable({
+    language: {
+      processing: "处理中...",
+      lengthMenu: "显示 _MENU_ 条",
+      zeroRecords: "没有匹配结果",
+      info: "显示第 _START_ 至 _END_ 条,共 _TOTAL_ 条",
+      infoEmpty: "显示第 0 至 0 条,共 0 条",
+      infoFiltered: "(由 _MAX_ 条过滤)",
+      search: "搜索:",
+      emptyTable: "暂无数据",
+      loadingRecords: "载入中...",
+      paginate: { first: "首页", previous: "上一页", next: "下一页", last: "末页" },
+      aria: { sortAscending: ": 升序", sortDescending: ": 降序" }
+    }
+  });
+});

--- a/apps/peise/app/templates/base.html
+++ b/apps/peise/app/templates/base.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<title>{% block title %}配色库存{% endblock %}</title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
+<link href="https://cdn.datatables.net/1.13.8/css/dataTables.bootstrap5.min.css" rel="stylesheet">
+<link href="{{ url_for('static', filename='css/app.css') }}" rel="stylesheet">
+</head>
+<body>
+<div class="d-flex">
+  <nav class="sidebar bg-dark text-white p-3" style="width:220px; min-height:100vh;">
+    <h5 class="mb-4"><i class="bi bi-palette-fill"></i> 配色库存</h5>
+    <ul class="nav flex-column">
+      <li><a class="nav-link text-white" href="{{ url_for('dashboard.index') }}"><i class="bi bi-speedometer2"></i> 仪表盘</a></li>
+      <li><a class="nav-link text-white" href="{{ url_for('pigments.index') }}"><i class="bi bi-droplet-fill"></i> 库存</a></li>
+      <li><a class="nav-link text-white" href="{{ url_for('transactions.in_list') }}"><i class="bi bi-box-arrow-in-down"></i> 入库</a></li>
+      <li><a class="nav-link text-white" href="{{ url_for('transactions.out_list') }}"><i class="bi bi-box-arrow-up"></i> 出库</a></li>
+    </ul>
+  </nav>
+  <main class="flex-grow-1 p-4">
+    {% with messages = get_flashed_messages(with_categories=true) %}
+      {% for category, msg in messages %}
+        <div class="alert alert-{{ category }}">{{ msg }}</div>
+      {% endfor %}
+    {% endwith %}
+    {% block content %}{% endblock %}
+  </main>
+</div>
+<script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://cdn.datatables.net/1.13.8/js/jquery.dataTables.min.js"></script>
+<script src="https://cdn.datatables.net/1.13.8/js/dataTables.bootstrap5.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+<script src="{{ url_for('static', filename='js/app.js') }}"></script>
+{% block scripts %}{% endblock %}
+</body>
+</html>

--- a/apps/peise/app/templates/dashboard.html
+++ b/apps/peise/app/templates/dashboard.html
@@ -1,0 +1,44 @@
+{% extends "base.html" %}
+{% block title %}仪表盘 · 配色库存{% endblock %}
+{% block content %}
+<h3 class="mb-4">仪表盘</h3>
+<div class="row g-3 mb-4">
+  <div class="col-md-3"><div class="card text-bg-primary"><div class="card-body"><h6>颜料总数</h6><h2>{{ total_pigments }}</h2></div></div></div>
+  <div class="col-md-3"><div class="card text-bg-success"><div class="card-body"><h6>总瓶数</h6><h2>{{ total_bottles }}</h2></div></div></div>
+  <div class="col-md-3"><div class="card text-bg-warning"><div class="card-body"><h6>低库存</h6><h2>{{ low_stock|length }}</h2></div></div></div>
+  <div class="col-md-3"><div class="card text-bg-info"><div class="card-body"><h6>本月流水</h6><h2>{{ month_tx_count }}</h2></div></div></div>
+</div>
+<div class="row g-3">
+  <div class="col-md-6">
+    <div class="card"><div class="card-body">
+      <h6>色系分布</h6>
+      <canvas id="familyChart"></canvas>
+    </div></div>
+  </div>
+  <div class="col-md-6">
+    <div class="card"><div class="card-body">
+      <h6>低库存清单</h6>
+      <ul class="list-group">
+        {% for p, s in low_stock %}
+          <li class="list-group-item d-flex justify-content-between">
+            <span>{{ p.code or p.purchase_code }}</span>
+            <span class="badge bg-danger">{{ s.quantity }} / {{ p.min_stock }}</span>
+          </li>
+        {% else %}
+          <li class="list-group-item text-muted">无</li>
+        {% endfor %}
+      </ul>
+    </div></div>
+  </div>
+</div>
+{% endblock %}
+{% block scripts %}
+<script>
+const familyLabels = {{ family_data|map(attribute=0)|list|tojson }};
+const familyCounts = {{ family_data|map(attribute=1)|list|tojson }};
+new Chart(document.getElementById('familyChart'), {
+  type: 'doughnut',
+  data: { labels: familyLabels, datasets: [{ data: familyCounts }] }
+});
+</script>
+{% endblock %}

--- a/apps/peise/app/templates/pigments/detail.html
+++ b/apps/peise/app/templates/pigments/detail.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% block content %}
+<h3><span class="color-swatch" style="background:{{ pigment.hex }}"></span> {{ pigment.brand }} {{ pigment.code }} · {{ pigment.name }}</h3>
+<p class="text-muted">{{ pigment.color_family }} | {{ pigment.spec_value }} {{ pigment.spec_unit }} | 当前库存 <strong>{{ pigment.stock.quantity if pigment.stock else 0 }}</strong> | 阈值 {{ pigment.min_stock }}</p>
+<p>{{ pigment.notes }}</p>
+<div class="mb-3">
+  <a href="{{ url_for('pigments.edit', pid=pigment.id) }}" class="btn btn-outline-primary">编辑</a>
+  <a href="{{ url_for('transactions.in_new', pigment_id=pigment.id) }}" class="btn btn-success">入库</a>
+  <a href="{{ url_for('transactions.out_new', pigment_id=pigment.id) }}" class="btn btn-danger">出库</a>
+</div>
+<h5>流水</h5>
+<table class="table table-sm">
+  <thead><tr><th>时间</th><th>类型</th><th>数量</th><th>单价</th><th>备注</th></tr></thead>
+  <tbody>
+    {% for t in transactions %}
+      <tr><td>{{ t.occurred_at.strftime('%Y-%m-%d %H:%M') }}</td><td>{{ t.type }}</td><td>{{ t.quantity }}</td><td>{{ t.unit_price or '-' }}</td><td>{{ t.note }}</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/apps/peise/app/templates/pigments/form.html
+++ b/apps/peise/app/templates/pigments/form.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% block content %}
+<h3>{{ "编辑" if pigment else "新增" }}色粉</h3>
+<form method="post" class="row g-3" style="max-width:720px">
+  <div class="col-md-6"><label>色粉编号</label><input name="code" class="form-control" value="{{ pigment.code if pigment else '' }}" required></div>
+  <div class="col-md-6"><label>进货色粉编号</label><input name="purchase_code" class="form-control" value="{{ pigment.purchase_code if pigment else '' }}"></div>
+  <div class="col-md-4"><label>数量</label><input type="number" step="0.0001" id="qty" name="quantity" class="form-control" value="{{ '%.4f'|format(pigment.stock.quantity) if pigment and pigment.stock else '0' }}" min="0"></div>
+  <div class="col-md-3"><label>单价(元)</label><input type="number" step="0.01" id="price" name="unit_price" class="form-control" value="{{ '%.2f'|format(pigment.unit_price) if pigment else '0.00' }}"></div>
+  <div class="col-md-2"><label>单位</label><input class="form-control" value="KG" readonly></div>
+  <div class="col-md-3"><label>金额(元)</label><input id="amount" class="form-control" value="0.00" readonly></div>
+  <div class="col-12"><button class="btn btn-primary">保存</button> <a href="{{ url_for('pigments.index') }}" class="btn btn-secondary">取消</a></div>
+</form>
+<script>
+(function(){
+  const q = document.getElementById('qty'), p = document.getElementById('price'), a = document.getElementById('amount');
+  function update(){ a.value = (parseFloat(q.value||0) * parseFloat(p.value||0)).toFixed(2); }
+  q.addEventListener('input', update); p.addEventListener('input', update); update();
+})();
+</script>
+{% endblock %}

--- a/apps/peise/app/templates/pigments/import.html
+++ b/apps/peise/app/templates/pigments/import.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+{% block content %}
+<h3>导入颜料 Excel</h3>
+<p>请先<a href="{{ url_for('pigments.template_excel') }}">下载模板</a>。按 (品牌, 色号) 匹配,存在则更新,不存在则新建。</p>
+<form method="post" enctype="multipart/form-data" class="mb-4">
+  <input type="file" name="file" accept=".xlsx" class="form-control mb-2" required>
+  <button class="btn btn-primary">上传导入</button>
+  <a href="{{ url_for('pigments.index') }}" class="btn btn-secondary">返回</a>
+</form>
+{% if report %}
+  <div class="alert alert-info">新增 {{ report.created }},更新 {{ report.updated }},失败 {{ report.errors|length }}</div>
+  {% if report.errors %}
+    <table class="table table-sm"><thead><tr><th>行号</th><th>原因</th></tr></thead>
+    <tbody>{% for e in report.errors %}<tr><td>{{ e.row }}</td><td>{{ e.reason }}</td></tr>{% endfor %}</tbody></table>
+  {% endif %}
+{% endif %}
+{% endblock %}

--- a/apps/peise/app/templates/pigments/index.html
+++ b/apps/peise/app/templates/pigments/index.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h3>库存</h3>
+  <div>
+    <a href="{{ url_for('pigments.new') }}" class="btn btn-primary"><i class="bi bi-plus"></i> 新增</a>
+    <a href="{{ url_for('pigments.export_excel') }}" class="btn btn-success"><i class="bi bi-download"></i> 导出</a>
+    <a href="{{ url_for('pigments.import_excel') }}" class="btn btn-warning"><i class="bi bi-upload"></i> 导入</a>
+    <a href="{{ url_for('pigments.template_excel') }}" class="btn btn-outline-secondary"><i class="bi bi-file-earmark"></i> 模板</a>
+  </div>
+</div>
+<table class="table table-hover dt">
+  <thead><tr><th>色粉编号</th><th>进货色粉编号</th><th>当前库存(kg)</th><th>单价(元/kg)</th><th>库存金额</th><th>操作</th></tr></thead>
+  <tbody>
+    {% for p in pigments %}
+      {% set qty = p.stock.quantity if p.stock else 0 %}
+      <tr{% if qty <= p.min_stock %} class="table-warning"{% endif %}>
+        <td>{{ p.code }}</td>
+        <td>{{ p.purchase_code }}</td>
+        <td>{{ qty }}</td>
+        <td>{{ "%.2f"|format(p.unit_price) }}</td>
+        <td>{{ "%.2f"|format(qty * p.unit_price) }}</td>
+        <td>
+          <a href="{{ url_for('pigments.edit', pid=p.id) }}" class="btn btn-sm btn-outline-primary"><i class="bi bi-pencil"></i></a>
+          <form action="{{ url_for('pigments.delete', pid=p.id) }}" method="post" class="d-inline" onsubmit="return confirm('确认删除?')">
+            <button class="btn btn-sm btn-outline-danger"><i class="bi bi-trash"></i></button>
+          </form>
+        </td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/apps/peise/app/templates/transactions/in_form.html
+++ b/apps/peise/app/templates/transactions/in_form.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% block content %}
+<h3>入库</h3>
+<form method="post" style="max-width:600px">
+  <div class="mb-3"><label>色粉</label>
+    <select name="pigment_id" class="form-select" required>
+      {% for p in pigments %}
+        <option value="{{ p.id }}" {% if preselect==p.id %}selected{% endif %}>{{ p.code or '(待填)' }}{% if p.purchase_code %} / {{ p.purchase_code }}{% endif %}(当前 {{ p.stock.quantity if p.stock else 0 }})</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="mb-3"><label>数量</label><input type="number" step="0.01" name="quantity" class="form-control" min="0.01" required> <span class="text-muted">kg</span></div>
+  <div class="mb-3"><label>进货单价(元,可选)</label><input type="number" step="0.01" name="unit_price" class="form-control"></div>
+  <div class="mb-3"><label>备注</label><textarea name="note" class="form-control"></textarea></div>
+  <button class="btn btn-success">入库</button>
+  <a href="{{ url_for('transactions.in_list') }}" class="btn btn-secondary">取消</a>
+</form>
+{% endblock %}

--- a/apps/peise/app/templates/transactions/in_index.html
+++ b/apps/peise/app/templates/transactions/in_index.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="d-flex justify-content-between mb-3">
+  <h3>入库流水</h3>
+  <div>
+    <a href="{{ url_for('transactions.in_new') }}" class="btn btn-success"><i class="bi bi-plus"></i> 手动入库</a>
+    <a href="{{ url_for('transactions.in_ocr') }}" class="btn btn-primary"><i class="bi bi-camera"></i> 拍照识别</a>
+  </div>
+</div>
+<table class="table table-hover dt">
+  <thead><tr><th>时间</th><th>色粉编号</th><th>数量(kg)</th><th>单价(元/kg)</th><th>金额</th><th>备注</th><th>操作</th></tr></thead>
+  <tbody>
+    {% for t in transactions %}
+      <tr>
+        <td>{{ t.occurred_at.strftime('%Y-%m-%d %H:%M') }}</td>
+        <td>{{ t.pigment.code or t.pigment.purchase_code }}</td>
+        <td>{{ ("%.4f"|format(t.quantity)).rstrip('0').rstrip('.') }}</td>
+        <td>{{ "%.2f"|format(t.unit_price) if t.unit_price else '-' }}</td>
+        <td>{{ "%.2f"|format(t.quantity * t.unit_price) if t.unit_price else '-' }}</td>
+        <td>{{ t.note }}</td>
+        <td><form method="post" action="{{ url_for('transactions.delete', tx_id=t.id) }}" class="d-inline" onsubmit="return confirm('删除并回滚库存?')"><button class="btn btn-sm btn-outline-danger"><i class="bi bi-trash"></i></button></form></td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/apps/peise/app/templates/transactions/in_ocr.html
+++ b/apps/peise/app/templates/transactions/in_ocr.html
@@ -1,0 +1,64 @@
+{% extends "base.html" %}
+{% block content %}
+<h3>拍照识别入库单</h3>
+{% if rows is none %}
+<p class="text-muted">上传进货单据照片(jpg/png),系统会自动识别色粉编号、数量、单价。识别后可在表格中核对修改,再一键批量入库。</p>
+<form method="post" enctype="multipart/form-data" class="mb-3" style="max-width:500px">
+  <input type="file" name="file" accept="image/*" class="form-control mb-2" required>
+  <button class="btn btn-primary"><i class="bi bi-camera"></i> 上传识别</button>
+  <a href="{{ url_for('transactions.in_list') }}" class="btn btn-secondary">取消</a>
+</form>
+{% else %}
+<p>共识别出 <strong>{{ rows|length }}</strong> 行。请核对后提交,不需要的行点"删"移除。<br><small class="text-muted">已匹配库存的行显示 <span class="badge bg-success-subtle text-success-emphasis">→ 编号</span>;未匹配的行可手填"色粉编号",留空则自动新建待复核色粉。</small></p>
+<form method="post" action="{{ url_for('transactions.in_ocr_submit') }}">
+  <table class="table table-sm" id="ocrTable">
+    <thead><tr><th>进货色粉编号</th><th>色粉编号</th><th>数量(kg)</th><th>单价</th><th style="width:25%">识别文本</th><th></th></tr></thead>
+    <tbody>
+      {% for r in rows %}
+      <tr>
+        <td><input name="purchase_code[]" value="{{ r.purchase_code }}" class="form-control form-control-sm" readonly></td>
+        <td>
+          <input type="hidden" name="pigment_id[]" value="{{ r.pigment_id or '' }}">
+          {% if r.pigment_id %}
+            <span class="badge bg-success-subtle text-success-emphasis">→ {{ r.pigment_code or '(待填)' }}</span>
+            <input type="hidden" name="new_code[]" value="">
+          {% else %}
+            <input name="new_code[]" class="form-control form-control-sm" placeholder="留空则自动新建">
+          {% endif %}
+        </td>
+        <td><input type="number" name="quantity[]" value="{{ '%.2f'|format(r.quantity) }}" step="0.01" class="form-control form-control-sm" min="0"></td>
+        <td><input type="number" step="0.01" name="unit_price[]" value="{{ '%.2f'|format(r.unit_price) }}" class="form-control form-control-sm"></td>
+        <td><small class="text-muted">{{ r.raw }}</small></td>
+        <td><button type="button" class="btn btn-sm btn-outline-danger" onclick="this.closest('tr').remove()">删</button></td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  <button type="button" class="btn btn-outline-secondary mb-3" onclick="addInRow()">+ 添加行</button>
+  <div>
+    <button class="btn btn-success"><i class="bi bi-check2"></i> 批量入库</button>
+    <a href="{{ url_for('transactions.in_ocr') }}" class="btn btn-secondary">重新上传</a>
+  </div>
+</form>
+
+<template id="inRowTpl">
+  <tr>
+    <td><input name="purchase_code[]" class="form-control form-control-sm" placeholder="进货编号"></td>
+    <td>
+      <input type="hidden" name="pigment_id[]" value="">
+      <input name="new_code[]" class="form-control form-control-sm" placeholder="留空则自动新建">
+    </td>
+    <td><input type="number" step="0.01" name="quantity[]" value="0" class="form-control form-control-sm" min="0"></td>
+    <td><input type="number" step="0.01" name="unit_price[]" value="0" class="form-control form-control-sm"></td>
+    <td><small class="text-muted">手动</small></td>
+    <td><button type="button" class="btn btn-sm btn-outline-danger" onclick="this.closest('tr').remove()">删</button></td>
+  </tr>
+</template>
+<script>
+function addInRow(){
+  const t = document.getElementById('inRowTpl');
+  document.querySelector('#ocrTable tbody').appendChild(t.content.cloneNode(true));
+}
+</script>
+{% endif %}
+{% endblock %}

--- a/apps/peise/app/templates/transactions/out_form.html
+++ b/apps/peise/app/templates/transactions/out_form.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+{% block content %}
+<h3>出库</h3>
+<form method="post" style="max-width:600px">
+  <div class="mb-3"><label>色粉</label>
+    <select name="pigment_id" class="form-select" required>
+      {% for p in pigments %}
+        <option value="{{ p.id }}" {% if preselect==p.id %}selected{% endif %}>{{ p.code or '(待填)' }}{% if p.purchase_code %} / {{ p.purchase_code }}{% endif %}(当前 {{ p.stock.quantity if p.stock else 0 }})</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="mb-3"><label>数量</label><input type="number" step="0.01" name="quantity" class="form-control" min="0.01" required> <span class="text-muted">克(自动换算为 kg 扣减库存)</span></div>
+  <div class="mb-3"><label>备注</label><textarea name="note" class="form-control"></textarea></div>
+  <button class="btn btn-danger">出库</button>
+  <a href="{{ url_for('transactions.out_list') }}" class="btn btn-secondary">取消</a>
+</form>
+{% endblock %}

--- a/apps/peise/app/templates/transactions/out_index.html
+++ b/apps/peise/app/templates/transactions/out_index.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="d-flex justify-content-between mb-3">
+  <h3>出库流水</h3>
+  <div>
+    <a href="{{ url_for('transactions.out_new') }}" class="btn btn-danger"><i class="bi bi-plus"></i> 手动出库</a>
+    <a href="{{ url_for('transactions.out_ocr') }}" class="btn btn-primary"><i class="bi bi-camera"></i> 拍照识别</a>
+  </div>
+</div>
+<table class="table table-hover dt">
+  <thead><tr><th>时间</th><th>色粉编号</th><th>数量(g)</th><th>备注</th><th>操作</th></tr></thead>
+  <tbody>
+    {% for t in transactions %}
+      <tr>
+        <td>{{ t.occurred_at.strftime('%Y-%m-%d %H:%M') }}</td>
+        <td>{{ t.pigment.code or t.pigment.purchase_code }}</td>
+        <td>{{ ("%.2f"|format(t.quantity * 1000)).rstrip('0').rstrip('.') }}</td>
+        <td>{{ t.note }}</td>
+        <td><form method="post" action="{{ url_for('transactions.delete', tx_id=t.id) }}" class="d-inline" onsubmit="return confirm('删除并回滚库存?')"><button class="btn btn-sm btn-outline-danger"><i class="bi bi-trash"></i></button></form></td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/apps/peise/app/templates/transactions/out_ocr.html
+++ b/apps/peise/app/templates/transactions/out_ocr.html
@@ -1,0 +1,57 @@
+{% extends "base.html" %}
+{% block content %}
+<h3>拍照识别出库单</h3>
+{% if rows is none %}
+<p class="text-muted">上传领用单据照片(jpg/png),系统会自动识别色粉编号与数量。识别后可在表格中核对修改,再一键批量出库。</p>
+<form method="post" enctype="multipart/form-data" class="mb-3" style="max-width:500px">
+  <input type="file" name="file" accept="image/*" class="form-control mb-2" required>
+  <button class="btn btn-primary"><i class="bi bi-camera"></i> 上传识别</button>
+  <a href="{{ url_for('transactions.out_list') }}" class="btn btn-secondary">取消</a>
+</form>
+{% else %}
+<p>共识别出 <strong>{{ rows|length }}</strong> 行。<strong>数量按克填写,系统会自动 ÷1000 转成 kg 扣减库存。</strong>色粉编号可点开下拉搜索或直接手动输入。<br><small class="text-muted">编号若在库存里找不到,会自动新建占位色粉(允许负库存),之后可去「颜料档案」修改名称/品牌并补入库。</small></p>
+<form method="post" action="{{ url_for('transactions.out_ocr_submit') }}">
+  <table class="table table-sm" id="ocrTable">
+    <thead><tr><th style="width:30%">识别文本</th><th>色粉编号(搜索/手动输入)</th><th>数量(克)</th><th></th></tr></thead>
+    <tbody>
+      {% for r in rows %}
+      <tr>
+        <td><small class="text-muted">{{ r.raw }}</small></td>
+        <td><input name="pigment_code[]" list="pigmentCodes" autocomplete="off"
+                   class="form-control form-control-sm" placeholder="色粉编号"
+                   value="{{ r.pigment_code or r.purchase_code or '' }}"></td>
+        <td><input type="number" name="quantity[]" value="{{ '%.2f'|format(r.quantity) }}" step="0.01" class="form-control form-control-sm" min="0"></td>
+        <td><button type="button" class="btn btn-sm btn-outline-danger" onclick="this.closest('tr').remove()">删</button></td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  <button type="button" class="btn btn-outline-secondary mb-3" onclick="addOutRow()">+ 添加行</button>
+  <div>
+    <button class="btn btn-danger"><i class="bi bi-check2"></i> 批量出库</button>
+    <a href="{{ url_for('transactions.out_ocr') }}" class="btn btn-secondary">重新上传</a>
+  </div>
+</form>
+
+<template id="outRowTpl">
+  <tr>
+    <td><small class="text-muted">手动</small></td>
+    <td><input name="pigment_code[]" list="pigmentCodes" autocomplete="off" class="form-control form-control-sm" placeholder="色粉编号"></td>
+    <td><input type="number" step="0.01" name="quantity[]" value="0" class="form-control form-control-sm" min="0"></td>
+    <td><button type="button" class="btn btn-sm btn-outline-danger" onclick="this.closest('tr').remove()">删</button></td>
+  </tr>
+</template>
+<datalist id="pigmentCodes">
+  {% for p in pigments %}
+    <option value="{{ p.code }}">{% if p.purchase_code %}进货:{{ p.purchase_code }} · {% endif %}{{ p.name }}</option>
+    {% if p.purchase_code %}<option value="{{ p.purchase_code }}">编号:{{ p.code }} · {{ p.name }}</option>{% endif %}
+  {% endfor %}
+</datalist>
+<script>
+function addOutRow(){
+  const t = document.getElementById('outRowTpl');
+  document.querySelector('#ocrTable tbody').appendChild(t.content.cloneNode(true));
+}
+</script>
+{% endif %}
+{% endblock %}

--- a/apps/peise/requirements.txt
+++ b/apps/peise/requirements.txt
@@ -1,0 +1,8 @@
+flask==3.0.0
+flask-sqlalchemy==3.1.1
+pandas==2.2.0
+openpyxl==3.1.2
+pytest==8.0.0
+requests>=2.31
+Pillow>=10
+gunicorn>=21

--- a/apps/peise/run.py
+++ b/apps/peise/run.py
@@ -1,0 +1,6 @@
+from app import create_app
+
+app = create_app()
+
+if __name__ == "__main__":
+    app.run(debug=True, host="127.0.0.1", port=5000)

--- a/apps/peise/scripts/backup_db.bat
+++ b/apps/peise/scripts/backup_db.bat
@@ -1,0 +1,4 @@
+@echo off
+REM 由 Windows 任务计划程序调用,每日 19:00 跑一次
+REM 日志追加到 instance\backups\backup.log
+D:\Python\python.exe "D:\project\peise\scripts\backup_db.py" >> "D:\project\peise\instance\backups\backup.log" 2>&1

--- a/apps/peise/scripts/backup_db.py
+++ b/apps/peise/scripts/backup_db.py
@@ -1,0 +1,44 @@
+"""每日 DB 备份:用 SQLite backup API 拷贝 instance/peise.db 到 instance/backups/。
+
+用 Online Backup API 而不是 shutil.copy,避免 Flask 正在写时拷到一个半成品的文件。
+不删旧备份,保留全部历史;磁盘占用自己监控。
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+from datetime import datetime
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "instance" / "peise.db"
+DST_DIR = ROOT / "instance" / "backups"
+
+
+def main() -> int:
+    if not SRC.exists():
+        print(f"[backup] source missing: {SRC}", file=sys.stderr)
+        return 1
+    DST_DIR.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now().strftime("%Y%m%d-%H%M")
+    dst = DST_DIR / f"peise-{stamp}.db"
+    # 同一分钟多次执行不覆盖
+    i = 2
+    while dst.exists():
+        dst = DST_DIR / f"peise-{stamp}-{i}.db"
+        i += 1
+    src_conn = sqlite3.connect(f"file:{SRC}?mode=ro", uri=True)
+    dst_conn = sqlite3.connect(str(dst))
+    try:
+        with dst_conn:
+            src_conn.backup(dst_conn)
+    finally:
+        src_conn.close()
+        dst_conn.close()
+    size = dst.stat().st_size
+    print(f"[backup] ok -> {dst}  ({size:,} bytes)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/apps/peise/scripts/debug_ocr.py
+++ b/apps/peise/scripts/debug_ocr.py
@@ -1,0 +1,62 @@
+"""一次性诊断:对指定图片跑 OCR,逐层打印证据。"""
+import sys, io
+from pathlib import Path
+sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app import create_app
+from app.services.ocr import (
+    _raw_ocr, _group_rows, _first_marker_pos, _parse_row, _is_valid,
+    START_MARKERS, STOP_MARKERS, SKIP_KEYWORDS, build_pigment_lookup,
+)
+
+IMG = r"d:\xwechat_files\wxid_z63azb4tgium22_f11a\temp\RWTemp\2026-04\9e20f478899dc29eb19741386f9343c8\6246a185a07904124c8f4c7bc8e9b1a9.png"
+
+app = create_app()
+with app.app_context():
+    lookup = build_pigment_lookup()
+    print(f"[lookup] pigment tokens loaded: {len(lookup)}  sample: {list(lookup)[:8]}")
+    data = Path(IMG).read_bytes()
+    items = _raw_ocr(data)
+    print(f"\n[raw ocr] {len(items)} text boxes")
+    for it in items:
+        print(f"  y={it['y']:.0f} x=[{it['x_min']:.0f},{it['x_max']:.0f}] conf={it['conf']:.2f}  {it['text']!r}")
+    rows = _group_rows(items)
+    print(f"\n[rows] {len(rows)} rows grouped")
+    for i, row in enumerate(rows):
+        raw = " ".join(it["text"] for it in row)
+        print(f"  row#{i}: {raw!r}")
+    stop_pos = _first_marker_pos(rows, ("合计", "总计"))
+    start_pos = _first_marker_pos(rows, START_MARKERS)
+    print(f"\n[markers] start_pos={start_pos}  stop_pos={stop_pos}")
+    if stop_pos is not None and start_pos is not None and stop_pos < start_pos:
+        print("[markers] -> reversing rows")
+        rows = [list(reversed(r)) for r in reversed(rows)]
+    parsed = []
+    started = False
+    for i, row in enumerate(rows):
+        raw = " ".join(it["text"] for it in row)
+        if not started:
+            if any(m in raw for m in START_MARKERS):
+                started = True
+                print(f"[walk] row#{i} START hit -> {raw!r}")
+            else:
+                print(f"[walk] row#{i} skipped (before start): {raw!r}")
+                continue
+        if any(m in raw for m in STOP_MARKERS):
+            print(f"[walk] row#{i} STOP hit -> {raw!r}")
+            break
+        if any(k in raw for k in SKIP_KEYWORDS):
+            print(f"[walk] row#{i} SKIP keyword -> {raw!r}")
+            continue
+        r = _parse_row(row, lookup)
+        if r is None:
+            print(f"[walk] row#{i} parse=None: {raw!r}")
+            continue
+        ok = _is_valid(r)
+        print(f"[walk] row#{i} parse={r}  valid={ok}")
+        if ok:
+            parsed.append(r)
+    print(f"\n[final] {len(parsed)} rows kept")
+    for r in parsed:
+        print(f"  {r}")

--- a/apps/peise/scripts/debug_ocr_llm.py
+++ b/apps/peise/scripts/debug_ocr_llm.py
@@ -1,0 +1,29 @@
+"""一次性诊断:用 OpenRouter Gemma 4 31B 识别指定图片,打印原始响应与解析结果。"""
+import io, os, sys
+from pathlib import Path
+
+sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app import create_app
+from app.services.ocr_llm import parse_image_llm
+from app.services.ocr import build_pigment_lookup
+
+IMG = sys.argv[1] if len(sys.argv) > 1 else (
+    r"d:\xwechat_files\wxid_z63azb4tgium22_f11a\temp\RWTemp\2026-04"
+    r"\9e20f478899dc29eb19741386f9343c8\6246a185a07904124c8f4c7bc8e9b1a9.png"
+)
+
+if not os.environ.get("GEMINI_API_KEY"):
+    print("请先设置 GEMINI_API_KEY 环境变量")
+    raise SystemExit(1)
+
+app = create_app()
+with app.app_context():
+    lookup = build_pigment_lookup()
+    data = Path(IMG).read_bytes()
+    print(f"[image] {IMG}  size={len(data)}")
+    rows = parse_image_llm(data, lookup)
+    print(f"[rows] {len(rows)}")
+    for r in rows:
+        print(f"  {r}")

--- a/apps/peise/scripts/import_huadeng.py
+++ b/apps/peise/scripts/import_huadeng.py
@@ -1,0 +1,82 @@
+"""一次性脚本:导入华登仓库库存表.xlsx 到本系统。
+
+读取 4 个横向重复列块(0-6, 8-14, 16-22, 24-30),
+每块 7 列:色粉编号 | 上月剩余KG | 本月进货KG | 进货编号 | 本月剩余KG | 单价 | 金额
+"""
+import sys, math
+from pathlib import Path
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app import create_app
+from app.extensions import db
+from app.models import Pigment, Stock
+
+SRC = r"C:\Users\1\OneDrive\Desktop\华登\配色\仓库库存表 .xlsx"
+BLOCKS = [(0, 6), (8, 14), (16, 22), (24, 30)]
+HEADER_ROW = 2
+DATA_START = 3
+
+
+def clean_str(v):
+    if v is None or (isinstance(v, float) and math.isnan(v)):
+        return ""
+    return str(v).strip()
+
+
+def clean_float(v):
+    try:
+        f = float(v)
+        if math.isnan(f):
+            return 0.0
+        return f
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def iter_rows():
+    df = pd.read_excel(SRC, sheet_name=0, header=None)
+    for ridx in range(DATA_START, len(df)):
+        for start, _ in BLOCKS:
+            code = clean_str(df.iat[ridx, start])
+            if not code:
+                continue
+            purchase_code = clean_str(df.iat[ridx, start + 3])
+            qty_kg = clean_float(df.iat[ridx, start + 4])
+            unit_price = clean_float(df.iat[ridx, start + 5])
+            yield {
+                "code": code,
+                "purchase_code": purchase_code,
+                "qty": int(round(qty_kg)),
+                "unit_price": unit_price,
+            }
+
+
+def main():
+    app = create_app()
+    with app.app_context():
+        created = updated = 0
+        for row in iter_rows():
+            p = Pigment.query.filter_by(brand="", code=row["code"]).first()
+            is_new = p is None
+            if is_new:
+                p = Pigment(brand="", code=row["code"], name=row["code"])
+                db.session.add(p)
+            p.purchase_code = row["purchase_code"]
+            p.unit_price = row["unit_price"]
+            if p.stock is None:
+                p.stock = Stock(quantity=row["qty"])
+            else:
+                p.stock.quantity = row["qty"]
+            db.session.flush()
+            if is_new:
+                created += 1
+            else:
+                updated += 1
+        db.session.commit()
+        print(f"新增 {created},更新 {updated}")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/peise/tests/conftest.py
+++ b/apps/peise/tests/conftest.py
@@ -1,0 +1,24 @@
+import pytest
+from app import create_app
+from app.extensions import db as _db
+
+class TestConfig:
+    SECRET_KEY = "test"
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    TESTING = True
+
+@pytest.fixture
+def app():
+    app = create_app(TestConfig)
+    yield app
+
+@pytest.fixture
+def db(app):
+    with app.app_context():
+        yield _db
+        _db.session.remove()
+
+@pytest.fixture
+def client(app):
+    return app.test_client()

--- a/apps/peise/tests/test_excel_io.py
+++ b/apps/peise/tests/test_excel_io.py
@@ -1,0 +1,59 @@
+import io
+import pandas as pd
+from app.models import Pigment, Stock
+from app.services.excel_io import export_pigments_to_bytes, import_pigments_from_bytes
+
+
+def test_export_contains_new_columns(db):
+    p = Pigment(brand="", code="X1", name="X1", hex="#ffffff",
+                color_family="其他", spec_value=0, spec_unit="kg",
+                purchase_code="P1", unit_price=5.0)
+    p.stock = Stock(quantity=3)
+    db.session.add(p); db.session.commit()
+    data = export_pigments_to_bytes()
+    df = pd.read_excel(io.BytesIO(data))
+    assert set(["色粉编号", "进货色粉编号", "数量", "单价", "单位", "金额"]).issubset(df.columns)
+    assert df.iloc[0]["数量"] == 3
+    assert df.iloc[0]["金额"] == 15.0
+
+
+def _make_xlsx(rows):
+    df = pd.DataFrame(rows)
+    buf = io.BytesIO()
+    df.to_excel(buf, index=False, engine="openpyxl")
+    return buf.getvalue()
+
+
+def test_import_upsert(db):
+    existing = Pigment(brand="", code="X1", name="X1", hex="#000000",
+                       color_family="其他", spec_value=0, spec_unit="kg")
+    db.session.add(existing); db.session.commit()
+    data = _make_xlsx([
+        {"色粉编号": "X1", "进货色粉编号": "P1", "数量": 5, "单价": 10},
+        {"色粉编号": "X2", "进货色粉编号": "P2", "数量": 2, "单价": 3},
+    ])
+    report = import_pigments_from_bytes(data)
+    assert report["created"] == 1
+    assert report["updated"] == 1
+    x1 = Pigment.query.filter_by(code="X1").first()
+    assert x1.stock.quantity == 5
+    assert x1.unit_price == 10
+
+
+def test_import_archives_missing_and_handles_blank(db):
+    a = Pigment(brand="", code="A1", name="A1", hex="#000000",
+                color_family="其他", spec_value=0, spec_unit="kg")
+    b = Pigment(brand="", code="B1", name="B1", hex="#000000",
+                color_family="其他", spec_value=0, spec_unit="kg")
+    a.stock = Stock(quantity=0); b.stock = Stock(quantity=0)
+    db.session.add_all([a, b]); db.session.commit()
+    # Excel 只有 A1, 进货色粉编号/备注 留空
+    data = _make_xlsx([
+        {"色粉编号": "A1", "进货色粉编号": None, "数量": 7, "单价": 4, "备注": None},
+    ])
+    report = import_pigments_from_bytes(data)
+    assert report["archived"] == 1
+    a1 = Pigment.query.filter_by(code="A1").first()
+    assert a1.purchase_code == ""  # 不再写 "nan"
+    assert a1.notes == ""
+    assert Pigment.query.filter_by(code="B1").first().is_archived is True

--- a/apps/peise/tests/test_inventory.py
+++ b/apps/peise/tests/test_inventory.py
@@ -1,0 +1,37 @@
+import pytest
+from app.models import Pigment, Stock
+from app.services.inventory import stock_in, stock_out, stock_adjust, InsufficientStock
+
+def make_pigment(db, qty=0):
+    p = Pigment(brand="T", code="1", name="x", hex="#000000",
+                color_family="其他", spec_value=15, spec_unit="ml", min_stock=1)
+    p.stock = Stock(quantity=qty)
+    db.session.add(p)
+    db.session.commit()
+    return p
+
+def test_stock_in_increments(db):
+    p = make_pigment(db, qty=2)
+    stock_in(p.id, 3, note="采购")
+    assert p.stock.quantity == 5
+    assert len(p.transactions) == 1
+    assert p.transactions[0].type == "in"
+
+def test_stock_out_decrements(db):
+    p = make_pigment(db, qty=5)
+    stock_out(p.id, 2)
+    assert p.stock.quantity == 3
+
+def test_stock_out_insufficient_raises(db):
+    p = make_pigment(db, qty=1)
+    with pytest.raises(InsufficientStock):
+        stock_out(p.id, 5)
+    assert p.stock.quantity == 1
+
+def test_stock_adjust_sets_absolute(db):
+    p = make_pigment(db, qty=3)
+    stock_adjust(p.id, 10)
+    assert p.stock.quantity == 10
+    tx = p.transactions[0]
+    assert tx.type == "adjust"
+    assert tx.quantity == 7

--- a/apps/peise/tests/test_models.py
+++ b/apps/peise/tests/test_models.py
@@ -1,0 +1,10 @@
+from app.models import Pigment, Stock
+
+def test_create_pigment_with_stock(db):
+    p = Pigment(brand="Holbein", code="W001", name="钛白", hex="#ffffff",
+                color_family="中性", spec_value=15, spec_unit="ml", min_stock=2)
+    p.stock = Stock(quantity=5)
+    db.session.add(p)
+    db.session.commit()
+    assert p.id is not None
+    assert p.stock.quantity == 5

--- a/apps/peise/tests/test_routes.py
+++ b/apps/peise/tests/test_routes.py
@@ -1,0 +1,48 @@
+def test_dashboard_200(client, db):
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert "仪表盘".encode("utf-8") in resp.data
+
+
+from app.models import Pigment, Stock
+
+
+def test_pigments_index_200(client, db):
+    resp = client.get("/pigments/")
+    assert resp.status_code == 200
+
+
+def test_create_pigment(client, db):
+    resp = client.post("/pigments/new", data={
+        "code": "W001", "purchase_code": "P001",
+        "quantity": "3", "unit_price": "12.50"
+    }, follow_redirects=True)
+    assert resp.status_code == 200
+    p = Pigment.query.filter_by(code="W001").first()
+    assert p is not None
+    assert p.stock.quantity == 3
+    assert p.unit_price == 12.50
+
+
+def test_stock_in_via_route(client, db):
+    p = Pigment(brand="B", code="1", name="x", hex="#000000",
+                color_family="其他", spec_value=15, spec_unit="ml")
+    p.stock = Stock(quantity=0)
+    db.session.add(p); db.session.commit()
+    resp = client.post("/transactions/in/new", data={
+        "pigment_id": p.id, "quantity": "4", "note": ""
+    }, follow_redirects=True)
+    assert resp.status_code == 200
+    assert p.stock.quantity == 4
+
+
+def test_archive_pigment_with_transactions(client, db):
+    p = Pigment(brand="A", code="1", name="x", hex="#000000",
+                color_family="其他", spec_value=15, spec_unit="ml")
+    p.stock = Stock(quantity=1)
+    db.session.add(p); db.session.commit()
+    from app.services.inventory import stock_out
+    stock_out(p.id, 1)
+    resp = client.post(f"/pigments/{p.id}/delete", follow_redirects=True)
+    assert resp.status_code == 200
+    assert Pigment.query.get(p.id).is_archived is True

--- a/docker-compose.cloud.yml
+++ b/docker-compose.cloud.yml
@@ -425,6 +425,33 @@ services:
     networks:
       - platform-net
 
+  peise:
+    build:
+      context: ./apps/peise
+      dockerfile: Dockerfile
+    environment:
+      - BASE_PATH=/peise
+      - GEMINI_API_KEY=${PEISE_GEMINI_API_KEY:-}
+      - GEMINI_BASE_URL=${PEISE_GEMINI_BASE_URL:-https://gemini-proxy.hufan4308.workers.dev}
+      - GEMINI_MODEL=${PEISE_GEMINI_MODEL:-gemini-2.5-flash}
+    volumes:
+      - ./apps/peise/instance:/app/instance
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5006/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    mem_limit: 512m
+    memswap_limit: 512m
+    restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    networks:
+      - platform-net
+
 networks:
   platform-net:
     driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -239,3 +239,26 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
+
+
+  peise:
+    build:
+      context: ./apps/peise
+      dockerfile: Dockerfile
+    env_file:
+      - ./apps/peise/.env
+    volumes:
+      - "./apps/peise/instance:/app/instance"
+    mem_limit: 512m
+    memswap_limit: 512m
+    restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -247,6 +247,8 @@ services:
       dockerfile: Dockerfile
     env_file:
       - ./apps/peise/.env
+    environment:
+      - BASE_PATH=/peise
     volumes:
       - "./apps/peise/instance:/app/instance"
     mem_limit: 512m
@@ -258,7 +260,7 @@ services:
         max-size: "10m"
         max-file: "3"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:5000/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:5006/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/frontend/index.cloud.html
+++ b/frontend/index.cloud.html
@@ -249,6 +249,12 @@
                 <span class="plugin-name">成品核对系统</span>
               </div>
             </div>
+            <div class="plugin-item">
+              <div class="plugin-info">
+                <div class="plugin-dot gray" id="peiseDot"></div>
+                <span class="plugin-name">配色库存管理</span>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -582,7 +588,7 @@
       <div class="dept-icon pmc" style="width:40px;height:40px;font-size:18px;">&#128230;</div>
       PMC跟仓管
     </div>
-    <div class="page-subtitle">采购订单 · 成品核对</div>
+    <div class="page-subtitle">采购订单 · 成品核对 · 配色库存</div>
 
     <div class="detail-plugin-card">
       <div class="detail-plugin-left">
@@ -624,6 +630,27 @@
         <a href="/liwenjuan/" target="_blank" class="btn btn-primary">打开系统</a>
       </div>
     </div>
+
+    <div class="detail-plugin-card">
+      <div class="detail-plugin-left">
+        <div class="detail-plugin-icon" style="background:linear-gradient(135deg,#10b981,#059669);">&#127912;</div>
+        <div>
+          <div class="detail-plugin-name">配色库存管理</div>
+          <div class="detail-plugin-desc">颜料/色粉档案与库存流水管理，拍照识别送货单（Gemini 多模态 OCR），Excel 批量导入导出</div>
+          <div class="feature-grid">
+            <div class="feature-tag">&#127912; 颜料档案</div>
+            <div class="feature-tag">&#128202; 库存仪表盘</div>
+            <div class="feature-tag">&#128247; Gemini OCR 送货单</div>
+            <div class="feature-tag">&#128230; Excel 导入/导出</div>
+            <div class="feature-tag">&#128221; 入库/出库流水</div>
+          </div>
+        </div>
+      </div>
+      <div class="detail-plugin-right">
+        <div class="detail-plugin-status"><div class="plugin-dot gray" id="peiseDetailDot"></div> 检查中...</div>
+        <a href="/peise/" target="_blank" class="btn btn-primary">打开系统</a>
+      </div>
+    </div>
   </div>
 
 </div>
@@ -663,6 +690,7 @@ async function checkHealth() {
       { name: 'quotation', url: '/quotation/health', dot: 'quotationDot', detailDot: 'quotationDetailDot' },
       { name: 'tomy', url: '/tomy-paiqi/health', dot: 'tomyDot', detailDot: 'tomyDetailDot' },
       { name: 'zuruMaster', url: '/zuru-master/health', dot: 'zuruMasterDot', detailDot: 'zuruMasterDetailDot' },
+      { name: 'peise', url: '/peise/health', dot: 'peiseDot', detailDot: 'peiseDetailDot' },
     ];
     var healthy = 0;
     var total = checks.length;

--- a/nginx/nginx.cloud.conf
+++ b/nginx/nginx.cloud.conf
@@ -111,6 +111,11 @@ http {
         keepalive 4;
     }
 
+    upstream peise_backend {
+        server peise:5006;
+        keepalive 4;
+    }
+
     # ─── HTTP → HTTPS redirect (enable when SSL certs are provisioned) ───
     # Uncomment this block after running setup-ssl.sh:
     # server {
@@ -598,6 +603,36 @@ http {
             client_max_body_size 200m;
             proxy_read_timeout 300s;
             proxy_send_timeout 300s;
+        }
+
+        # ─── Standalone: 配色库存管理 (peise) ───
+        location = /peise {
+            return 301 /peise/;
+        }
+        location = /peise/health {
+            auth_basic off;
+            proxy_pass http://peise_backend/health;
+            proxy_set_header Host $host;
+        }
+        location /peise/ {
+            limit_req zone=upload_limit burst=10 nodelay;
+            proxy_pass http://peise_backend/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Prefix /peise;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            client_max_body_size 32m;
+            proxy_read_timeout 120s;
+            proxy_send_timeout 120s;
+            # peise 模板用 jsdelivr CDN（Bootstrap/jQuery/DataTables/Chart.js）
+            add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://code.jquery.com https://cdn.datatables.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdn.datatables.net; img-src 'self' data: blob:; font-src 'self' data: https://cdn.jsdelivr.net; connect-src 'self'; frame-ancestors 'self';" always;
+            add_header X-Frame-Options "SAMEORIGIN" always;
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header X-XSS-Protection "1; mode=block" always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         }
 
         # ─── Removed apps: return 404 to stop stale health check polling ───


### PR DESCRIPTION
## 目标

把 peise（配色库存管理）Flask 应用按 `apps/jiangping` 的 pattern 接入仓库。

## 改动范围（最小化，不碰共享基建）

| 文件 | 变更 |
|---|---|
| `apps/peise/**` | 新增整份源码 + `Dockerfile` + `.env.example` + `.gitignore` |
| `docker-compose.yml` | **末尾追加** `peise` service 块（只新增 1 段，未改已有行） |

未触碰 `nginx/`、`.github/workflows/deploy.yml`、`core/`、`plugin_sdk/`、任何已有 service 的配置。

## 功能

- 颜料档案 + 库存 + 入库/出库流水
- 拍照识别送货单（Gemini 2.5 Flash 多模态 → JSON，失败回退 PaddleOCR）
- Excel 导入（覆盖语义，未列出的 `brand=""` 色粉自动归档）/ 导出 / 模板
- SQLite 持久化到 `apps/peise/instance/`（卷挂载）

## 部署维护者需做的两件事

1. **在服务器上创建 `apps/peise/.env`**（参照 `.env.example`）：
   ```
   GEMINI_API_KEY=AIzaSy...
   GEMINI_BASE_URL=https://gemini-proxy.hufan4308.workers.dev
   ```
   `GEMINI_BASE_URL` 是 Cloudflare Worker 反向代理，境内 ECS 绕墙调 Gemini 用；Gemini key 在 https://aistudio.google.com/app/apikey 免费申请。

2. **确保服务器 `apps/peise/instance/` 目录存在且可写**（compose 卷挂载需要，首次 up -d 会自动创建）。

## CI 影响

`.github/workflows/deploy.yml` 里的 health check 列表**未添加** /peise/health，因此 peise 容器起或没起都不影响现有 CI 通过。想对外暴露该服务再单独开 PR 改 nginx + 补 health check 条目。

## 验证

- 本地 pytest 13 测试全过
- OCR 链路本地验证：直连 Gemini + 通过 Cloudflare Worker 代理均能正确返回结构化数据

## 来源 repo

初始版本在 https://github.com/fxxaxxx/peisecangku （独立 Flask 项目），此次按 RR-Portal 插件形态整合进来。