### PR TITLE
feat(工程啤办单): 工程部料价缺徽章 + 啤办费 RMB→HKD 换算

### DIFF
--- a/plugins/工程啤办单/public/engineering.html
+++ b/plugins/工程啤办单/public/engineering.html
@@ -670,7 +670,15 @@ function renderOrderList(orders) {
     });
     rows = rowArr.join('');
   } else {
-    rows = orders.map(o => `
+    const priceMapEng = (currentTab === 'injection') ? buildPriceMap(_matPrices) : null;
+    rows = orders.map(o => {
+      const hasMissingPrice = priceMapEng
+        ? (o.items || []).some(it => it.material && !resolvePrice(it.material, priceMapEng))
+        : false;
+      const matBadge = hasMissingPrice
+        ? ' <span class="badge bg-warning text-dark ms-1" title="部分原料未录入价格"><i class="bi bi-exclamation-circle me-1"></i>料价缺</span>'
+        : '';
+      return `
     <tr class="order-row" style="cursor:pointer" onclick="viewOrderDetail(${o.id},'${(o.order_number||'').replace(/'/g,'')}')">
       <td>${esc(o.order_number || '-')}</td>
       <td>${esc(o.product_name || '-')}</td>
@@ -682,7 +690,7 @@ function renderOrderList(orders) {
       <td>${esc(o.eng_name || '-')}</td>
       <td class="text-truncate" style="max-width:120px" title="${esc(o.reason||'')}">${esc(o.reason || '-')}</td>
       <td class="text-nowrap">
-        ${statusBadge(o.status)}
+        ${statusBadge(o.status)}${matBadge}
         ${engProblemsMap[o.id] ? `<span class="badge bg-danger ms-1" style="cursor:pointer" onclick="event.stopPropagation();viewEngProblems(${o.id},'${(o.order_number||'').replace(/'/g,'')}')"><i class="bi bi-exclamation-triangle-fill me-1"></i>${engProblemsMap[o.id]}</span>` : ''}
       </td>
       <td class="text-nowrap" onclick="event.stopPropagation()">
@@ -695,7 +703,8 @@ function renderOrderList(orders) {
           ${engProblemsMap[o.id] ? `<button class="btn btn-danger" onclick="viewEngProblems(${o.id},'${(o.order_number||'').replace(/'/g,'')}')" title="查看问题"><i class="bi bi-exclamation-triangle-fill"></i></button>` : ''}
         </div>
       </td>
-    </tr>`).join('');
+    </tr>`;
+    }).join('');
   }
 
   document.getElementById('orderList').innerHTML = `

--- a/plugins/工程啤办单/public/injection.html
+++ b/plugins/工程啤办单/public/injection.html
@@ -490,8 +490,11 @@ function viewOrder(id) {
           <td><input type="number" class="form-control form-control-sm bg-light" name="actual_amount_hkd"
               value="${it.actual_amount_hkd||''}" step="0.01" style="width:85px" placeholder="自动计算"
               title="= 实际用料 × 单价，也可手动修改" oninput="recalcTotals()"></td>
-          <td><input type="number" class="form-control form-control-sm" name="injection_cost"
-              value="${it.injection_cost||''}" step="0.01" style="width:85px" placeholder="0.00" oninput="recalcTotals()"></td>
+          <td>
+            <input type="number" class="form-control form-control-sm" name="injection_cost"
+              value="${it.injection_cost||''}" step="0.01" style="width:85px" placeholder="0.00 RMB" oninput="recalcTotals();updateInjHkdPreview(this)">
+            <div class="small text-muted" data-role="inj-hkd-preview" style="font-size:.72rem;line-height:1.1"></div>
+          </td>
         </tr>`;
       }).join('');
 
@@ -540,7 +543,7 @@ function viewOrder(id) {
                 <th>工模编号</th><th>工模名称</th><th>机型</th><th>原料/单价</th><th>颜色</th><th>色粉编号</th><th>件数/套数</th>
                 <th>数量(啤)</th><th>整啤毛重(g)</th><th>所需用料(KG)</th><th>模具回厂时间</th><th>啤办完成时间</th><th>备注</th>
                 <th>领原料单号</th><th>领料重量(KG)</th>
-                <th>实际用料(KG)</th><th>用料金额(HKD)</th><th>啤办费用(HKD)</th>
+                <th>实际用料(KG)</th><th>用料金额(HKD)</th><th>啤办费用(RMB)</th>
               </tr>
             </thead>
             <tbody id="machineItemsBody">${rows}</tbody>
@@ -578,6 +581,7 @@ function viewOrder(id) {
       }
 
       new bootstrap.Modal(document.getElementById('detailModal')).show();
+      recalcTotals(); // 初始化预览和合计
     });
 }
 
@@ -594,18 +598,41 @@ function autoCalcAmt(input) {
   recalcTotals();
 }
 
+// 当前 RMB→HKD 汇率（由后端 /api/settings 加载）
+let _exchangeRate = 1.08;
+apiFetch('/api/settings').then(r => r.json()).then(s => {
+  if (s && +s.exchange_rate_rmb_to_hkd > 0) _exchangeRate = +s.exchange_rate_rmb_to_hkd;
+}).catch(() => {});
+
+// 更新单行啤办费 RMB→HKD 的预览文本
+function updateInjHkdPreview(inp) {
+  const tr = inp.closest('tr');
+  const preview = tr?.querySelector('[data-role="inj-hkd-preview"]');
+  if (!preview) return;
+  const rmb = parseFloat(inp.value);
+  if (!rmb || rmb <= 0) { preview.textContent = ''; return; }
+  const hkd = rmb * _exchangeRate;
+  preview.textContent = `≈ ${hkd.toFixed(2)} HKD @ ${_exchangeRate}`;
+}
+
+function refreshAllInjHkdPreview() {
+  document.querySelectorAll('#machineItemsBody [name="injection_cost"]').forEach(inp => updateInjHkdPreview(inp));
+}
+
 function recalcTotals() {
-  let totalAmt = 0, totalCost = 0;
+  let totalAmt = 0, totalCostRmb = 0;
   document.querySelectorAll('#machineItemsBody tr[data-item-id]').forEach(tr => {
     totalAmt  += parseFloat(tr.querySelector('[name="actual_amount_hkd"]')?.value) || 0;
-    totalCost += parseFloat(tr.querySelector('[name="injection_cost"]')?.value)    || 0;
+    totalCostRmb += parseFloat(tr.querySelector('[name="injection_cost"]')?.value) || 0;
   });
+  const totalCostHkd = totalCostRmb * _exchangeRate;
   const sumAmt = document.getElementById('sumAmt');
   const sumCost = document.getElementById('sumCost');
   const sumGrand = document.getElementById('sumGrand');
   if (sumAmt)   sumAmt.textContent  = totalAmt.toFixed(2);
-  if (sumCost)  sumCost.textContent = totalCost.toFixed(2);
-  if (sumGrand) sumGrand.textContent = (totalAmt + totalCost).toFixed(2) + ' HKD';
+  if (sumCost)  sumCost.textContent = totalCostRmb ? `${totalCostRmb.toFixed(2)} RMB (≈ ${totalCostHkd.toFixed(2)} HKD)` : '0.00';
+  if (sumGrand) sumGrand.textContent = (totalAmt + totalCostHkd).toFixed(2) + ' HKD';
+  refreshAllInjHkdPreview();
 }
 
 function saveMachineData(orderId) {

--- a/plugins/工程啤办单/public/manager.html
+++ b/plugins/工程啤办单/public/manager.html
@@ -199,6 +199,12 @@
         <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
       </div>
       <div class="modal-body">
+        <div class="alert alert-info py-2 px-3 mb-3 d-flex align-items-center gap-2" style="font-size:.85rem">
+          <i class="bi bi-currency-exchange"></i>
+          <span class="fw-bold">RMB → HKD 汇率：</span>
+          <input type="number" id="ptExchangeRate" step="0.0001" min="0" class="form-control form-control-sm" style="width:90px" placeholder="1.08">
+          <span class="text-muted">1 RMB = X HKD（啤机部录入 RMB，保存时按此汇率折算 HKD）</span>
+        </div>
         <div class="d-flex gap-2 mb-3 align-items-center">
           <input id="ptSearch" class="form-control form-control-sm" style="max-width:240px" placeholder="搜索原料名..." oninput="renderPriceTable()">
           <div class="form-check">
@@ -739,13 +745,18 @@ async function openPriceTableModal() {
   document.getElementById('ptSearch').value = '';
   document.getElementById('ptOnlyMissing').checked = false;
   document.getElementById('ptMgrPin').value = '';
+  document.getElementById('ptExchangeRate').value = '';
   try {
-    const r = await apiFetch('/api/material-prices');
-    _priceRows = (await r.json()).map(p => ({
+    const [pr, sr] = await Promise.all([
+      apiFetch('/api/material-prices').then(r => r.json()),
+      apiFetch('/api/settings').then(r => r.json()).catch(() => ({}))
+    ]);
+    _priceRows = pr.map(p => ({
       material: p.material || '',
       unit_price: +(p.unit_price || 0),
       notes: p.notes || ''
     }));
+    document.getElementById('ptExchangeRate').value = sr.exchange_rate_rmb_to_hkd || '';
   } catch (e) { _priceRows = []; }
   renderPriceTable();
   new bootstrap.Modal(document.getElementById('priceTableModal')).show();
@@ -800,11 +811,14 @@ async function savePriceTable() {
   if (dup) { err.textContent = `存在重复原料名：${dup}`; err.classList.remove('d-none'); return; }
   const managerPin = (document.getElementById('ptMgrPin').value || '').trim();
   if (!managerPin) { err.textContent = '请输入经理 PIN'; err.classList.remove('d-none'); return; }
+  const rateRaw = (document.getElementById('ptExchangeRate').value || '').trim();
+  const exchange_rate = rateRaw ? +rateRaw : null;
+  if (rateRaw && !(exchange_rate > 0)) { err.textContent = '汇率必须为正数'; err.classList.remove('d-none'); return; }
   try {
     const r = await apiFetch('/api/manager-update-prices', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ manager_name: MANAGER_NAME, manager_pin: managerPin, prices: clean })
+      body: JSON.stringify({ manager_name: MANAGER_NAME, manager_pin: managerPin, prices: clean, ...(exchange_rate != null ? { exchange_rate } : {}) })
     });
     const d = await r.json();
     if (!r.ok || !d.success) { err.textContent = d.error || '保存失败'; err.classList.remove('d-none'); return; }

--- a/plugins/工程啤办单/server.js
+++ b/plugins/工程啤办单/server.js
@@ -41,6 +41,9 @@ function loadData() {
     if (!data.assembly_orders) data.assembly_orders = [];
     if (!data.assembly_items) data.assembly_items = [];
     if (!data.assembly_users) data.assembly_users = [];
+    if (typeof data.exchange_rate_rmb_to_hkd !== 'number' || !(data.exchange_rate_rmb_to_hkd > 0)) {
+      data.exchange_rate_rmb_to_hkd = 1.08;
+    }
     _cache = data;
     return _cache;
   }
@@ -407,10 +410,23 @@ app.use('/api', (req, res, next) => {
       const updates = req.body.updates || [];
       const items = data[`${type}_items`];
       const ITEM_WHITELIST = ['receipt_no','collected_weight_kg','actual_weight_kg','actual_amount_hkd','injection_cost'];
+      const rate = +(data.exchange_rate_rmb_to_hkd || 1.08);
       updates.forEach(u => {
         const item = items.find(i => i.id === +u.id && i.order_id === +req.params.id);
         if (item) {
           ITEM_WHITELIST.forEach(f => { if (f in u) item[f] = u[f]; });
+          // 啤办费：新录入的 injection_cost 视为 RMB，自动换算 HKD
+          // 历史已录入但无 injection_cost_hkd 的订单保持原值（视为 HKD），不触发换算
+          if (type === 'injection' && 'injection_cost' in u) {
+            const rmb = +(u.injection_cost || 0);
+            if (rmb > 0) {
+              item.injection_cost_hkd = Math.round(rmb * rate * 100) / 100;
+              item.exchange_rate_at_save = rate;
+            } else {
+              item.injection_cost_hkd = null;
+              item.exchange_rate_at_save = null;
+            }
+          }
         }
       });
       saveData(data);
@@ -490,6 +506,12 @@ app.put('/api/clients', (req, res) => {
     saveData(data);
     res.json(data.clients);
   } catch (e) { res.status(500).json({ error: e.message }); }
+});
+
+// ─── 系统设置（汇率等） ─────────────────────────────────────────────────────
+app.get('/api/settings', (req, res) => {
+  const data = loadData();
+  res.json({ exchange_rate_rmb_to_hkd: data.exchange_rate_rmb_to_hkd || 1.08 });
 });
 
 // ─── 原料价格管理 ──────────────────────────────────────────────────────────────
@@ -632,21 +654,26 @@ app.get('/api/injection-total-costs', (req, res) => {
     const details = orderItems.map(it => {
       const matRaw = +(it.actual_amount_hkd || 0);
       const mat = Number.isFinite(matRaw) ? matRaw : 0;
+      // 啤办费优先用 injection_cost_hkd（换算后），无则回退 injection_cost（legacy 视为 HKD）
       const injRaw = it.injection_cost;
-      const injNum = +(injRaw || 0);
-      const inj = Number.isFinite(injNum) ? injNum : 0;
+      const hasRaw = !(injRaw === null || injRaw === undefined || injRaw === '');
+      const injHkdRaw = it.injection_cost_hkd;
+      const hasHkd = !(injHkdRaw === null || injHkdRaw === undefined || injHkdRaw === '');
+      const injHkdNum = hasHkd ? +(injHkdRaw || 0) : (hasRaw ? +(injRaw || 0) : 0);
+      const inj = Number.isFinite(injHkdNum) ? injHkdNum : 0;
       totalMat += mat;
       if (!skipInjCost) totalInj += inj;
       // 料价缺：有材料名但模糊解析找不到价格
       if (it.material && resolvePrice(it.material, priceMap) <= 0) hasMissingPrice = true;
       // 啤办费缺：没有填写（null/undefined/空字符串），发至订单除外
-      if (!skipInjCost && (injRaw === null || injRaw === undefined || injRaw === '')) hasMissingInj = true;
+      if (!skipInjCost && !hasRaw && !hasHkd) hasMissingInj = true;
       return {
         mold_id: it.mold_id || '',
         mold_name: it.mold_name || '',
         material: it.material || '',
         material_cost: Math.round(mat * 100) / 100,
-        injection_cost: skipInjCost ? null : ((injRaw === null || injRaw === undefined || injRaw === '') ? null : inj)
+        injection_cost: skipInjCost ? null : (!hasRaw && !hasHkd ? null : inj),
+        injection_cost_rmb: skipInjCost ? null : (hasHkd && hasRaw ? +injRaw : null)
       };
     });
     return {
@@ -908,7 +935,7 @@ function appendAudit(data, req, action, actor, extra) {
 app.post('/api/manager-update-prices', (req, res) => {
   const actor = authManager(req, res);
   if (!actor) return;
-  const { prices } = req.body;
+  const { prices, exchange_rate } = req.body;
   if (!Array.isArray(prices)) {
     return res.status(400).json({ error: '参数不完整' });
   }
@@ -921,6 +948,13 @@ app.post('/api/manager-update-prices', (req, res) => {
     unit_price: +(p.unit_price || 0),
     notes: String(p.notes || '')
   }));
+  if (exchange_rate !== undefined && exchange_rate !== null && exchange_rate !== '') {
+    const rate = +exchange_rate;
+    if (!(rate > 0) || !Number.isFinite(rate)) {
+      return res.status(400).json({ error: '汇率必须为正数' });
+    }
+    data.exchange_rate_rmb_to_hkd = rate;
+  }
   const priceMap = buildPriceMap(data.material_prices);
   let backfilled = 0;
   (data.injection_items || []).forEach(item => {


### PR DESCRIPTION
## Summary
1. **工程部订单列表新增「料价缺」徽章** — 任一明细原料不在价格表则状态旁显示黄色提示，和啤机部徽章一致（仅啤办单 Tab 生效）
2. **啤办费 RMB→HKD 自动换算**
   - 后端新增 \`data.exchange_rate_rmb_to_hkd\` 配置（默认 1.08）
   - \`GET /api/settings\` 返回当前汇率
   - 经理「价格表管理」Modal 顶部新增汇率输入，保存时可同时更新汇率
   - 啤机部啤办费输入改标「(RMB)」，下方实时预览「≈ X.XX HKD @ rate」
   - 合计行同时显示 RMB 与换算 HKD
   - 保存 injection_cost 时自动写入 \`injection_cost_hkd\` + \`exchange_rate_at_save\`
   - 总费用表优先用 \`injection_cost_hkd\`；历史订单无此字段则回退 \`injection_cost\`（legacy HKD），**不修改历史数据**

## Changed files
- \`plugins/工程啤办单/public/engineering.html\` — 料价缺徽章
- \`plugins/工程啤办单/public/injection.html\` — RMB/HKD 输入 + 预览
- \`plugins/工程啤办单/public/manager.html\` — 汇率输入框
- \`plugins/工程啤办单/server.js\` — settings 端点、PATCH items 换算、manager-update-prices 扩展、总费用表使用 HKD

## Test plan
- [ ] 工程部啤办单列表：原料不在价格表的订单显示「料价缺」徽章
- [ ] 经理 → 价格表管理 → 顶部汇率输入框显示当前值（1.08）
- [ ] 修改汇率为 1.10 → 输入 PIN → 保存 → 重开 Modal 显示 1.10
- [ ] 啤机部订单详情 → 啤办费列标 (RMB) → 输入 100 → 预览 ≈ 110 HKD
- [ ] 保存后刷新 → 合计行显示 100 RMB (≈ 110 HKD)
- [ ] 总费用表显示编辑过的订单啤办费已换算为 HKD
- [ ] 历史已完成订单（未被重新编辑）啤办费值保持不变

🤖 Generated with [Claude Code](https://claude.com/claude-code)