### PR TITLE
fix: peise Excel NaN crash + huadeng POST redirect 404

### DIFF
--- a/apps/peise/app/services/excel_io.py
+++ b/apps/peise/app/services/excel_io.py
@@ -53,6 +53,22 @@ def _cell_str(v) -> str:
     return str(v).strip()
 
 
+def _cell_float(v) -> float:
+    """Excel 空单元格是 NaN; NaN or 0 在 Python 里仍是 NaN(NaN 是 truthy)，会让
+    后续 SQLite NOT NULL 校验炸。先用 pd.isna() 把 NaN/None 折成 0。"""
+    if v is None:
+        return 0.0
+    try:
+        if pd.isna(v):
+            return 0.0
+    except (TypeError, ValueError):
+        pass
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return 0.0
+
+
 def import_pigments_from_bytes(data: bytes) -> dict:
     """Excel 是 brand="" 正规色粉库的真源:
     - Excel 里出现的 code → 更新/新建,并取消归档
@@ -78,16 +94,10 @@ def import_pigments_from_bytes(data: bytes) -> dict:
                 p = Pigment(brand="", code=code, name=code, spec_unit="kg")
                 db.session.add(p)
             p.purchase_code = _cell_str(row.get("进货色粉编号"))
-            try:
-                p.unit_price = float(row.get("单价") or 0)
-            except (TypeError, ValueError):
-                p.unit_price = 0
+            p.unit_price = _cell_float(row.get("单价"))
             if "备注" in df.columns:
                 p.notes = _cell_str(row.get("备注"))
-            try:
-                qty = float(row.get("数量") or 0)
-            except (TypeError, ValueError):
-                qty = 0
+            qty = _cell_float(row.get("数量"))
             if p.stock is None:
                 p.stock = Stock(quantity=qty)
             else:

--- a/nginx/nginx.cloud.conf
+++ b/nginx/nginx.cloud.conf
@@ -632,6 +632,9 @@ http {
             proxy_set_header Connection "";
             # 禁用 gzip 让 sub_filter 能扫描 response body
             proxy_set_header Accept-Encoding "";
+            # Flask redirect() 返回 Location: /channel/1 (root-relative)，浏览器跳到根路径 → 404
+            # 在 nginx 层把 Location header 加 /huadeng 前缀（同 sub_filter 重写 href 的逻辑）
+            proxy_redirect / /huadeng/;
             client_max_body_size 32m;
             proxy_read_timeout 120s;
             proxy_send_timeout 120s;


### PR DESCRIPTION
Two bugs found in production:

1. **peise Excel import NaN**: Empty Excel cells become NaN, which is truthy in Python. The `float(x or 0)` pattern doesn't catch NaN → SQLite NOT NULL violation. Fixed with `_cell_float()` using `pd.isna()`.

2. **huadeng POST → 404**: Flask app generates root-relative redirects (`Location: /channel/1`) without /huadeng/ prefix. Browser jumps to root → 404 (data IS saved though). Fixed in nginx with `proxy_redirect / /huadeng/;`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)