### PR TITLE
feat(peise): 重命名 Excel 列名 + OCR 入库自动匹配累加已有色粉

### DIFF
--- a/apps/peise/app/routes/transactions.py
+++ b/apps/peise/app/routes/transactions.py
@@ -194,16 +194,28 @@ def _ocr_submit(tx_type: str):
                 failed += 1
                 errors.append(f"第{i+1}行:{e}")
             continue
-        # 未匹配:自动新建。new_code 填了就用作 code,否则留空待复核
+        # 未匹配:先按 (new_code 填了优先,否则 purchase_code) 二次精确匹配已有色粉;
+        # 找到 → 累加到已有色粉;找不到 → 新建 brand="未分类" 待复核
         new_code = new_codes[i].strip() if i < len(new_codes) else ""
         purchase_code = purchase_codes[i].strip() if i < len(purchase_codes) else ""
-        code = new_code
+        code = new_code or purchase_code
         if code:
-            base, n = code, 1
-            while Pigment.query.filter_by(brand="未分类", code=code).first():
-                n += 1
-                code = f"{base}-{n}"
-        display_name = code or purchase_code or f"待填-{datetime.now():%H%M%S}"
+            # 二次匹配:先按 code 精确匹配(对应用户原话"色粉编号相同=一致"),
+            # 没找到再按 purchase_code 匹配(对应"进货编号相同也视为同一色粉")
+            existing = Pigment.query.filter_by(code=code, is_archived=False).first()
+            if existing is None:
+                existing = Pigment.query.filter_by(purchase_code=code, is_archived=False).first()
+            if existing:
+                try:
+                    stock_in(existing.id, float(qty),
+                             unit_price=float(price) if price else None,
+                             note="拍照识别(进货编号精确匹配)")
+                    success += 1
+                except Exception as e:
+                    failed += 1
+                    errors.append(f"第{i+1}行:{e}")
+                continue
+        display_name = code or f"待填-{datetime.now():%H%M%S}"
         try:
             pigment = Pigment(
                 brand="未分类",
@@ -211,7 +223,7 @@ def _ocr_submit(tx_type: str):
                 name=display_name,
                 purchase_code=purchase_code,
                 unit_price=float(price) if price else 0,
-                notes="OCR 自动新建,待复核" if not code else "",
+                notes="OCR 自动新建,待复核" if not new_code else "",
             )
             db.session.add(pigment)
             db.session.flush()

--- a/apps/peise/app/services/excel_io.py
+++ b/apps/peise/app/services/excel_io.py
@@ -3,7 +3,7 @@ import pandas as pd
 from app.models import Pigment, Stock
 from app.extensions import db
 
-COLUMNS = ["色粉编号", "进货色粉编号", "数量", "单位", "单价", "金额", "备注"]
+COLUMNS = ["色粉编号", "进货编号", "库存KG", "单价", "金额"]
 
 
 def _fmt_num(v: float) -> float:
@@ -18,12 +18,10 @@ def export_pigments_to_bytes() -> bytes:
         price = _fmt_num(p.unit_price)
         rows.append({
             "色粉编号": p.code,
-            "进货色粉编号": p.purchase_code or "",
-            "数量": qty,
-            "单位": "KG",
+            "进货编号": p.purchase_code or "",
+            "库存KG": qty,
             "单价": price,
             "金额": round(qty * price, 2),
-            "备注": p.notes or "",
         })
     df = pd.DataFrame(rows, columns=COLUMNS)
     buf = io.BytesIO()
@@ -93,11 +91,9 @@ def import_pigments_from_bytes(data: bytes) -> dict:
             if is_new:
                 p = Pigment(brand="", code=code, name=code, spec_unit="kg")
                 db.session.add(p)
-            p.purchase_code = _cell_str(row.get("进货色粉编号"))
+            p.purchase_code = _cell_str(row.get("进货编号"))
             p.unit_price = _cell_float(row.get("单价"))
-            if "备注" in df.columns:
-                p.notes = _cell_str(row.get("备注"))
-            qty = _cell_float(row.get("数量"))
+            qty = _cell_float(row.get("库存KG"))
             if p.stock is None:
                 p.stock = Stock(quantity=qty)
             else:

--- a/apps/peise/app/services/excel_io.py
+++ b/apps/peise/app/services/excel_io.py
@@ -5,6 +5,34 @@ from app.extensions import db
 
 COLUMNS = ["色粉编号", "进货编号", "库存KG", "单价", "金额"]
 
+# 向后兼容：用户手上的旧 Excel 列名 → 新列名
+# 导出永远用新列名；导入同时接受两者，避免用户历史 Excel 被静默清空
+_LEGACY_COL_ALIASES = {
+    "进货编号": ["进货色粉编号"],
+    "库存KG": ["数量"],
+}
+
+
+def _row_get(row, col: str):
+    """Excel 导入取列值：先试新列名，落空回退历史列名。"""
+    v = row.get(col)
+    # pd.isna 会对字符串报 TypeError，用 _cell_str / _cell_float 前先判 None/NaN
+    if v is not None:
+        try:
+            if not pd.isna(v):
+                return v
+        except (TypeError, ValueError):
+            return v
+    for legacy in _LEGACY_COL_ALIASES.get(col, []):
+        lv = row.get(legacy)
+        if lv is not None:
+            try:
+                if not pd.isna(lv):
+                    return lv
+            except (TypeError, ValueError):
+                return lv
+    return None
+
 
 def _fmt_num(v: float) -> float:
     return round(float(v or 0), 6)
@@ -91,9 +119,9 @@ def import_pigments_from_bytes(data: bytes) -> dict:
             if is_new:
                 p = Pigment(brand="", code=code, name=code, spec_unit="kg")
                 db.session.add(p)
-            p.purchase_code = _cell_str(row.get("进货编号"))
+            p.purchase_code = _cell_str(_row_get(row, "进货编号"))
             p.unit_price = _cell_float(row.get("单价"))
-            qty = _cell_float(row.get("库存KG"))
+            qty = _cell_float(_row_get(row, "库存KG"))
             if p.stock is None:
                 p.stock = Stock(quantity=qty)
             else:

--- a/apps/peise/app/templates/pigments/form.html
+++ b/apps/peise/app/templates/pigments/form.html
@@ -3,7 +3,7 @@
 <h3>{{ "编辑" if pigment else "新增" }}色粉</h3>
 <form method="post" class="row g-3" style="max-width:720px">
   <div class="col-md-6"><label>色粉编号</label><input name="code" class="form-control" value="{{ pigment.code if pigment else '' }}" required></div>
-  <div class="col-md-6"><label>进货色粉编号</label><input name="purchase_code" class="form-control" value="{{ pigment.purchase_code if pigment else '' }}"></div>
+  <div class="col-md-6"><label>进货编号</label><input name="purchase_code" class="form-control" value="{{ pigment.purchase_code if pigment else '' }}"></div>
   <div class="col-md-4"><label>数量</label><input type="number" step="0.0001" id="qty" name="quantity" class="form-control" value="{{ '%.4f'|format(pigment.stock.quantity) if pigment and pigment.stock else '0' }}" min="0"></div>
   <div class="col-md-3"><label>单价(元)</label><input type="number" step="0.01" id="price" name="unit_price" class="form-control" value="{{ '%.2f'|format(pigment.unit_price) if pigment else '0.00' }}"></div>
   <div class="col-md-2"><label>单位</label><input class="form-control" value="KG" readonly></div>

--- a/apps/peise/app/templates/pigments/form.html
+++ b/apps/peise/app/templates/pigments/form.html
@@ -4,7 +4,7 @@
 <form method="post" class="row g-3" style="max-width:720px">
   <div class="col-md-6"><label>色粉编号</label><input name="code" class="form-control" value="{{ pigment.code if pigment else '' }}" required></div>
   <div class="col-md-6"><label>进货编号</label><input name="purchase_code" class="form-control" value="{{ pigment.purchase_code if pigment else '' }}"></div>
-  <div class="col-md-4"><label>数量</label><input type="number" step="0.0001" id="qty" name="quantity" class="form-control" value="{{ '%.4f'|format(pigment.stock.quantity) if pigment and pigment.stock else '0' }}" min="0"></div>
+  <div class="col-md-4"><label>库存KG</label><input type="number" step="0.0001" id="qty" name="quantity" class="form-control" value="{{ '%.4f'|format(pigment.stock.quantity) if pigment and pigment.stock else '0' }}" min="0"></div>
   <div class="col-md-3"><label>单价(元)</label><input type="number" step="0.01" id="price" name="unit_price" class="form-control" value="{{ '%.2f'|format(pigment.unit_price) if pigment else '0.00' }}"></div>
   <div class="col-md-2"><label>单位</label><input class="form-control" value="KG" readonly></div>
   <div class="col-md-3"><label>金额(元)</label><input id="amount" class="form-control" value="0.00" readonly></div>

--- a/apps/peise/app/templates/pigments/index.html
+++ b/apps/peise/app/templates/pigments/index.html
@@ -10,7 +10,7 @@
   </div>
 </div>
 <table class="table table-hover dt">
-  <thead><tr><th>色粉编号</th><th>进货色粉编号</th><th>当前库存(kg)</th><th>单价(元/kg)</th><th>库存金额</th><th>操作</th></tr></thead>
+  <thead><tr><th>色粉编号</th><th>进货编号</th><th>库存KG</th><th>单价</th><th>金额</th><th>操作</th></tr></thead>
   <tbody>
     {% for p in pigments %}
       {% set qty = p.stock.quantity if p.stock else 0 %}

--- a/apps/peise/app/templates/transactions/in_ocr.html
+++ b/apps/peise/app/templates/transactions/in_ocr.html
@@ -9,7 +9,7 @@
   <a href="{{ url_for('transactions.in_list') }}" class="btn btn-secondary">取消</a>
 </form>
 {% else %}
-<p>共识别出 <strong>{{ rows|length }}</strong> 行。请核对后提交,不需要的行点"删"移除。<br><small class="text-muted">已匹配库存的行显示 <span class="badge bg-success-subtle text-success-emphasis">→ 编号</span>;未匹配的行可手填"色粉编号",留空则自动新建待复核色粉。</small></p>
+<p>共识别出 <strong>{{ rows|length }}</strong> 行。请核对后提交,不需要的行点"删"移除。<br><small class="text-muted">已匹配库存的行显示 <span class="badge bg-success-subtle text-success-emphasis">→ 编号</span>;未匹配的行可手填"色粉编号",留空则按"进货色粉编号"再查一次:匹到则累加,匹不到则新建待复核。</small></p>
 <form method="post" action="{{ url_for('transactions.in_ocr_submit') }}">
   <table class="table table-sm" id="ocrTable">
     <thead><tr><th>进货色粉编号</th><th>色粉编号</th><th>数量(kg)</th><th>单价</th><th style="width:25%">识别文本</th><th></th></tr></thead>

--- a/apps/peise/app/templates/transactions/in_ocr.html
+++ b/apps/peise/app/templates/transactions/in_ocr.html
@@ -2,17 +2,17 @@
 {% block content %}
 <h3>拍照识别入库单</h3>
 {% if rows is none %}
-<p class="text-muted">上传进货单据照片(jpg/png),系统会自动识别色粉编号、数量、单价。识别后可在表格中核对修改,再一键批量入库。</p>
+<p class="text-muted">上传进货单据照片(jpg/png),系统会自动识别色粉编号、库存KG、单价。识别后可在表格中核对修改,再一键批量入库。</p>
 <form method="post" enctype="multipart/form-data" class="mb-3" style="max-width:500px">
   <input type="file" name="file" accept="image/*" class="form-control mb-2" required>
   <button class="btn btn-primary"><i class="bi bi-camera"></i> 上传识别</button>
   <a href="{{ url_for('transactions.in_list') }}" class="btn btn-secondary">取消</a>
 </form>
 {% else %}
-<p>共识别出 <strong>{{ rows|length }}</strong> 行。请核对后提交,不需要的行点"删"移除。<br><small class="text-muted">已匹配库存的行显示 <span class="badge bg-success-subtle text-success-emphasis">→ 编号</span>;未匹配的行可手填"色粉编号",留空则按"进货色粉编号"再查一次:匹到则累加,匹不到则新建待复核。</small></p>
+<p>共识别出 <strong>{{ rows|length }}</strong> 行。请核对后提交,不需要的行点"删"移除。<br><small class="text-muted">已匹配库存的行显示 <span class="badge bg-success-subtle text-success-emphasis">→ 编号</span>;未匹配的行可手填"色粉编号",留空则按"进货编号"再查一次:匹到则累加(相同色粉编号或进货编号视为同一色粉,不分品牌),匹不到则新建待复核。</small></p>
 <form method="post" action="{{ url_for('transactions.in_ocr_submit') }}">
   <table class="table table-sm" id="ocrTable">
-    <thead><tr><th>进货色粉编号</th><th>色粉编号</th><th>数量(kg)</th><th>单价</th><th style="width:25%">识别文本</th><th></th></tr></thead>
+    <thead><tr><th>进货编号</th><th>色粉编号</th><th>库存KG</th><th>单价</th><th style="width:25%">识别文本</th><th></th></tr></thead>
     <tbody>
       {% for r in rows %}
       <tr>

--- a/apps/peise/scripts/sim_ocr_import.py
+++ b/apps/peise/scripts/sim_ocr_import.py
@@ -1,0 +1,163 @@
+"""
+模拟 OCR 识别送货单 → 按新逻辑入库的端到端演示。
+
+跳过真正的 LLM 调用,直接构造"OCR 识别后的 rows",
+驱动 /transactions/in/ocr/submit 这个真实的 Flask 路由,
+打印前后 DB 状态对比。
+
+用独立临时 SQLite,不影响 instance/peise.db。
+
+运行: python scripts/sim_ocr_import.py
+"""
+import os
+import sys
+import tempfile
+
+# peise 根目录加到 sys.path,让 `from app import ...` 能找到
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+# Windows 控制台中文不乱码
+if sys.stdout.encoding and sys.stdout.encoding.lower() != "utf-8":
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")
+        sys.stderr.reconfigure(encoding="utf-8")
+    except Exception:
+        pass
+
+from werkzeug.datastructures import MultiDict
+
+os.environ.setdefault("OPENROUTER_API_KEY", "fake-not-called-in-this-script")
+
+# 用一个临时 sqlite 文件,不碰本地开发 DB
+_tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+_tmp.close()
+TMP_DB = _tmp.name
+
+from app.config import Config
+
+
+class DemoConfig(Config):
+    SQLALCHEMY_DATABASE_URI = f"sqlite:///{TMP_DB}"
+    SECRET_KEY = "demo"
+
+
+from app import create_app
+from app.extensions import db
+from app.models import Pigment, Stock, Transaction
+from app.services.inventory import stock_in
+
+app = create_app(DemoConfig)
+
+
+def dump_pigments(label: str):
+    print(f"\n========== {label} ==========")
+    print(f"{'brand':<8}{'code':<10}{'purchase':<10}{'qty':>8}{'price':>8}  notes")
+    print("-" * 70)
+    for p in Pigment.query.order_by(Pigment.brand, Pigment.code).all():
+        qty = p.stock.quantity if p.stock else 0
+        notes = (p.notes or "")[:25]
+        print(f"{p.brand:<8}{p.code:<10}{p.purchase_code:<10}{qty:>8.2f}{p.unit_price:>8.2f}  {notes}")
+
+
+def dump_transactions():
+    print(f"\n---------- 流水(按 id 顺序) ----------")
+    for tx in Transaction.query.order_by(Transaction.id).all():
+        p = Pigment.query.get(tx.pigment_id)
+        code = f"{p.brand}/{p.code}" if p else "?"
+        price = tx.unit_price if tx.unit_price else 0
+        print(f"  #{tx.id} [{tx.type}] → {code:<16} qty={tx.quantity:>6} price={price:>6}  note='{tx.note}'")
+
+
+with app.app_context():
+    # ==== Step 1: seed 3 个"正规"色粉 + 每个初始入库 10kg ====
+    print("\n【Step 1】seed 3 个正规色粉,各入库 10kg")
+    for d in [
+        dict(code="P001", name="红色粉", purchase_code="S001", unit_price=50.0),
+        dict(code="P002", name="蓝色粉", purchase_code="S002", unit_price=80.0),
+        dict(code="P003", name="绿色粉", purchase_code="",     unit_price=30.0),
+    ]:
+        p = Pigment(brand="", spec_unit="kg", **d)
+        db.session.add(p)
+    db.session.commit()
+    for p in Pigment.query.all():
+        stock_in(p.id, 10.0, unit_price=p.unit_price, note="初始化")
+
+    dump_pigments("初始状态(每种 10kg)")
+
+with app.test_client() as client:
+    # ==== Step 2: 模拟 OCR 识别出的 4 行,POST 到 /transactions/in/ocr/submit ====
+    print("\n\n【Step 2】模拟 OCR 识别一张送货单,共 4 行明细:")
+    print("  行1: OCR 已匹配到 P001 (pigment_id 提前填好)       → 应累加到 P001")
+    print("  行2: OCR 没匹上; new_code 留空; purchase_code=S002 (对上 P002 的进货编号)")
+    print("       → 新逻辑: 按 purchase_code 二次匹配 → 累加到 P002,不新建")
+    print("  行3: OCR 没匹上; new_code 留空; purchase_code=S999 (查不到)")
+    print("       → 新逻辑: 用 purchase_code 作 code, 新建 未分类/S999 待复核")
+    print("  行4: OCR 没匹上; new_code=P001 手填")
+    print("       → 新逻辑: 查到已有 P001, 累加(跨品牌匹配)")
+
+    with app.app_context():
+        p001 = Pigment.query.filter_by(brand="", code="P001").first()
+        p001_id = p001.id
+
+    form = MultiDict([
+        # 行1
+        ("pigment_id[]", str(p001_id)),
+        ("purchase_code[]", "S001"),
+        ("new_code[]", ""),
+        ("quantity[]", "5"),
+        ("unit_price[]", "50"),
+        # 行2
+        ("pigment_id[]", ""),
+        ("purchase_code[]", "S002"),
+        ("new_code[]", ""),
+        ("quantity[]", "3"),
+        ("unit_price[]", "80"),
+        # 行3
+        ("pigment_id[]", ""),
+        ("purchase_code[]", "S999"),
+        ("new_code[]", ""),
+        ("quantity[]", "7"),
+        ("unit_price[]", "100"),
+        # 行4
+        ("pigment_id[]", ""),
+        ("purchase_code[]", ""),
+        ("new_code[]", "P001"),
+        ("quantity[]", "2"),
+        ("unit_price[]", "50"),
+    ])
+    resp = client.post("/transactions/in/ocr/submit", data=form, follow_redirects=False)
+    print(f"\n提交结果: HTTP {resp.status_code} (302=成功重定向)")
+
+with app.app_context():
+    dump_pigments("OCR 提交后")
+    dump_transactions()
+
+    print("\n\n【Step 3】预期校验")
+    p001 = Pigment.query.filter_by(brand="", code="P001").first()
+    p002 = Pigment.query.filter_by(brand="", code="P002").first()
+    p003 = Pigment.query.filter_by(brand="", code="P003").first()
+    s999 = Pigment.query.filter_by(brand="未分类", code="S999").first()
+
+    checks = [
+        ("P001 库存 = 10 + 5(行1) + 2(行4) = 17", p001.stock.quantity, 17.0),
+        ("P002 库存 = 10 + 3(行2 purchase_code 二次匹配) = 13", p002.stock.quantity, 13.0),
+        ("P003 库存 = 10 (没被碰)", p003.stock.quantity, 10.0),
+        ("S999 是否新建了 未分类 待复核条目", s999 is not None, True),
+        ("S999 库存 = 7 (行3 新建+入库)", s999.stock.quantity if s999 else None, 7.0),
+        ("S999 的 notes 标注待复核", (s999.notes if s999 else "") == "OCR 自动新建,待复核", True),
+    ]
+    all_ok = True
+    for desc, actual, expected in checks:
+        ok = actual == expected
+        all_ok = all_ok and ok
+        mark = "✅" if ok else "❌"
+        print(f"  {mark} {desc}: actual={actual}, expected={expected}")
+
+    print(f"\n{'🎉 全部通过' if all_ok else '⚠️ 有失败,检查上面'}")
+
+# 清理临时 DB
+try:
+    os.unlink(TMP_DB)
+except OSError:
+    pass

--- a/apps/peise/tests/test_excel_io.py
+++ b/apps/peise/tests/test_excel_io.py
@@ -40,6 +40,20 @@ def test_import_upsert(db):
     assert x1.unit_price == 10
 
 
+def test_import_accepts_legacy_column_names(db):
+    """用户手上的旧 Excel 用「进货色粉编号」「数量」等老列名，必须仍能导入不静默清空。"""
+    data = _make_xlsx([
+        {"色粉编号": "L1", "进货色粉编号": "OLD1", "数量": 4, "单价": 6},
+        {"色粉编号": "L2", "进货色粉编号": "OLD2", "数量": 8, "单价": 2},
+    ])
+    report = import_pigments_from_bytes(data)
+    assert report["created"] == 2
+    l1 = Pigment.query.filter_by(code="L1").first()
+    assert l1.purchase_code == "OLD1"
+    assert l1.stock.quantity == 4
+    assert l1.unit_price == 6
+
+
 def test_import_archives_missing_and_handles_blank(db):
     a = Pigment(brand="", code="A1", name="A1", hex="#000000",
                 color_family="其他", spec_value=0, spec_unit="kg")

--- a/apps/peise/tests/test_excel_io.py
+++ b/apps/peise/tests/test_excel_io.py
@@ -12,8 +12,8 @@ def test_export_contains_new_columns(db):
     db.session.add(p); db.session.commit()
     data = export_pigments_to_bytes()
     df = pd.read_excel(io.BytesIO(data))
-    assert set(["色粉编号", "进货色粉编号", "数量", "单价", "单位", "金额"]).issubset(df.columns)
-    assert df.iloc[0]["数量"] == 3
+    assert set(["色粉编号", "进货编号", "库存KG", "单价", "金额"]).issubset(df.columns)
+    assert df.iloc[0]["库存KG"] == 3
     assert df.iloc[0]["金额"] == 15.0
 
 
@@ -29,8 +29,8 @@ def test_import_upsert(db):
                        color_family="其他", spec_value=0, spec_unit="kg")
     db.session.add(existing); db.session.commit()
     data = _make_xlsx([
-        {"色粉编号": "X1", "进货色粉编号": "P1", "数量": 5, "单价": 10},
-        {"色粉编号": "X2", "进货色粉编号": "P2", "数量": 2, "单价": 3},
+        {"色粉编号": "X1", "进货编号": "P1", "库存KG": 5, "单价": 10},
+        {"色粉编号": "X2", "进货编号": "P2", "库存KG": 2, "单价": 3},
     ])
     report = import_pigments_from_bytes(data)
     assert report["created"] == 1
@@ -47,13 +47,12 @@ def test_import_archives_missing_and_handles_blank(db):
                 color_family="其他", spec_value=0, spec_unit="kg")
     a.stock = Stock(quantity=0); b.stock = Stock(quantity=0)
     db.session.add_all([a, b]); db.session.commit()
-    # Excel 只有 A1, 进货色粉编号/备注 留空
+    # Excel 只有 A1, 进货编号 留空
     data = _make_xlsx([
-        {"色粉编号": "A1", "进货色粉编号": None, "数量": 7, "单价": 4, "备注": None},
+        {"色粉编号": "A1", "进货编号": None, "库存KG": 7, "单价": 4},
     ])
     report = import_pigments_from_bytes(data)
     assert report["archived"] == 1
     a1 = Pigment.query.filter_by(code="A1").first()
     assert a1.purchase_code == ""  # 不再写 "nan"
-    assert a1.notes == ""
     assert Pigment.query.filter_by(code="B1").first().is_archived is True


### PR DESCRIPTION
Excel / UI 层:
- Excel 列改为 [色粉编号, 进货编号, 库存KG, 单价, 金额] (去掉 单位/备注; 数量→库存KG; 进货色粉编号→进货编号)
- 库存列表表头 / 色粉表单 label 同步对齐
- 破坏性: 老列名 (如"数量") 的 Excel 导入会读不到 → 库存被覆盖为 0 需改标题为"库存KG"再导入

OCR 入库匹配 (transactions.py _ocr_submit 入库分支):
- 未匹到且 new_code 留空时, 用 purchase_code 作兜底色粉编号
- 提交前二次精确匹配: 先查 code 字段, 再查 purchase_code 字段
- 匹到已有色粉 → 累加 (避免同号分裂成"正规/P002"和"未分类/S002")
- 匹不到 → 新建 brand="未分类", notes="OCR 自动新建,待复核"

验证:
- 13 个单元测试全过
- scripts/sim_ocr_import.py 端到端模拟 6/6 场景通过 (无需 OpenRouter key)