### PR TITLE
feat(工程啤办单): 混合料双字段输入 + 原料从价格表选择 + 费用按完成月份

### DIFF
--- a/plugins/工程啤办单/public/engineering.html
+++ b/plugins/工程啤办单/public/engineering.html
@@ -851,6 +851,24 @@ _matDropEl.style.cssText = 'display:none;position:fixed;z-index:9999;background:
 document.body.appendChild(_matDropEl);
 let _matDropInp = null;
 
+// 校验原料输入必须在价格表中（空值允许）
+function matValidateInput(el) {
+  const v = (el.value || '').trim();
+  if (!v) { el.style.border = ''; el.title = ''; return true; }
+  const norm = normMat(v);
+  const match = _matPrices.find(p => normMat(p.material) === norm);
+  if (match) {
+    el.value = match.material; // 规范化为价格表中的标准写法
+    el.style.border = '';
+    el.title = match.material;
+    matCompose(el);
+    return true;
+  }
+  el.style.border = '2px solid #dc3545';
+  el.title = '「' + v + '」不在价格表中，请从下拉选择';
+  return false;
+}
+
 // 解析混合料字符串为 [{name,pct}, ...]
 function parseMaterial(s) {
   const str = String(s || '').trim();
@@ -875,7 +893,8 @@ function matSel(val) {
     <div class="d-flex gap-1 align-items-center">
       <input type="text" class="form-control form-control-sm mat-name-1" style="flex:1;min-width:100px"
         value="${esc(n1)}" placeholder="搜索原料..." autocomplete="off"
-        onfocus="matDropShow(this)" oninput="matDropFilter(this);matCompose(this)">
+        onfocus="matDropShow(this)" oninput="matDropFilter(this);matCompose(this)"
+        onblur="setTimeout(()=>matValidateInput(this),200)">
       <input type="number" class="form-control form-control-sm mat-pct-1 ${isMixed?'':'d-none'}" style="width:52px"
         value="${esc(p1)}" placeholder="%" min="0" max="100" step="1" oninput="matCompose(this)">
       <button type="button" class="btn btn-sm btn-outline-secondary mat-toggle" style="padding:1px 6px;font-size:11px;white-space:nowrap"
@@ -884,7 +903,8 @@ function matSel(val) {
     <div class="d-flex gap-1 align-items-center mat-row-2 ${isMixed?'':'d-none'}">
       <input type="text" class="form-control form-control-sm mat-name-2" style="flex:1;min-width:100px"
         value="${esc(n2)}" placeholder="第二种料..." autocomplete="off"
-        onfocus="matDropShow(this)" oninput="matDropFilter(this);matCompose(this)">
+        onfocus="matDropShow(this)" oninput="matDropFilter(this);matCompose(this)"
+        onblur="setTimeout(()=>matValidateInput(this),200)">
       <input type="number" class="form-control form-control-sm mat-pct-2" style="width:52px"
         value="${esc(p2)}" placeholder="%" min="0" max="100" step="1" oninput="matCompose(this)">
       <span style="width:28px"></span>
@@ -1180,6 +1200,24 @@ function saveOrder(type) {
     if (body.items && body.items.some(it => !it.product_name)) { alert('请填写所有明细行的产品名称'); return; }
   } else {
     if (!body.product_name) { alert('请填写产品名称'); return; }
+  }
+
+  // 啤办单：原料必须在价格表中（防止自由输入）
+  if (type === 'injection') {
+    const invalid = [];
+    document.querySelectorAll('#injItemsBody .mat-sel-wrap').forEach((wrap, i) => {
+      ['mat-name-1', 'mat-name-2'].forEach(cls => {
+        const inp = wrap.querySelector('.' + cls);
+        if (!inp) return;
+        // 只校验可见的输入（mat-name-2 在单料模式下 row2 隐藏，跳过）
+        if (cls === 'mat-name-2' && wrap.querySelector('.mat-row-2').classList.contains('d-none')) return;
+        if (!matValidateInput(inp)) invalid.push(`第 ${i+1} 行: ${inp.value}`);
+      });
+    });
+    if (invalid.length) {
+      alert('以下原料不在价格表中，请从下拉选择：\n' + invalid.join('\n'));
+      return;
+    }
   }
 
   if (!currentUser) { showLoginModal(); return; }

--- a/plugins/工程啤办单/public/engineering.html
+++ b/plugins/工程啤办单/public/engineering.html
@@ -851,13 +851,91 @@ _matDropEl.style.cssText = 'display:none;position:fixed;z-index:9999;background:
 document.body.appendChild(_matDropEl);
 let _matDropInp = null;
 
+// 解析混合料字符串为 [{name,pct}, ...]
+function parseMaterial(s) {
+  const str = String(s || '').trim();
+  if (!str) return [];
+  const parts = str.split(/[+＋]/).map(p => p.trim()).filter(Boolean);
+  const parsed = parts.map(p => {
+    const m = p.match(/^(\d+(?:\.\d+)?)\s*[%％]\s*(.+)$/);
+    return m ? { pct: m[1], name: m[2].trim() } : { pct: '', name: p };
+  });
+  return parsed;
+}
+
 function matSel(val) {
-  const v = esc(val||'');
-  return `<div class="mat-sel-wrap" style="min-width:130px">
-    <input type="text" class="form-control form-control-sm" name="material"
-      value="${v}" placeholder="搜索原料..." autocomplete="off"
-      onfocus="matDropShow(this)" oninput="matDropFilter(this)">
+  const parsed = parseMaterial(val);
+  const n1 = parsed[0]?.name || '';
+  const p1 = parsed[0]?.pct || '';
+  const n2 = parsed[1]?.name || '';
+  const p2 = parsed[1]?.pct || '';
+  const isMixed = parsed.length >= 2;
+  return `<div class="mat-sel-wrap" style="min-width:180px;display:flex;flex-direction:column;gap:2px">
+    <input type="hidden" name="material" value="${esc(val||'')}">
+    <div class="d-flex gap-1 align-items-center">
+      <input type="text" class="form-control form-control-sm mat-name-1" style="flex:1;min-width:100px"
+        value="${esc(n1)}" placeholder="搜索原料..." autocomplete="off"
+        onfocus="matDropShow(this)" oninput="matDropFilter(this);matCompose(this)">
+      <input type="number" class="form-control form-control-sm mat-pct-1" style="width:52px;${isMixed?'':'display:none'}"
+        value="${esc(p1)}" placeholder="%" min="0" max="100" step="1" oninput="matCompose(this)">
+      <button type="button" class="btn btn-sm btn-outline-secondary mat-toggle" style="padding:1px 6px;font-size:11px;white-space:nowrap"
+        onclick="matToggleMixed(this)" title="${isMixed?'取消混合料':'添加第二种料'}">${isMixed?'−':'+料'}</button>
+    </div>
+    <div class="d-flex gap-1 align-items-center mat-row-2" style="${isMixed?'':'display:none'}">
+      <input type="text" class="form-control form-control-sm mat-name-2" style="flex:1;min-width:100px"
+        value="${esc(n2)}" placeholder="第二种料..." autocomplete="off"
+        onfocus="matDropShow(this)" oninput="matDropFilter(this);matCompose(this)">
+      <input type="number" class="form-control form-control-sm mat-pct-2" style="width:52px"
+        value="${esc(p2)}" placeholder="%" min="0" max="100" step="1" oninput="matCompose(this)">
+      <span style="width:28px"></span>
+    </div>
   </div>`;
+}
+
+// 根据两行输入拼接 hidden material 值
+function matCompose(el) {
+  const wrap = el.closest('.mat-sel-wrap');
+  if (!wrap) return;
+  const hidden = wrap.querySelector('input[name="material"]');
+  const n1 = wrap.querySelector('.mat-name-1').value.trim();
+  const p1 = wrap.querySelector('.mat-pct-1').value.trim();
+  const row2 = wrap.querySelector('.mat-row-2');
+  const mixed = row2 && row2.style.display !== 'none';
+  if (mixed) {
+    const n2 = wrap.querySelector('.mat-name-2').value.trim();
+    const p2 = wrap.querySelector('.mat-pct-2').value.trim();
+    // 两边都有料就拼成 pct%name+pct%name；缺则退化为单料
+    if (n1 && n2 && (p1 || p2)) {
+      hidden.value = `${p1||0}%${n1}+${p2||0}%${n2}`;
+    } else if (n1 && !n2) {
+      hidden.value = n1;
+    } else {
+      hidden.value = [n1 && (p1 ? `${p1}%${n1}` : n1), n2 && (p2 ? `${p2}%${n2}` : n2)].filter(Boolean).join('+');
+    }
+  } else {
+    hidden.value = n1;
+  }
+  // 触发 summary 刷新（保留原有逻辑）
+  hidden.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+// 切换混合料模式
+function matToggleMixed(btn) {
+  const wrap = btn.closest('.mat-sel-wrap');
+  const row2 = wrap.querySelector('.mat-row-2');
+  const pct1 = wrap.querySelector('.mat-pct-1');
+  const on = row2.style.display === 'none';
+  row2.style.display = on ? '' : 'none';
+  pct1.style.display = on ? '' : 'none';
+  btn.textContent = on ? '−' : '+料';
+  btn.title = on ? '取消混合料' : '添加第二种料';
+  if (!on) {
+    // 取消混合：清空第二行与比例
+    wrap.querySelector('.mat-name-2').value = '';
+    wrap.querySelector('.mat-pct-2').value = '';
+    pct1.value = '';
+  }
+  matCompose(btn);
 }
 function matDropShow(inp) {
   if (_matPrices.length === 0) return;
@@ -920,7 +998,13 @@ function matDropFilter(inp) {
   _matDropEl.style.display = '';
 }
 function matDropPick(el, val) {
-  if (_matDropInp) { _matDropInp.value = val; _matDropInp.title = val; _matDropInp.style.border = ''; }
+  if (_matDropInp) {
+    _matDropInp.value = val;
+    _matDropInp.title = val;
+    _matDropInp.style.border = '';
+    // 若在混合料选择器中，同步更新 hidden name="material"
+    if (_matDropInp.closest('.mat-sel-wrap')) matCompose(_matDropInp);
+  }
   _matDropEl.style.display = 'none';
   _matDropInp = null;
 }
@@ -960,7 +1044,7 @@ function addInjRow(it={}, isSubRow=false) {
   document.getElementById('injItemsBody').appendChild(tr);
   // 未匹配原料：红框提示，placeholder 显示原始名称
   if (it._matUnmatched) {
-    const matInp = tr.querySelector('[name="material"]');
+    const matInp = tr.querySelector('.mat-name-1');
     if (matInp) {
       matInp.style.border = '2px solid #dc3545';
       matInp.placeholder = it._matUnmatched + '（未匹配，请手动选择）';

--- a/plugins/工程啤办单/public/engineering.html
+++ b/plugins/工程啤办单/public/engineering.html
@@ -876,12 +876,12 @@ function matSel(val) {
       <input type="text" class="form-control form-control-sm mat-name-1" style="flex:1;min-width:100px"
         value="${esc(n1)}" placeholder="搜索原料..." autocomplete="off"
         onfocus="matDropShow(this)" oninput="matDropFilter(this);matCompose(this)">
-      <input type="number" class="form-control form-control-sm mat-pct-1" style="width:52px;${isMixed?'':'display:none'}"
+      <input type="number" class="form-control form-control-sm mat-pct-1 ${isMixed?'':'d-none'}" style="width:52px"
         value="${esc(p1)}" placeholder="%" min="0" max="100" step="1" oninput="matCompose(this)">
       <button type="button" class="btn btn-sm btn-outline-secondary mat-toggle" style="padding:1px 6px;font-size:11px;white-space:nowrap"
         onclick="matToggleMixed(this)" title="${isMixed?'取消混合料':'添加第二种料'}">${isMixed?'−':'+料'}</button>
     </div>
-    <div class="d-flex gap-1 align-items-center mat-row-2" style="${isMixed?'':'display:none'}">
+    <div class="d-flex gap-1 align-items-center mat-row-2 ${isMixed?'':'d-none'}">
       <input type="text" class="form-control form-control-sm mat-name-2" style="flex:1;min-width:100px"
         value="${esc(n2)}" placeholder="第二种料..." autocomplete="off"
         onfocus="matDropShow(this)" oninput="matDropFilter(this);matCompose(this)">
@@ -900,7 +900,7 @@ function matCompose(el) {
   const n1 = wrap.querySelector('.mat-name-1').value.trim();
   const p1 = wrap.querySelector('.mat-pct-1').value.trim();
   const row2 = wrap.querySelector('.mat-row-2');
-  const mixed = row2 && row2.style.display !== 'none';
+  const mixed = row2 && !row2.classList.contains('d-none');
   if (mixed) {
     const n2 = wrap.querySelector('.mat-name-2').value.trim();
     const p2 = wrap.querySelector('.mat-pct-2').value.trim();
@@ -924,9 +924,9 @@ function matToggleMixed(btn) {
   const wrap = btn.closest('.mat-sel-wrap');
   const row2 = wrap.querySelector('.mat-row-2');
   const pct1 = wrap.querySelector('.mat-pct-1');
-  const on = row2.style.display === 'none';
-  row2.style.display = on ? '' : 'none';
-  pct1.style.display = on ? '' : 'none';
+  const on = row2.classList.contains('d-none');
+  row2.classList.toggle('d-none', !on);
+  pct1.classList.toggle('d-none', !on);
   btn.textContent = on ? '−' : '+料';
   btn.title = on ? '取消混合料' : '添加第二种料';
   if (!on) {

--- a/plugins/工程啤办单/server.js
+++ b/plugins/工程啤办单/server.js
@@ -69,6 +69,15 @@ function saveData(data) {
   fs.renameSync(tmp, DATA_FILE);
 }
 
+// 月份匹配：容忍 "YYYY-M-D"（completed_date 可能不补零）与 "YYYY-MM" 比较
+function monthMatches(dateStr, month) {
+  if (!dateStr || !month) return false;
+  const parts = String(dateStr).split(/[-\/]/);
+  if (parts.length < 2) return false;
+  const normalized = parts[0] + '-' + String(parts[1]).padStart(2, '0');
+  return normalized === month;
+}
+
 // ─── 材料价格解析（模糊匹配 + 混合料按最高比例组分取价） ───────────────────
 // 规范化：去掉空格/括号/横杠并转小写，用于模糊比对
 //   "PP(EP332K)" / "PP (EP332K)" / "PPEP332K" / "pp-ep332k" → "ppep332k"
@@ -546,16 +555,15 @@ app.get('/api/material-stats', (req, res) => {
   const workshop = req.query.workshop; // optional workshop filter
   const docSearch = req.query.doc_number; // optional product number search
   const clientSearch = req.query.client_name; // optional client name search
-  const APPROVED_S = ['待生产','生产中','已完成','已取消'];
-  // 始终只统计审核通过的订单
+  // 只统计已完成订单，月份按完成日期匹配
   const q = (orderSearch || '').toLowerCase();
   const dq = (docSearch || '').toLowerCase();
   const cq = (clientSearch || '').toLowerCase();
   const validOrderIds = new Set(
     (data.injection_orders || [])
       .filter(o => {
-        if (!APPROVED_S.includes(o.status)) return false;
-        if (month && !(o.date || '').startsWith(month)) return false;
+        if (o.status !== '已完成') return false;
+        if (month && !monthMatches(o.completed_date, month)) return false;
         if (q && !((o.order_number || '') + (o.doc_number || '')).toLowerCase().includes(q)) return false;
         if (dq && !(o.doc_number || '').toLowerCase().includes(dq)) return false;
         if (cq && !(o.client_name || '').toLowerCase().includes(cq)) return false;
@@ -590,9 +598,9 @@ app.get('/api/material-stats', (req, res) => {
 app.get('/api/injection-costs', (req, res) => {
   const data = loadData();
   const month = req.query.month; // optional YYYY-MM filter
-  const APPROVED = ['待生产','生产中','已完成','已取消'];
-  let orders = (data.injection_orders || []).filter(o => APPROVED.includes(o.status));
-  if (month) orders = orders.filter(o => (o.date || '').startsWith(month));
+  // 只统计已完成订单，月份按完成日期匹配
+  let orders = (data.injection_orders || []).filter(o => o.status === '已完成');
+  if (month) orders = orders.filter(o => monthMatches(o.completed_date, month));
   const items = data.injection_items || [];
   const result = [];
   orders.forEach(o => {
@@ -619,9 +627,9 @@ app.get('/api/injection-costs', (req, res) => {
 app.get('/api/injection-total-costs', (req, res) => {
   const data = loadData();
   const month = req.query.month;
-  const APPROVED = ['待生产','生产中','已完成','已取消'];
-  let orders = (data.injection_orders || []).filter(o => APPROVED.includes(o.status));
-  if (month) orders = orders.filter(o => (o.date || '').startsWith(month));
+  // 只统计已完成订单，按完成月份分组（3月的订单在4月完成就算4月费用）
+  let orders = (data.injection_orders || []).filter(o => o.status === '已完成');
+  if (month) orders = orders.filter(o => monthMatches(o.completed_date, month));
   const items = data.injection_items || [];
   const priceMap = buildPriceMap(data.material_prices);
   const result = orders.map(o => {


### PR DESCRIPTION
## Summary
- **混合料双字段输入**：原料列默认单料 1 个下拉，点「+料」展开第二料 + 比例输入；点「−」回单料。无 100% 强校验。序列化格式 \`50%PP+50%ABS\` 完全兼容现有 resolvePrice。
- **原料必须从价格表选择**：原料输入框失焦 → 规范化匹配价格表，不在表中则红框 + 悬浮提示；保存时扫描所有明细行，有不在表的 alert 列出问题行并阻止提交
- **混合料选择器 d-none 切换**：避免 bootstrap form-control 的 display:block 抢占布局
- **三个费用表只统计已完成订单**：按 completed_date 分组（3月接单 4月完成 → 算 4月费用）
- **monthMatches helper**：容忍 \`2026-4-15\` 与 \`2026-04\` 比较（toLocaleDateString 月份不补零）

## Changed files
- \`plugins/工程啤办单/public/engineering.html\` — 混合料选择器 + 原料校验 + 保存拦截
- \`plugins/工程啤办单/server.js\` — monthMatches + 三个费用端点已完成过滤

## Test plan
- [ ] 工程部建单 → 原料列点「+料」→ 展开第二料和比例，填好后切换到 `50%PP+50%ABS` 序列化
- [ ] 点「−」→ 回单料，第二料和比例被清空
- [ ] 原料输入框填一个不在价格表的名 → 失焦变红
- [ ] 点保存时若有无效原料 → alert 列出问题行阻止提交
- [ ] 经理「价格表管理」加新原料 → 工程部下拉立即可见
- [ ] 费用表三个 Tab 只看到已完成订单；月份筛选按 completed_date 生效

🤖 Generated with [Claude Code](https://claude.com/claude-code)