### PR TITLE
chore: remove ZURU出货助手 + reorder business dept

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,6 @@ curl http://localhost:<port>/health
 | zouhuo | Node.js | 3002 | /zouhuo/ |
 | jiangping | Flask | 5001 | /jiangping/ |
 | paiji | Node.js | 3000 | /paiji/ |
-| zuru-shipment | Flask | 5003 | /zuru-shipment/ |
 | zuru-master-schedule (ZURU总排期入单) | Flask | 5003 | /zuru-master/ |
 | zuru-order-system (ZURU接单表入单系统) | Flask | 5005 | /zuru-order-system/ |
 | quotation 套客表系统 | Node.js | 3004 | /quotation/ |
@@ -340,7 +339,6 @@ const data = JSON.parse(fs.readFileSync('data/data.json'));
 | figure-mold-cost-system | 模具手办采购订单 | Engineering | Standalone (Node.js) | /figure-mold-cost-system/ | https://github.com/hufan4308-blip/figure-mold-cost-system |
 | jiangping | 采购订单管理系统 | PMC跟仓管 | Standalone (Python/Flask) | /jiangping/ | https://github.com/fxxaxxx/jiangping |
 | paiji | AI注塑啤机排产系统 | 生产部 | Standalone (Node.js) | /paiji/ | https://github.com/duanlei10/234 |
-| zuru-shipment-deploy | ZURU出货助手 | 业务部 | Standalone (Python/Flask) | /zuru-shipment/ | https://github.com/hanson678/zuru-shipment-deploy |
 | zuru-master-schedule | ZURU总排期入单 | 业务部 | Standalone (Python/Flask) | /zuru-master/ | (PR #59) |
 | zuru-order-system | ZURU接单表入单系统 | 业务部 | Standalone (Python/Flask) | /zuru-order-system/ | https://github.com/hanson678/zuru-order-system |
 | quotation | 套客表系统 | 业务部 | Standalone (Node.js) | /quotation/ | — |
@@ -357,3 +355,4 @@ const data = JSON.parse(fs.readFileSync('data/data.json'));
 - 印尼小组 (Indonesia) — 2026-03-23
 - business-data-statistics 生产经营数据系统 (总部) — 2026-04-15
 - schedule-system (Production)
+- ZURU出货助手 zuru-shipment-deploy (业务部) — 2026-04-21（源码仍在 apps/zuru-shipment-deploy/，未 git rm，需要恢复时 revert 即可；服务器数据 /opt/rr-portal/apps/zuru-shipment-deploy/data/ 也保留）

--- a/docker-compose.cloud.yml
+++ b/docker-compose.cloud.yml
@@ -268,31 +268,6 @@ services:
     networks:
       - platform-net
 
-  zuru-shipment:
-    build:
-      context: ./apps/zuru-shipment-deploy
-      dockerfile: Dockerfile
-    environment:
-      - PORT=5003
-      - DATA_PATH=/app/data
-    volumes:
-      - ./apps/zuru-shipment-deploy/data:/app/data
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:5003/health"]
-      interval: 10s
-      timeout: 5s
-      retries: 3
-    mem_limit: 512m
-    memswap_limit: 512m
-    restart: unless-stopped
-    logging:
-      driver: json-file
-      options:
-        max-size: "10m"
-        max-file: "3"
-    networks:
-      - platform-net
-
   zuru-master-schedule:
     build:
       context: ./plugins/zuru-总排期入单

--- a/frontend/index.cloud.html
+++ b/frontend/index.cloud.html
@@ -297,14 +297,14 @@
           <div class="plugin-list">
             <div class="plugin-item">
               <div class="plugin-info">
-                <div class="plugin-dot gray" id="zuruDot"></div>
-                <span class="plugin-name">ZURU出货助手</span>
+                <div class="plugin-dot gray" id="zuruOrderDot"></div>
+                <span class="plugin-name">ZURU接单表入单系统</span>
               </div>
             </div>
             <div class="plugin-item">
               <div class="plugin-info">
-                <div class="plugin-dot gray" id="zuruOrderDot"></div>
-                <span class="plugin-name">ZURU接单表入单系统</span>
+                <div class="plugin-dot gray" id="zuruMasterDot"></div>
+                <span class="plugin-name">ZURU总排期入单</span>
               </div>
             </div>
             <div class="plugin-item">
@@ -317,12 +317,6 @@
               <div class="plugin-info">
                 <div class="plugin-dot gray" id="tomyDot"></div>
                 <span class="plugin-name">TOMY排期核对系统</span>
-              </div>
-            </div>
-            <div class="plugin-item">
-              <div class="plugin-info">
-                <div class="plugin-dot gray" id="zuruMasterDot"></div>
-                <span class="plugin-name">ZURU总排期入单</span>
               </div>
             </div>
           </div>
@@ -479,27 +473,7 @@
       <div class="dept-icon business" style="width:40px;height:40px;font-size:18px;">&#128176;</div>
       业务部
     </div>
-    <div class="page-subtitle">ZURU出货 · ZURU接单表入单 · 报价管理 · TOMY排期核对 · ZURU总排期入单</div>
-
-    <div class="detail-plugin-card">
-      <div class="detail-plugin-left">
-        <div class="detail-plugin-icon" style="background:linear-gradient(135deg,#f59e0b,#ef4444);">&#128230;</div>
-        <div>
-          <div class="detail-plugin-name">ZURU出货助手</div>
-          <div class="detail-plugin-desc">上传接单表与出货资料文件夹，自动匹配出货记录并标记日期，支持金额表与库存异常报告</div>
-          <div class="feature-grid">
-            <div class="feature-tag">&#128230; 出货匹配</div>
-            <div class="feature-tag">&#128197; 日期标记</div>
-            <div class="feature-tag">&#128202; 库存报告</div>
-            <div class="feature-tag">&#128196; Excel处理</div>
-          </div>
-        </div>
-      </div>
-      <div class="detail-plugin-right">
-        <div class="detail-plugin-status"><div class="plugin-dot gray" id="zuruDetailDot"></div> 检查中...</div>
-        <a href="/zuru-shipment/" target="_blank" class="btn btn-primary">打开系统</a>
-      </div>
-    </div>
+    <div class="page-subtitle">ZURU接单表入单 · ZURU总排期入单 · 报价管理 · TOMY排期核对</div>
 
     <div class="detail-plugin-card">
       <div class="detail-plugin-left">
@@ -518,6 +492,26 @@
       <div class="detail-plugin-right">
         <div class="detail-plugin-status"><div class="plugin-dot gray" id="zuruOrderDetailDot"></div> 检查中...</div>
         <a href="/zuru-order-system/" target="_blank" class="btn btn-primary">打开系统</a>
+      </div>
+    </div>
+
+    <div class="detail-plugin-card">
+      <div class="detail-plugin-left">
+        <div class="detail-plugin-icon" style="background:linear-gradient(135deg,#f59e0b,#ef4444);">&#128202;</div>
+        <div>
+          <div class="detail-plugin-name">ZURU总排期入单</div>
+          <div class="detail-plugin-desc">上传总排期Excel + 批量PO Excel，自动识别修改单/新单，输出修改明细与新单Excel供粘贴</div>
+          <div class="feature-grid">
+            <div class="feature-tag">&#128196; PO Excel解析</div>
+            <div class="feature-tag">&#128203; 修改单/新单识别</div>
+            <div class="feature-tag">&#128202; 有填充行汇总</div>
+            <div class="feature-tag">&#128230; 新单Excel生成</div>
+          </div>
+        </div>
+      </div>
+      <div class="detail-plugin-right">
+        <div class="detail-plugin-status"><div class="plugin-dot gray" id="zuruMasterDetailDot"></div> 检查中...</div>
+        <a href="/zuru-master/" target="_blank" class="btn btn-primary">打开系统</a>
       </div>
     </div>
 
@@ -558,26 +552,6 @@
       <div class="detail-plugin-right">
         <div class="detail-plugin-status"><div class="plugin-dot gray" id="tomyDetailDot"></div> 检查中...</div>
         <a href="/tomy-paiqi/" target="_blank" class="btn btn-primary">打开系统</a>
-      </div>
-    </div>
-
-    <div class="detail-plugin-card">
-      <div class="detail-plugin-left">
-        <div class="detail-plugin-icon" style="background:linear-gradient(135deg,#f59e0b,#ef4444);">&#128202;</div>
-        <div>
-          <div class="detail-plugin-name">ZURU总排期入单</div>
-          <div class="detail-plugin-desc">上传总排期Excel + 批量PO Excel，自动识别修改单/新单，输出修改明细与新单Excel供粘贴</div>
-          <div class="feature-grid">
-            <div class="feature-tag">&#128196; PO Excel解析</div>
-            <div class="feature-tag">&#128203; 修改单/新单识别</div>
-            <div class="feature-tag">&#128202; 有填充行汇总</div>
-            <div class="feature-tag">&#128230; 新单Excel生成</div>
-          </div>
-        </div>
-      </div>
-      <div class="detail-plugin-right">
-        <div class="detail-plugin-status"><div class="plugin-dot gray" id="zuruMasterDetailDot"></div> 检查中...</div>
-        <a href="/zuru-master/" target="_blank" class="btn btn-primary">打开系统</a>
       </div>
     </div>
   </div>
@@ -711,7 +685,6 @@ async function checkHealth() {
       { name: 'figureMold', url: '/figure-mold-cost-system/health', dot: 'figureMoldDot', detailDot: 'figureMoldDetailDot' },
       { name: 'jiangping', url: '/jiangping/health', dot: 'jiangpingDot', detailDot: 'jiangpingDetailDot' },
       { name: 'paiji', url: '/paiji/health', dot: 'paijiDot', detailDot: 'paijiDetailDot' },
-      { name: 'zuru', url: '/zuru-shipment/health', dot: 'zuruDot', detailDot: 'zuruDetailDot' },
       { name: 'zuruOrder', url: '/zuru-order-system/health', dot: 'zuruOrderDot', detailDot: 'zuruOrderDetailDot' },
       { name: 'liwenjuan', url: '/liwenjuan/health', dot: 'liwenjuanDot', detailDot: 'liwenjuanDetailDot' },
       { name: 'quotation', url: '/quotation/health', dot: 'quotationDot', detailDot: 'quotationDetailDot' },

--- a/nginx/nginx.cloud.conf
+++ b/nginx/nginx.cloud.conf
@@ -81,11 +81,6 @@ http {
         keepalive 4;
     }
 
-    upstream zuru_shipment_backend {
-        server zuru-shipment:5003;
-        keepalive 4;
-    }
-
     upstream zuru_order_system_backend {
         server zuru-order-system:5005;
         keepalive 4;
@@ -426,32 +421,8 @@ http {
             proxy_set_header Connection "";
         }
 
-        # ─── Standalone: ZURU出货助手 (zuru-shipment) ───
-        location = /zuru-shipment {
-            return 301 /zuru-shipment/;
-        }
-        location = /zuru-shipment/health {
-            auth_basic off;
-            proxy_pass http://zuru_shipment_backend/health;
-            proxy_set_header Host $host;
-        }
-        location /zuru-shipment/ {
-            proxy_pass http://zuru_shipment_backend/;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_http_version 1.1;
-            proxy_set_header Connection "";
-            # Large file uploads (500MB for Excel processing)
-            client_max_body_size 500m;
-            # Match gunicorn 300s timeout for large Excel processing
-            proxy_read_timeout 300s;
-            proxy_send_timeout 300s;
-            # SSE support — disable buffering for log streaming
-            proxy_buffering off;
-            proxy_cache off;
-        }
+        # ─── Removed: ZURU出货助手 (zuru-shipment) — 2026-04-21 ───
+        location /zuru-shipment/ { return 404; }
 
         # ─── Standalone: ZURU接单表入单系统 (zuru-order-system) ───
         location = /zuru-order-system {


### PR DESCRIPTION
Remove ZURU出货助手 (zuru-shipment) entirely from runtime. Reorder business dept so all ZURU apps come first.

Source files in apps/zuru-shipment-deploy/ kept for now (not git rm'd) for easy revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)