### PR TITLE
fix(paiji): 13 code review issues (3 blocker + 3 high + 4 medium + 3 nit)

### DIFF
--- a/apps/paiji/client/src/pages/Orders.jsx
+++ b/apps/paiji/client/src/pages/Orders.jsx
@@ -5,7 +5,7 @@ import {
 } from 'antd';
 import {
   UploadOutlined, PlusOutlined, DeleteOutlined,
-  EditOutlined, ClearOutlined, InboxOutlined,
+  EditOutlined, InboxOutlined,
 } from '@ant-design/icons';
 import axios from 'axios';
 
@@ -65,12 +65,6 @@ export default function Orders() {
     load();
   };
 
-  const handleClearAll = async () => {
-    await axios.delete('/api/orders');
-    message.success('已清空所有订单');
-    load();
-  };
-
   const handleImport = async (file) => {
     const formData = new FormData();
     formData.append('file', file);
@@ -114,9 +108,6 @@ export default function Orders() {
         <Upload beforeUpload={handleImport} showUploadList={false} accept=".xlsx,.xls,.pdf">
           <Button icon={<UploadOutlined />}>导入 Excel / PDF</Button>
         </Upload>
-        <Popconfirm title="确认清空所有订单？" onConfirm={handleClearAll}>
-          <Button danger icon={<ClearOutlined />}>清空订单</Button>
-        </Popconfirm>
         <Tag color="geekblue">共 {orders.length} 条订单</Tag>
       </Space>
 

--- a/apps/paiji/client/src/pages/ScheduleResult.jsx
+++ b/apps/paiji/client/src/pages/ScheduleResult.jsx
@@ -62,7 +62,7 @@ export default function ScheduleResult({ workshop = 'B' }) {
       const { data } = await axios.get('/api/machines', { params: { workshop } });
       setMachines(data.sort((a, b) => getMachineNum(a.machine_no) - getMachineNum(b.machine_no)));
     } catch (e) {
-      // 静默失败
+      message.error('机台列表加载失败，机械手/机台切换功能不可用');
     }
   };
 

--- a/apps/paiji/server/db/init.js
+++ b/apps/paiji/server/db/init.js
@@ -81,6 +81,9 @@ function initDatabase() {
   db.exec(`CREATE INDEX IF NOT EXISTS idx_history_shot_weight ON history_records(machine_no, shot_weight)`);
   db.exec(`CREATE INDEX IF NOT EXISTS idx_history_material ON history_records(material_type)`);
   db.exec(`CREATE INDEX IF NOT EXISTS idx_history_mold ON history_records(mold_name)`);
+  // 去重：同一批次里同一机台同一订单同一产品不重复（允许 import_batch 为 NULL 多占位）
+  db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS uq_history_batch_item
+           ON history_records(import_batch, machine_no, order_no, product_code, source_date)`);
 
   // ========== 排机单表 ==========
   db.exec(`

--- a/apps/paiji/server/routes/history.js
+++ b/apps/paiji/server/routes/history.js
@@ -132,27 +132,30 @@ router.post('/import', upload.single('file'), async (req, res) => {
     const batch = Date.now().toString();
     const workshop = req.body.workshop || 'B';
     const insert = db.prepare(`
-      INSERT INTO history_records (machine_no, product_code, mold_name, color, color_powder_no,
+      INSERT OR IGNORE INTO history_records (machine_no, product_code, mold_name, color, color_powder_no,
         material_type, shot_weight, material_kg, sprue_pct, ratio_pct, accumulated,
         quantity_needed, shortage, order_no, target_24h, target_11h, packing_qty, notes, import_batch, workshop)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
 
     const insertAll = db.transaction((rows) => {
-      let count = 0;
+      let inserted = 0;
+      let skipped = 0;
       for (const r of rows) {
-        insert.run(
+        const result = insert.run(
           r.machine_no, r.product_code, r.mold_name, r.color, r.color_powder_no,
           r.material_type, r.shot_weight, r.material_kg, r.sprue_pct, r.ratio_pct,
           r.accumulated, r.quantity_needed, r.shortage, r.order_no,
           r.target_24h, r.target_11h, r.packing_qty, r.notes, batch, workshop
         );
-        count++;
+        if (result.changes > 0) inserted++;
+        else skipped++;
       }
-      return count;
+      return { inserted, skipped };
     });
 
-    const count = insertAll(records);
+    const { inserted, skipped } = insertAll(records);
+    const count = inserted;
 
     // 自动刷新机台啤重统计（按车间过滤）
     const stats = db.prepare(`
@@ -171,7 +174,10 @@ router.post('/import', upload.single('file'), async (req, res) => {
       for (const s of stats) updateMachine.run(s.min_w, s.max_w, s.avg_w, s.cnt, prefix + s.machine_no, workshop);
     })();
 
-    res.json({ message: `成功导入${count}条历史记录`, count, batch });
+    const msg = skipped > 0
+      ? `导入 ${inserted} 条，跳过 ${skipped} 条重复记录`
+      : `成功导入${count}条历史记录`;
+    res.json({ message: msg, count, inserted, skipped, batch });
   } catch (err) {
     console.error('导入历史数据失败:', err);
     res.status(500).json({ message: '导入失败: ' + err.message });

--- a/apps/paiji/server/routes/orders.js
+++ b/apps/paiji/server/routes/orders.js
@@ -112,17 +112,6 @@ router.delete('/:id', (req, res) => {
   }
 });
 
-// 清空所有订单（仅当前车间）
-router.delete('/', (req, res) => {
-  try {
-    const workshop = req.query.workshop || req.body.workshop || 'B';
-    db.prepare('DELETE FROM orders WHERE workshop = ?').run(workshop);
-    res.json({ message: '已清空' });
-  } catch (err) {
-    res.status(500).json({ message: '清空失败：' + err.message });
-  }
-});
-
 // 下载订单导入模板
 router.get('/template', async (req, res) => {
   const wb = new ExcelJS.Workbook();
@@ -239,6 +228,21 @@ router.post('/import', upload.single('file'), async (req, res) => {
     }
 
     const workshop = req.body.workshop || 'B';
+
+    // 批内去重：同一份文件如果有完全相同的 (order_no + product_code + mold_no) 只保留第一条
+    const seen = new Set();
+    const dedup = [];
+    let dupeCount = 0;
+    for (const o of parsed) {
+      const key = [o.order_no || '', o.product_code || '', o.mold_no || ''].join('|');
+      if (key === '||' || !seen.has(key)) {
+        seen.add(key);
+        dedup.push(o);
+      } else {
+        dupeCount++;
+      }
+    }
+
     const insertMany = db.transaction((rows) => {
       for (const o of rows) {
         stmts().insert.run(
@@ -252,8 +256,11 @@ router.post('/import', upload.single('file'), async (req, res) => {
       }
     });
 
-    insertMany(parsed);
-    res.json({ message: `成功导入 ${parsed.length} 条订单`, count: parsed.length, added: parsed.length });
+    insertMany(dedup);
+    const msg = dupeCount > 0
+      ? `导入 ${dedup.length} 条订单（跳过 ${dupeCount} 条文件内重复）`
+      : `成功导入 ${dedup.length} 条订单`;
+    res.json({ message: msg, count: dedup.length, added: dedup.length, dupeCount });
   } catch (err) {
     res.status(500).json({ message: '导入失败：' + err.message });
   } finally {

--- a/apps/paiji/server/routes/scheduling.js
+++ b/apps/paiji/server/routes/scheduling.js
@@ -53,18 +53,28 @@ router.get('/carry-over', (req, res) => {
 });
 
 // 执行智能排机 — 必须在 /:id 之前
+// 同车间+日期+班次并发锁：防止快速双击创建两张草稿
+const generateLocks = new Set();
 router.post('/generate', (req, res) => {
+  const { date, shift, orderIds, workshop } = req.body;
+  if (!date || !shift || !Array.isArray(orderIds)) {
+    return res.status(400).json({ message: '请提供date、shift和orderIds' });
+  }
+  const ws = workshop || 'B';
+  const lockKey = `${ws}|${date}|${shift}`;
+  if (generateLocks.has(lockKey)) {
+    return res.status(429).json({ message: '排机进行中，请稍候再试' });
+  }
+  generateLocks.add(lockKey);
   try {
-    const { date, shift, orderIds, workshop } = req.body;
-    if (!date || !shift || !Array.isArray(orderIds)) {
-      return res.status(400).json({ message: '请提供date、shift和orderIds' });
-    }
     const { generateSchedule } = require('../services/schedulingEngine');
-    const result = generateSchedule({ orderIds, date, shift, workshop: workshop || 'B' });
+    const result = generateSchedule({ orderIds, date, shift, workshop: ws });
     res.json(result);
   } catch (err) {
     console.error('排机失败:', err);
     res.status(500).json({ message: '排机失败: ' + err.message });
+  } finally {
+    generateLocks.delete(lockKey);
   }
 });
 
@@ -108,19 +118,24 @@ router.put('/:id/items/:itemId', (req, res) => {
     values.push(accumulated, shortage);
 
     // 同步更新订单表，若欠数为0则标记完成
+    // 只同步到未确认的草稿排机单，不覆盖历史已确认班次的数据
     if (currentItem.order_id) {
       if (shortage <= 0) {
         db.prepare("UPDATE orders SET accumulated = ?, status = 'completed' WHERE id = ?")
           .run(accumulated, currentItem.order_id);
-        // 同步所有排单里相同订单的条目，欠数全部归零
-        db.prepare("UPDATE schedule_items SET accumulated = ?, shortage = 0 WHERE order_id = ? AND id != ?")
-          .run(accumulated, currentItem.order_id, itemId);
+        db.prepare(`
+          UPDATE schedule_items SET accumulated = ?, shortage = 0
+          WHERE order_id = ? AND id != ?
+            AND schedule_id IN (SELECT id FROM schedules WHERE status != 'confirmed')
+        `).run(accumulated, currentItem.order_id, itemId);
       } else {
         db.prepare('UPDATE orders SET accumulated = ? WHERE id = ?')
           .run(accumulated, currentItem.order_id);
-        // 同步其他排单里相同订单的条目的累计数
-        db.prepare("UPDATE schedule_items SET accumulated = ?, shortage = ? WHERE order_id = ? AND id != ?")
-          .run(accumulated, shortage, currentItem.order_id, itemId);
+        db.prepare(`
+          UPDATE schedule_items SET accumulated = ?, shortage = ?
+          WHERE order_id = ? AND id != ?
+            AND schedule_id IN (SELECT id FROM schedules WHERE status != 'confirmed')
+        `).run(accumulated, shortage, currentItem.order_id, itemId);
       }
     }
   }
@@ -183,6 +198,10 @@ router.post('/:id/confirm', (req, res) => {
     const schedule = db.prepare('SELECT * FROM schedules WHERE id = ?').get(req.params.id);
     if (!schedule) return res.status(404).json({ message: '排机单不存在' });
 
+    if (schedule.status === 'confirmed') {
+      return res.status(409).json({ message: '排机单已确认，不能重复确认' });
+    }
+
     const items = db.prepare('SELECT * FROM schedule_items WHERE schedule_id = ?').all(req.params.id);
     if (items.length === 0) return res.status(400).json({ message: '排机单无明细' });
 
@@ -198,6 +217,13 @@ router.post('/:id/confirm', (req, res) => {
     const scheduleWorkshop = schedule.workshop || 'B';
 
     const writeAll = db.transaction(() => {
+      // 事务内重新检查状态，防止竞态（并发两个 confirm 请求）
+      const fresh = db.prepare('SELECT status FROM schedules WHERE id = ?').get(req.params.id);
+      if (fresh.status === 'confirmed') {
+        throw new Error('ALREADY_CONFIRMED');
+      }
+      db.prepare('UPDATE schedules SET status = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?')
+        .run('confirmed', req.params.id);
       for (const item of items) {
         insertHistory.run(
           item.machine_no, item.product_code, item.mold_name, item.color,
@@ -207,8 +233,6 @@ router.post('/:id/confirm', (req, res) => {
           item.packing_qty, item.notes, schedule.schedule_date, batch, scheduleWorkshop
         );
       }
-      db.prepare('UPDATE schedules SET status = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?')
-        .run('confirmed', req.params.id);
       for (const item of items) {
         if (item.order_id) {
           db.prepare('UPDATE orders SET status = ? WHERE id = ?').run('scheduled', item.order_id);
@@ -216,7 +240,14 @@ router.post('/:id/confirm', (req, res) => {
       }
     });
 
-    writeAll();
+    try {
+      writeAll();
+    } catch (e) {
+      if (e.message === 'ALREADY_CONFIRMED') {
+        return res.status(409).json({ message: '排机单已确认，不能重复确认' });
+      }
+      throw e;
+    }
 
     // 刷新机台统计
     const machines = db.prepare('SELECT DISTINCT machine_no FROM schedule_items WHERE schedule_id = ?').all(req.params.id);

--- a/apps/paiji/server/services/excelExporter.js
+++ b/apps/paiji/server/services/excelExporter.js
@@ -7,13 +7,18 @@ const WEEKDAYS = ['星期日', '星期一', '星期二', '星期三', '星期四
  * 格式化日期为中文: "2026年3月10日星期二"
  */
 function formatDateChinese(dateStr) {
-  const d = new Date(dateStr);
+  // dateStr 期望 "YYYY-MM-DD"。用手动解析避免 new Date('YYYY-MM-DD') 被当成 UTC 午夜，
+  // 在容器 TZ 未设置时偏移一天。
+  const m = String(dateStr || '').match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (!m) return dateStr;
+  const y = Number(m[1]);
+  const mo = Number(m[2]);
+  const day = Number(m[3]);
+  // 本地时间构造 Date 用于算 weekday（不依赖时区）
+  const d = new Date(y, mo - 1, day);
   if (isNaN(d)) return dateStr;
-  const y = d.getFullYear();
-  const m = d.getMonth() + 1;
-  const day = d.getDate();
   const weekday = WEEKDAYS[d.getDay()];
-  return `${y}年${m}月${day}日${weekday}`;
+  return `${y}年${mo}月${day}日${weekday}`;
 }
 
 /**
@@ -186,7 +191,7 @@ async function exportScheduleExcel(scheduleId) {
       item.order_no || '',               // N 下单单号
       '',                                 // O 单号（留空手填）
       item.target_24h || 0,              // P 24H目标
-      item.target_24h ? Math.round((item.target_24h)/24*11) : 0,     // Q 11H
+      item.target_11h || (item.target_24h ? Math.round((item.target_24h)/24*11) : 0),     // Q 11H — 优先用 DB 值，回退计算
       item.target_24h ? Math.round(Math.max(0,(item.quantity_needed||0)-(item.accumulated||0))/(item.target_24h)*100)/100 : '', // R 天数
       item.notes || '',                  // S 备注
       item.robot_arm || '',              // T 机械手
@@ -410,7 +415,7 @@ function writeScheduleSheet(ws, schedule, items, machineMap, wsName) {
       Math.max(0, (item.quantity_needed||0) - (item.accumulated||0)),
       item.order_no || '', '',
       item.target_24h || 0,
-      item.target_24h ? Math.round((item.target_24h)/24*11) : 0,
+      item.target_11h || (item.target_24h ? Math.round((item.target_24h)/24*11) : 0),
       item.target_24h ? Math.round(Math.max(0,(item.quantity_needed||0)-(item.accumulated||0))/(item.target_24h)*100)/100 : '',
       item.notes || '', item.robot_arm || '', item.clamp || '',
       item.mold_change_time || '', item.adjuster || '', armLabel, machine.tonnage || '',

--- a/apps/paiji/server/services/schedulingEngine.js
+++ b/apps/paiji/server/services/schedulingEngine.js
@@ -36,6 +36,16 @@ function needsFiveAxis(order) {
 }
 
 /**
+ * 按机台吨位估算合理啤重区间（g）— 新机台无历史数据时 fallback
+ * 经验法则：每吨锁模力对应约 0.5~3g 塑料（视产品薄厚而定）
+ */
+function tonnageShotWeightRange(tonnage) {
+  const t = Number(tonnage) || 0;
+  if (t <= 0) return null;
+  return { min: t * 0.3, max: t * 3.0 };
+}
+
+/**
  * 获取上一班次
  * 夜班 → 同日白班
  * 白班 → 前一天夜班
@@ -273,6 +283,16 @@ function generateSchedule({ orderIds, date, shift, workshop }) {
             : (shotWeight - ms.max_w) / ms.max_w;
           score -= Math.min(distance * 20, 20);
         }
+      } else if (shotWeight > 0) {
+        // 新机台无历史 → 用吨位估算合理啤重区间，避免大件排到小机
+        const range = tonnageShotWeightRange(m.tonnage);
+        if (range) {
+          if (shotWeight < range.min || shotWeight > range.max) {
+            continue; // 吨位与啤重差距过大，跳过
+          }
+          score += 5; // 吨位匹配，小幅加分
+          reasons.push('吨位匹配');
+        }
       }
 
       // Step 3: 啤重越接近均值越好 → 0~10分
@@ -321,9 +341,16 @@ function generateSchedule({ orderIds, date, shift, workshop }) {
         a.machine_no === m.machine_no &&
         isSameMold(a.order.mold_no, order.mold_no)
       );
-      const sameMoldCarryOver = (carryOverByMachine[m.machine_no] || []).some(item =>
-        order.mold_no && item.mold_name && item.mold_name.includes(order.mold_no)
-      );
+      // 结转项的 mold_name 可能包含模号（如 "MNVN-17M-01 XX玩具"），
+      // 用 moldBase 提取核心编号比较，而不是只做 includes 子串匹配
+      const orderMoldBase = moldBase(order.mold_no || '');
+      const sameMoldCarryOver = (carryOverByMachine[m.machine_no] || []).some(item => {
+        if (!item.mold_name) return false;
+        const itemMoldBase = moldBase(item.mold_name);
+        if (orderMoldBase && itemMoldBase && orderMoldBase === itemMoldBase) return true;
+        // 兜底：旧逻辑的 includes，以防 moldBase 未识别格式
+        return order.mold_no && item.mold_name.includes(order.mold_no);
+      });
       if (sameMoldNew || sameMoldCarryOver) {
         score += 100;
         reasons.push('同套模');
@@ -440,8 +467,11 @@ function generateSchedule({ orderIds, date, shift, workshop }) {
     let sortOrder = (maxSort?.m ?? -1) + 1;
 
     // 先写结转项（is_carry_over=1，仅限机台正常的）
+    // 使用 DB 存储的 shortage（权威值），因为调机人手动调过的 accumulated 可能已偏离简单累加
     for (const item of filteredCarryOver) {
-      const shortage = Math.max(0, (item.quantity_needed || 0) - (item.accumulated || 0));
+      const shortage = item.shortage !== null && item.shortage !== undefined
+        ? item.shortage
+        : Math.max(0, (item.quantity_needed || 0) - (item.accumulated || 0));
       insertItem.run(
         scheduleId, item.machine_no,
         item.product_code || '', item.mold_name || '', item.color || '',


### PR DESCRIPTION
## Summary

修复 paiji 排产系统 code review 发现的 13/14 项问题（第 14 项 A/C 车间机台 hardcode 需要业务方提供数据另行处理）。

### Blocker (3)
- ✅ **accumulated 同步覆盖历史** — `PUT /:id/items/:itemId` 只同步到 status != 'confirmed' 的草稿排机单
- ✅ **confirm 重入重复写 history** — 路由层 + 事务内双重幂等检查
- ✅ **history_records 无唯一约束** — 加 UNIQUE (import_batch, machine_no, order_no, product_code, source_date) + INSERT OR IGNORE

### High (3/4, #7 pending)
- ✅ **删除 DELETE /api/orders 清空路由** — 同步删前端"清空订单"按钮
- ✅ **新机台吨位 fallback** — 无历史数据时按吨位估算啤重区间
- ✅ **Excel 11H 用 DB 值** — 优先 item.target_11h，fallback 才重算
- ⏳ A/C 车间机台 hardcode 另行处理（需业务方提供每台机清单）

### Medium (4)
- ✅ orders 批内去重 (order_no + product_code + mold_no)
- ✅ 结转 shortage 用 DB 值而非重算
- ✅ 同套模结转用 moldBase 对比而非 includes
- ✅ /generate 并发锁（same workshop/date/shift → 429）

### Nit (3)
- ✅ formatDateChinese 时区安全
- ✅ fetchMachines 失败 UI 提示
- ✅ DELETE workshop fallback（随清空路由一起删除）

## Test plan
- [x] 所有 server js 文件语法检查通过
- [ ] 云端 rebuild paiji 容器，/paiji/health 200
- [ ] 手测排机 + 更新 accumulated + confirm 流程
- [ ] 手测 history 重复上传提示跳过
- [ ] 手测 Excel 导出日期/11H 显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)