### PR TITLE
feat(工程啤办单): 啤机部新增总费用表（料费 + 啤办费）

### DIFF
--- a/plugins/工程啤办单/public/injection.html
+++ b/plugins/工程啤办单/public/injection.html
@@ -870,10 +870,13 @@ function renderTotalData() {
       : '';
     const detailRows = (o.items || []).map(it => {
       const matCls = (!it.material_cost || it.material_cost === 0) ? 'text-warning' : '';
-      const injCls = (it.injection_cost === null) ? 'text-warning' : '';
       const matTxt = it.material_cost ? it.material_cost.toFixed(2) : '<i class="bi bi-exclamation-circle"></i> 缺';
-      const injTxt = (it.injection_cost === null) ? '<i class="bi bi-exclamation-circle"></i> 缺' : it.injection_cost.toFixed(2);
-      const itemTotal = (it.material_cost || 0) + (it.injection_cost || 0);
+      // 发至模厂/湖南订单：啤办费显示「—」（N/A），不标红不计合计
+      let injTxt, injCls;
+      if (o.skip_inj) { injTxt = '<span class="text-muted">—</span>'; injCls = ''; }
+      else if (it.injection_cost === null) { injTxt = '<i class="bi bi-exclamation-circle"></i> 缺'; injCls = 'text-warning'; }
+      else { injTxt = it.injection_cost.toFixed(2); injCls = ''; }
+      const itemTotal = (it.material_cost || 0) + (o.skip_inj ? 0 : (it.injection_cost || 0));
       return `<tr class="detail-row" id="${gid}" style="display:none;background:#f8f9ff;font-size:.8rem">
         <td></td>
         <td class="text-muted ps-3">${esc(it.mold_id || '-')}</td>
@@ -893,7 +896,7 @@ function renderTotalData() {
         <td>${esc(o.date ? o.date.slice(5) : '-')}</td>
         <td>${esc(o.workshop || '-')}</td>
         <td class="text-end fw-bold" style="color:${o.total_material_cost ? '#1a6e3a' : '#aaa'}">${o.total_material_cost.toFixed(2)}</td>
-        <td class="text-end fw-bold" style="color:${o.total_injection_cost ? '#1a6e3a' : '#aaa'}">${o.total_injection_cost.toFixed(2)}</td>
+        <td class="text-end fw-bold" style="color:${o.total_injection_cost ? '#1a6e3a' : '#aaa'}">${o.skip_inj ? '<span class="text-muted" title="发至外厂订单不计啤办费">—</span>' : o.total_injection_cost.toFixed(2)}</td>
         <td class="text-end fw-bold" style="color:${o.total_cost ? '#0d6efd' : '#aaa'};font-size:.95rem">${o.total_cost.toFixed(2)}</td>
       </tr>
       ${detailRows}`;

--- a/plugins/工程啤办单/public/injection.html
+++ b/plugins/工程啤办单/public/injection.html
@@ -41,6 +41,11 @@
         <i class="bi bi-cash-coin me-1"></i>啤办费用表
       </button>
     </li>
+    <li class="nav-item">
+      <button class="nav-link" onclick="switchInjTab('total',this)">
+        <i class="bi bi-calculator me-1"></i>总费用表
+      </button>
+    </li>
   </ul>
 
   <!-- ── 任务单 Tab ── -->
@@ -215,6 +220,81 @@
             </thead>
             <tbody id="costBody">
               <tr><td colspan="11" class="text-center text-muted p-3">加载中...</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ── 总费用表 Tab ── -->
+  <div id="injTabTotal" style="display:none">
+    <div class="card shadow-sm">
+      <div class="card-header d-flex justify-content-between align-items-center flex-wrap gap-2">
+        <h6 class="mb-0"><i class="bi bi-calculator me-2"></i>总费用表（料费 + 啤办费）</h6>
+        <div class="d-flex gap-2 flex-wrap align-items-center">
+          <div class="input-group input-group-sm" style="width:150px">
+            <span class="input-group-text"><i class="bi bi-calendar3"></i></span>
+            <input type="month" class="form-control" id="totalMonth" onchange="loadTotalData()">
+          </div>
+          <button class="btn btn-sm btn-outline-warning" onclick="document.getElementById('totalMonth').value='';loadTotalData()" title="显示全部月份">全部</button>
+          <select id="totalWorkshop" class="form-select form-select-sm" style="width:auto" onchange="renderTotalData()">
+            <option value="">全部车间</option>
+            <option value="A车间">A车间</option>
+            <option value="B车间">B车间</option>
+            <option value="华登车间">华登车间</option>
+          </select>
+          <div class="input-group input-group-sm" style="width:180px">
+            <span class="input-group-text"><i class="bi bi-search"></i></span>
+            <input type="text" class="form-control" id="totalProductSearch"
+              placeholder="搜索产品编号..." oninput="renderTotalData()" autocomplete="off">
+            <button class="btn btn-outline-secondary"
+              onclick="document.getElementById('totalProductSearch').value='';renderTotalData()" title="清除">
+              <i class="bi bi-x-lg"></i>
+            </button>
+          </div>
+          <div class="input-group input-group-sm" style="width:180px">
+            <span class="input-group-text"><i class="bi bi-box-seam"></i></span>
+            <input type="text" class="form-control" id="totalOrderSearch"
+              placeholder="搜索订单编号..." oninput="renderTotalData()" autocomplete="off">
+            <button class="btn btn-outline-secondary"
+              onclick="document.getElementById('totalOrderSearch').value='';renderTotalData()" title="清除">
+              <i class="bi bi-x-lg"></i>
+            </button>
+          </div>
+          <select id="totalClientFilter" class="form-select form-select-sm" style="width:auto" onchange="renderTotalData()">
+            <option value="">全部客户</option>
+          </select>
+          <div class="form-check form-check-inline ms-1">
+            <input type="checkbox" id="totalOnlyMissing" class="form-check-input" onchange="renderTotalData()">
+            <label for="totalOnlyMissing" class="form-check-label small">只看缺料价/缺啤办费</label>
+          </div>
+          <button class="btn btn-sm btn-outline-secondary" onclick="loadTotalData()">
+            <i class="bi bi-arrow-clockwise me-1"></i>刷新数据
+          </button>
+          <button class="btn btn-sm btn-outline-primary" onclick="printTable('total')">
+            <i class="bi bi-printer me-1"></i>打印
+          </button>
+        </div>
+      </div>
+      <div class="card-body p-0">
+        <div class="table-responsive">
+          <table class="table table-bordered table-sm mb-0" id="totalTable">
+            <thead class="table-dark text-center" style="font-size:.82rem">
+              <tr>
+                <th style="width:46px">序号</th>
+                <th>产品编号</th>
+                <th>产品名称</th>
+                <th>客名</th>
+                <th>日期</th>
+                <th>车间</th>
+                <th style="width:120px">料费合计<br><small>(HKD)</small></th>
+                <th style="width:120px">啤办费合计<br><small>(HKD)</small></th>
+                <th style="width:130px">总合计<br><small>(HKD)</small></th>
+              </tr>
+            </thead>
+            <tbody id="totalBody">
+              <tr><td colspan="9" class="text-center text-muted p-3">加载中...</td></tr>
             </tbody>
           </table>
         </div>
@@ -684,8 +764,10 @@ function switchInjTab(name, el) {
   document.getElementById('injTabOrders').style.display = name === 'orders' ? '' : 'none';
   document.getElementById('injTabStats').style.display  = name === 'stats'  ? '' : 'none';
   document.getElementById('injTabCost').style.display   = name === 'cost'   ? '' : 'none';
+  document.getElementById('injTabTotal').style.display  = name === 'total'  ? '' : 'none';
   if (name === 'stats') loadStats();
   if (name === 'cost')  loadCostData();
+  if (name === 'total') loadTotalData();
 }
 
 // ── 原料汇总表（只读）──────────────────────────────────────────────────────
@@ -734,6 +816,107 @@ function loadStats() {
     });
     renderStats();
   });
+}
+
+// ── 总费用表（料费 + 啤办费） ────────────────────────────────────────────────
+let totalData = [];
+
+function loadTotalData() {
+  const month = document.getElementById('totalMonth')?.value || '';
+  const url = month ? `/api/injection-total-costs?month=${month}` : '/api/injection-total-costs';
+  apiFetch(url).then(r => r.json()).then(items => {
+    totalData = items;
+    // 客户下拉初始化
+    const sel = document.getElementById('totalClientFilter');
+    const prev = sel.value;
+    const clients = [...new Set(items.map(it => it.client_name).filter(Boolean))].sort();
+    sel.innerHTML = '<option value="">全部客户</option>' + clients.map(c => `<option value="${esc(c)}">${esc(c)}</option>`).join('');
+    sel.value = prev;
+    renderTotalData();
+  });
+}
+
+function renderTotalData() {
+  const ws = document.getElementById('totalWorkshop')?.value || '';
+  const pq = (document.getElementById('totalProductSearch')?.value || '').trim().toLowerCase();
+  const oq = (document.getElementById('totalOrderSearch')?.value || '').trim().toLowerCase();
+  const cq = document.getElementById('totalClientFilter')?.value || '';
+  const onlyMissing = document.getElementById('totalOnlyMissing')?.checked;
+  let filtered = totalData;
+  if (ws) filtered = filtered.filter(it => it.workshop === ws);
+  if (pq) filtered = filtered.filter(it => (it.doc_number || '').toLowerCase().includes(pq));
+  if (oq) filtered = filtered.filter(it => (it.order_number || '').toLowerCase().includes(oq));
+  if (cq) filtered = filtered.filter(it => (it.client_name || '') === cq);
+  if (onlyMissing) filtered = filtered.filter(it => it.has_missing_price || it.has_missing_injection_cost);
+
+  const hasFilter = ws || pq || oq || cq || onlyMissing;
+  const body = document.getElementById('totalBody');
+  if (!filtered.length) {
+    body.innerHTML = `<tr><td colspan="9" class="text-center text-muted p-3">${hasFilter ? '没有匹配的订单' : '暂无数据'}</td></tr>`;
+    return;
+  }
+
+  let gMat = 0, gInj = 0, gTotal = 0;
+  const rows = filtered.map((o, i) => {
+    gMat += o.total_material_cost || 0;
+    gInj += o.total_injection_cost || 0;
+    gTotal += o.total_cost || 0;
+    const gid = `tg${i}`;
+    const badgeMat = o.has_missing_price
+      ? ' <span class="badge bg-warning text-dark ms-1" style="font-size:.65rem" title="部分原料未录入价格"><i class="bi bi-exclamation-circle"></i> 料价缺</span>'
+      : '';
+    const badgeInj = o.has_missing_injection_cost
+      ? ' <span class="badge bg-warning text-dark ms-1" style="font-size:.65rem" title="部分模具未填写啤办费"><i class="bi bi-exclamation-circle"></i> 啤办费缺</span>'
+      : '';
+    const detailRows = (o.items || []).map(it => {
+      const matCls = (!it.material_cost || it.material_cost === 0) ? 'text-warning' : '';
+      const injCls = (it.injection_cost === null) ? 'text-warning' : '';
+      const matTxt = it.material_cost ? it.material_cost.toFixed(2) : '<i class="bi bi-exclamation-circle"></i> 缺';
+      const injTxt = (it.injection_cost === null) ? '<i class="bi bi-exclamation-circle"></i> 缺' : it.injection_cost.toFixed(2);
+      const itemTotal = (it.material_cost || 0) + (it.injection_cost || 0);
+      return `<tr class="detail-row" id="${gid}" style="display:none;background:#f8f9ff;font-size:.8rem">
+        <td></td>
+        <td class="text-muted ps-3">${esc(it.mold_id || '-')}</td>
+        <td>${esc(it.mold_name || '-')}</td>
+        <td class="text-muted" colspan="3">${esc(it.material || '-')}</td>
+        <td class="text-end ${matCls}">${matTxt}</td>
+        <td class="text-end ${injCls}">${injTxt}</td>
+        <td class="text-end fw-bold">${itemTotal ? itemTotal.toFixed(2) : '0.00'}</td>
+      </tr>`;
+    }).join('');
+    return `
+      <tr style="cursor:pointer" onclick="toggleTotalGroup('${gid}',this)">
+        <td class="text-center text-muted" style="font-size:.8rem">${i + 1}</td>
+        <td><strong>${esc(o.order_number || '-')}</strong>&nbsp;<i class="bi bi-chevron-down toggle-icon-${gid}" style="font-size:.7rem;color:#888"></i></td>
+        <td>${esc(o.product_name || '-')}${badgeMat}${badgeInj}</td>
+        <td>${esc(o.client_name || '-')}</td>
+        <td>${esc(o.date ? o.date.slice(5) : '-')}</td>
+        <td>${esc(o.workshop || '-')}</td>
+        <td class="text-end fw-bold" style="color:${o.total_material_cost ? '#1a6e3a' : '#aaa'}">${o.total_material_cost.toFixed(2)}</td>
+        <td class="text-end fw-bold" style="color:${o.total_injection_cost ? '#1a6e3a' : '#aaa'}">${o.total_injection_cost.toFixed(2)}</td>
+        <td class="text-end fw-bold" style="color:${o.total_cost ? '#0d6efd' : '#aaa'};font-size:.95rem">${o.total_cost.toFixed(2)}</td>
+      </tr>
+      ${detailRows}`;
+  });
+
+  const missing = filtered.filter(it => it.has_missing_price || it.has_missing_injection_cost).length;
+  const hint = hasFilter ? `（匹配 ${filtered.length} 个订单${missing ? '，其中 ' + missing + ' 个有缺项' : ''}）` : `（共 ${filtered.length} 个订单${missing ? '，其中 ' + missing + ' 个有缺项' : ''}）`;
+  body.innerHTML = rows.join('') + `
+    <tr style="font-weight:700;background:#f0f7f0">
+      <td colspan="6" class="text-end">合计${hint}</td>
+      <td class="text-end" style="color:#1a6e3a">${gMat.toFixed(2)}</td>
+      <td class="text-end" style="color:#1a6e3a">${gInj.toFixed(2)}</td>
+      <td class="text-end" style="color:#0d6efd">${gTotal.toFixed(2)}</td>
+    </tr>`;
+}
+
+function toggleTotalGroup(gid, summaryRow) {
+  const rows = document.querySelectorAll(`tr[id="${gid}"]`);
+  const icon = summaryRow.querySelector(`.toggle-icon-${gid}`);
+  const isOpen = rows[0]?.style.display !== 'none';
+  rows.forEach(r => r.style.display = isOpen ? 'none' : '');
+  if (icon) icon.className = isOpen ? `bi bi-chevron-down toggle-icon-${gid}` : `bi bi-chevron-up toggle-icon-${gid}`;
+  if (icon) icon.style.cssText = 'font-size:.7rem;color:#888';
 }
 
 // ── 啤办费用表 ──────────────────────────────────────────────────────────────
@@ -862,14 +1045,19 @@ function renderStats() {
 // ── 打印汇总表 ──────────────────────────────────────────────────────────────
 function printTable(type) {
   const isStats = type === 'stats';
-  const title = isStats ? '工程原料汇总表' : '啤办费用表';
+  const isTotal = type === 'total';
+  const title = isStats ? '工程原料汇总表' : (isTotal ? '总费用表' : '啤办费用表');
   const month = isStats
     ? (document.getElementById('matMonth')?.value || '')
-    : (document.getElementById('costMonth')?.value || '');
+    : (isTotal ? (document.getElementById('totalMonth')?.value || '') : (document.getElementById('costMonth')?.value || ''));
   const monthLabel = month || '全部';
 
   let tableHtml;
-  if (isStats) {
+  if (isTotal) {
+    const tableEl = document.getElementById('totalTable');
+    if (!tableEl) return;
+    tableHtml = tableEl.outerHTML;
+  } else if (isStats) {
     // 原料汇总表：只打印有使用量的原料
     const used = statsData.filter(s => s.total_actual_weight > 0 || s.total_amount > 0);
     let tw = 0, ta = 0;

--- a/plugins/工程啤办单/server.js
+++ b/plugins/工程啤办单/server.js
@@ -598,23 +598,25 @@ app.get('/api/injection-total-costs', (req, res) => {
   const priceMap = buildPriceMap(data.material_prices);
   const result = orders.map(o => {
     const orderItems = items.filter(i => i.order_id === o.id).sort((a,b) => a.sort_order - b.sort_order);
+    // 发至模厂/发至湖南（或车间=模厂）的订单不统计啤办费，也不提示缺项
+    const skipInjCost = o.send_to === '发至模厂' || o.send_to === '发至湖南' || o.workshop === '模厂';
     let totalMat = 0, totalInj = 0, hasMissingPrice = false, hasMissingInj = false;
     const details = orderItems.map(it => {
       const mat = +(it.actual_amount_hkd || 0);
       const injRaw = it.injection_cost;
       const inj = +(injRaw || 0);
       totalMat += mat;
-      totalInj += inj;
+      if (!skipInjCost) totalInj += inj;
       // 料价缺：有材料名但模糊解析找不到价格
       if (it.material && resolvePrice(it.material, priceMap) <= 0) hasMissingPrice = true;
-      // 啤办费缺：没有填写（null/undefined/空字符串）
-      if (injRaw === null || injRaw === undefined || injRaw === '') hasMissingInj = true;
+      // 啤办费缺：没有填写（null/undefined/空字符串），发至订单除外
+      if (!skipInjCost && (injRaw === null || injRaw === undefined || injRaw === '')) hasMissingInj = true;
       return {
         mold_id: it.mold_id || '',
         mold_name: it.mold_name || '',
         material: it.material || '',
         material_cost: Math.round(mat * 100) / 100,
-        injection_cost: (injRaw === null || injRaw === undefined || injRaw === '') ? null : inj
+        injection_cost: skipInjCost ? null : ((injRaw === null || injRaw === undefined || injRaw === '') ? null : inj)
       };
     });
     return {

--- a/plugins/工程啤办单/server.js
+++ b/plugins/工程啤办单/server.js
@@ -587,6 +587,55 @@ app.get('/api/material-stats', (req, res) => {
 });
 
 // ─── 啤办费用汇总 ─────────────────────────────────────────────────────────────
+// ─── 啤办总费用汇总（料费 + 啤办费） ─────────────────────────────────────────
+app.get('/api/injection-total-costs', (req, res) => {
+  const data = loadData();
+  const month = req.query.month;
+  const APPROVED = ['待生产','生产中','已完成','已取消'];
+  let orders = (data.injection_orders || []).filter(o => APPROVED.includes(o.status));
+  if (month) orders = orders.filter(o => (o.date || '').startsWith(month));
+  const items = data.injection_items || [];
+  const priceMap = buildPriceMap(data.material_prices);
+  const result = orders.map(o => {
+    const orderItems = items.filter(i => i.order_id === o.id).sort((a,b) => a.sort_order - b.sort_order);
+    let totalMat = 0, totalInj = 0, hasMissingPrice = false, hasMissingInj = false;
+    const details = orderItems.map(it => {
+      const mat = +(it.actual_amount_hkd || 0);
+      const injRaw = it.injection_cost;
+      const inj = +(injRaw || 0);
+      totalMat += mat;
+      totalInj += inj;
+      // 料价缺：有材料名但模糊解析找不到价格
+      if (it.material && resolvePrice(it.material, priceMap) <= 0) hasMissingPrice = true;
+      // 啤办费缺：没有填写（null/undefined/空字符串）
+      if (injRaw === null || injRaw === undefined || injRaw === '') hasMissingInj = true;
+      return {
+        mold_id: it.mold_id || '',
+        mold_name: it.mold_name || '',
+        material: it.material || '',
+        material_cost: Math.round(mat * 100) / 100,
+        injection_cost: (injRaw === null || injRaw === undefined || injRaw === '') ? null : inj
+      };
+    });
+    return {
+      order_number: o.order_number || '',
+      product_name: o.product_name || '',
+      client_name: o.client_name || '',
+      doc_number: o.doc_number || '',
+      date: o.date || '',
+      workshop: o.workshop || '',
+      status: o.status,
+      total_material_cost: Math.round(totalMat * 100) / 100,
+      total_injection_cost: Math.round(totalInj * 100) / 100,
+      total_cost: Math.round((totalMat + totalInj) * 100) / 100,
+      has_missing_price: hasMissingPrice,
+      has_missing_injection_cost: hasMissingInj,
+      items: details
+    };
+  });
+  res.json(result);
+});
+
 app.get('/api/injection-costs', (req, res) => {
   const data = loadData();
   const month = req.query.month; // optional YYYY-MM filter

--- a/plugins/工程啤办单/server.js
+++ b/plugins/工程啤办单/server.js
@@ -626,6 +626,8 @@ app.get('/api/injection-total-costs', (req, res) => {
       doc_number: o.doc_number || '',
       date: o.date || '',
       workshop: o.workshop || '',
+      send_to: o.send_to || '',
+      skip_inj: skipInjCost,
       status: o.status,
       total_material_cost: Math.round(totalMat * 100) / 100,
       total_injection_cost: Math.round(totalInj * 100) / 100,


### PR DESCRIPTION
## Summary
- 后端 `GET /api/injection-total-costs`：按订单聚合料费 + 啤办费，返回总合计及缺项标记
- 前端啤机部新增「总费用表」Tab，列：产品编号/产品名/客名/日期/车间/料费合计/啤办费合计/**总合计**
- 点击行展开每模明细（mold_id/mold_name/原料/料费/啤办费/行合计）
- 筛选与现有 Tab 一致（月份/车间/产品/订单/客户）+ 新增「只看缺料价/缺啤办费」
- 缺料价 🟡 料价缺徽章；缺啤办费 🟡 啤办费缺徽章
- **发至模厂/发至湖南订单**（或车间=模厂）不统计啤办费，列显示 `—`（N/A）以区分「填了 0」与「缺填」
- 支持打印（A4 横向，沿用现有 printTable 流程）

## Changed files
- `plugins/工程啤办单/server.js` — 新增 total-costs 端点
- `plugins/工程啤办单/public/injection.html` — 新 Tab + 渲染 + 筛选 + 打印

## Test plan
- [ ] 啤机部 → 总费用表 Tab，看到所有订单的料费/啤办费/总合计三列
- [ ] 点击订单展开 → 显示该订单每模明细与行合计
- [ ] 切换月份/车间/客户筛选 → 数据正确过滤
- [ ] 勾选「只看缺料价/缺啤办费」→ 只显示缺项订单
- [ ] 发至模厂/湖南订单 → 啤办费列显示 `—`，不显示「啤办费缺」徽章
- [ ] 料费/啤办费缺的订单 → 对应黄色徽章正确显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)