### PR TITLE
perf(zuru-order-system): 修 openpyxl O(N²) 上传慢 bug（~200× 提速）

### DIFF
--- a/apps/业务部/ZURU接单表入单系统/app.py
+++ b/apps/业务部/ZURU接单表入单系统/app.py
@@ -134,14 +134,32 @@ def _save_config(cfg):
         json.dump(cfg, f, ensure_ascii=False, indent=2)
 
 
+# 接单表 PO 缓存：(mtime, size) → set[str]。openpyxl read_only 下 ws.cell(r,c) 是 O(N²)，
+# 对 2500+ 行接单表相当于每次请求 30+ 分钟；改用 iter_rows 流式读 + mtime-key 缓存
+_pos_cache_lock = threading.Lock()
+_pos_cache = {'key': None, 'pos': set()}
+
+
 def _read_existing_pos(filepath):
-    """读取接单表B列所有PO号，返回set"""
+    """读取接单表B列所有PO号，返回set。mtime 没变则命中缓存。"""
+    try:
+        st = os.stat(filepath)
+        key = (filepath, st.st_mtime, st.st_size)
+    except OSError as e:
+        logging.error(f'读取接单表 stat 失败: {filepath} - {e}')
+        return set()
+
+    with _pos_cache_lock:
+        if _pos_cache['key'] == key:
+            return _pos_cache['pos']
+
     pos = set()
     try:
         wb = openpyxl.load_workbook(filepath, data_only=True, read_only=True)
         ws = wb.active
-        for r in range(3, ws.max_row + 1):
-            v = ws.cell(r, 2).value
+        # iter_rows 流式读取：对 2500+ 行比 ws.cell(r,c) 快 ~200×
+        for row in ws.iter_rows(min_row=3, min_col=2, max_col=2, values_only=True):
+            v = row[0]
             if v:
                 s = str(v).strip().replace('.0', '')
                 if s:
@@ -149,6 +167,11 @@ def _read_existing_pos(filepath):
         wb.close()
     except Exception as e:
         logging.error(f'读取接单表失败: {filepath} - {e}')
+        return set()
+
+    with _pos_cache_lock:
+        _pos_cache['key'] = key
+        _pos_cache['pos'] = pos
     return pos
 
 

--- a/apps/业务部/ZURU接单表入单系统/po_parser.py
+++ b/apps/业务部/ZURU接单表入单系统/po_parser.py
@@ -11,6 +11,47 @@ import openpyxl
 
 logger = logging.getLogger(__name__)
 
+
+class _CellShim:
+    __slots__ = ('value',)
+
+    def __init__(self, value):
+        self.value = value
+
+
+_EMPTY_CELL = _CellShim(None)
+
+
+class _RowGrid:
+    """openpyxl worksheet 的 drop-in 替代：流式一次读完成 2D list，
+    之后 ws.cell(r,c).value / ws.max_row 访问都是 O(1)。
+
+    read_only=True 下原始 ws.cell(r,c) 每次从头 scan，循环读 N 行就是 O(N²)，
+    对 200+ 行的 PO 要几十秒。iter_rows 一次流式只要不到 1s。
+    """
+    __slots__ = ('_rows', '_max_row', '_max_col')
+
+    def __init__(self, ws):
+        self._rows = list(ws.iter_rows(values_only=True))
+        self._max_row = len(self._rows)
+        self._max_col = max((len(r) for r in self._rows), default=0)
+
+    def cell(self, r, c):
+        if 1 <= r <= self._max_row:
+            row = self._rows[r - 1]
+            if 1 <= c <= len(row):
+                return _CellShim(row[c - 1])
+        return _EMPTY_CELL
+
+    @property
+    def max_row(self):
+        return self._max_row
+
+    @property
+    def max_col(self):
+        return self._max_col
+
+
 # 修改单识别正则：文件名含Rev/R1/R2/R3/R4/Rev./.rev./Rev2.等
 _REV_RE = re.compile(r'(?:Rev\d*\.?|(?:^|\W)R\d\b|\.rev\.)', re.I)
 
@@ -190,7 +231,9 @@ def parse(filepath):
     }
     """
     wb = openpyxl.load_workbook(filepath, data_only=True, read_only=True)
-    ws = wb.active
+    # 流式读成 2D 数组后立刻关闭，后续所有 ws.cell(r,c).value 访问都是 O(1)
+    ws = _RowGrid(wb.active)
+    wb.close()
     result = {
         'po_number': '', 'po_date': None, 'customer': '',
         'customer_po': '', 'destination': '', 'from_person': '',
@@ -493,7 +536,6 @@ def parse(filepath):
     result['remark'] = '\n'.join(rm_parts)
     result['revision_records'] = '\n'.join(rev_parts)
 
-    wb.close()
     logger.info(f'[PO解析] PO={result["po_number"]} 客户={result["customer"]} '
                 f'{len(result["lines"])}行数据 目的国={result["destination"]}')
     return result


### PR DESCRIPTION
## Summary

- **根因**：`app.py::_read_existing_pos` 和 `po_parser.py::parse()` 在 `read_only=True` workbook 上循环用 `ws.cell(r,c).value`。openpyxl read_only 下这个调用每次从头 scan，N 行就是 O(N²)。2505 行接单表 → 30+ 分钟
- **修复**：
  - `_read_existing_pos` 改用 `ws.iter_rows()` 流式读取 + mtime-key 缓存
  - `po_parser.py` 新增 `_RowGrid` drop-in 包装：load 时 `iter_rows` 流式吃到 2D list，之后 `ws.cell(r,c).value` API 保持不变但 O(1)

## Benchmark

在 cloud 容器里跑真实接单表（1.9MB / 2505 PO 行）：

| 方法 | 范围 | 耗时 |
|---|---|---|
| 旧 `ws.cell` loop | 100 行 | 4.2s |
| 旧 `ws.cell` loop | 300 行 | 28.8s |
| 旧 `ws.cell` loop | 500 行 | 77.9s |
| 新 `iter_rows` | **全部 2505 行** | **10.7s** ✅ |

外推：原来 `/api/upload_table` → `_read_existing_pos` 对 2505 行要 ~30 分钟。现在 ~11s（首次）/ ~0ms（缓存命中）。

## Test plan

- [x] Syntax check (ast.parse) 通过
- [x] `_RowGrid` drop-in 兼容：toy workbook 跑 `parse()` 结果正确
- [x] Benchmark 在 cloud 容器 verified 提速
- [ ] 部署后用 real PO 文件端到端跑一遍：`/api/upload_table` → `/api/classify` → `/api/process` → 下载 Excel

🤖 Generated with [Claude Code](https://claude.com/claude-code)