### PR TITLE
feat(peise): 登录系统 + 待审核模块 + OCR A/B 冲淡公式

### DIFF
--- a/apps/PMC跟仓管/配色库存管理/.env.example
+++ b/apps/PMC跟仓管/配色库存管理/.env.example
@@ -11,3 +11,11 @@ BAILIAN_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
 
 # 必填: 通义千问多模态模型
 BAILIAN_MODEL=qwen-vl-max-latest
+
+# 登录(单密码模式)
+# AUTH_USERNAME / AUTH_PASSWORD 必填,否则启动报错
+AUTH_USERNAME=
+AUTH_PASSWORD=
+# 可选: 不设会自动在 instance/.secret_key 生成并持久化
+# 要手动设也行: python -c "import secrets; print(secrets.token_hex(32))"
+SECRET_KEY=

--- a/apps/PMC跟仓管/配色库存管理/app/__init__.py
+++ b/apps/PMC跟仓管/配色库存管理/app/__init__.py
@@ -15,12 +15,20 @@ def create_app(config_class=Config):
 
     os.makedirs(app.instance_path, exist_ok=True)
 
+    _ensure_secret_key(app)
+    _validate_auth_config(app)
+
     db.init_app(app)
 
-    from .routes import dashboard, pigments, transactions
+    from .routes import dashboard, pigments, transactions, pending, auth as auth_routes
+    app.register_blueprint(auth_routes.bp)
     app.register_blueprint(dashboard.bp)
     app.register_blueprint(pigments.bp, url_prefix="/pigments")
     app.register_blueprint(transactions.bp, url_prefix="/transactions")
+    app.register_blueprint(pending.bp, url_prefix="/pending")
+
+    from .auth import install_login_guard
+    install_login_guard(app)
 
     @app.route("/health")
     def _health():
@@ -32,6 +40,36 @@ def create_app(config_class=Config):
         _migrate_uq_brand_code_partial()
 
     return app
+
+
+def _ensure_secret_key(app):
+    """SECRET_KEY 优先读 env;没设就从 instance/.secret_key 读或首次生成后落盘。
+    instance/ 在云端是 bind mount,key 跨容器重启持久化。"""
+    if app.config.get("SECRET_KEY"):
+        return
+    import secrets
+    key_path = os.path.join(app.instance_path, ".secret_key")
+    if os.path.exists(key_path):
+        with open(key_path, "r", encoding="utf-8") as f:
+            app.config["SECRET_KEY"] = f.read().strip()
+            return
+    os.makedirs(app.instance_path, exist_ok=True)
+    new_key = secrets.token_hex(32)
+    with open(key_path, "w", encoding="utf-8") as f:
+        f.write(new_key)
+    app.config["SECRET_KEY"] = new_key
+
+
+def _validate_auth_config(app):
+    """启动时必须有 AUTH_USERNAME / AUTH_PASSWORD,否则拒绝起服务。
+    SECRET_KEY 由 _ensure_secret_key 保底,不在这里校验。"""
+    missing = [k for k in ("AUTH_USERNAME", "AUTH_PASSWORD")
+               if not app.config.get(k)]
+    if missing:
+        raise RuntimeError(
+            f"启动配置缺失: {', '.join(missing)}。"
+            f"请在 .env 里设置这些值(参考 .env.example)。"
+        )
 
 
 def _migrate_uq_brand_code_partial():

--- a/apps/PMC跟仓管/配色库存管理/app/auth.py
+++ b/apps/PMC跟仓管/配色库存管理/app/auth.py
@@ -1,0 +1,33 @@
+"""登录守卫:未登录访问任何非豁免路由都跳去 /login。
+
+豁免端点:auth.login / auth.logout / _health / static
+"""
+from functools import wraps
+
+from flask import current_app, redirect, request, session, url_for
+
+_EXEMPT_ENDPOINTS = {"auth.login", "auth.logout", "_health", "static"}
+
+
+def is_logged_in() -> bool:
+    return bool(session.get("logged_in"))
+
+
+def install_login_guard(app) -> None:
+    @app.before_request
+    def _require_login():
+        if request.endpoint in _EXEMPT_ENDPOINTS:
+            return None
+        if is_logged_in():
+            return None
+        return redirect(url_for("auth.login", next=request.full_path.rstrip("?")))
+
+
+def login_required(view):
+    """备用装饰器,主要靠 install_login_guard 做全局守卫。"""
+    @wraps(view)
+    def wrapper(*args, **kwargs):
+        if not is_logged_in():
+            return redirect(url_for("auth.login", next=request.full_path.rstrip("?")))
+        return view(*args, **kwargs)
+    return wrapper

--- a/apps/PMC跟仓管/配色库存管理/app/config.py
+++ b/apps/PMC跟仓管/配色库存管理/app/config.py
@@ -1,6 +1,22 @@
 import os
+from datetime import timedelta
+
+# python run.py 方式启动时不会自动加载 .env (Flask 的自动加载只在 flask CLI 下生效),
+# 在读取 env 之前显式 load_dotenv。python-dotenv 找不到 .env 就安静跳过。
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
 
 class Config:
-    SECRET_KEY = os.environ.get("SECRET_KEY", "dev-key-change-me")
+    SECRET_KEY = os.environ.get("SECRET_KEY", "")
     SQLALCHEMY_DATABASE_URI = "sqlite:///peise.db"
     SQLALCHEMY_TRACK_MODIFICATIONS = False
+
+    # 登录配置(单密码模式)
+    AUTH_USERNAME = os.environ.get("AUTH_USERNAME", "").strip()
+    AUTH_PASSWORD = os.environ.get("AUTH_PASSWORD", "").strip()
+    # "记住我"勾选后 session 保留 7 天
+    PERMANENT_SESSION_LIFETIME = timedelta(days=7)

--- a/apps/PMC跟仓管/配色库存管理/app/models.py
+++ b/apps/PMC跟仓管/配色库存管理/app/models.py
@@ -50,3 +50,20 @@ class Transaction(db.Model):
     note = db.Column(db.Text, default="")
     pigment = db.relationship("Pigment", back_populates="transactions")
 
+
+class PendingReview(db.Model):
+    """待审核:入库未填色粉编号、出库找不到色粉或库存不足,都进这里等人工处理。
+    quantity 单位跟随 type: in=kg, out=克 (和表单输入一致,resolve 时再换算)。
+    """
+    __tablename__ = "pending_review"
+    id = db.Column(db.Integer, primary_key=True)
+    type = db.Column(db.String(8), nullable=False)  # 'in' or 'out'
+    pigment_code = db.Column(db.String(64), nullable=False, default="")
+    purchase_code = db.Column(db.String(64), nullable=False, default="")
+    name = db.Column(db.String(128), nullable=False, default="")
+    quantity = db.Column(db.Float, nullable=False)
+    unit_price = db.Column(db.Float, nullable=True)
+    reason = db.Column(db.String(256), nullable=False)
+    note = db.Column(db.Text, default="")
+    created_at = db.Column(db.DateTime, default=datetime.now)
+

--- a/apps/PMC跟仓管/配色库存管理/app/routes/auth.py
+++ b/apps/PMC跟仓管/配色库存管理/app/routes/auth.py
@@ -1,0 +1,43 @@
+from urllib.parse import urlparse
+
+from flask import (Blueprint, current_app, flash, redirect, render_template,
+                   request, session, url_for)
+
+bp = Blueprint("auth", __name__)
+
+
+def _safe_next(target: str | None) -> str:
+    """防 open-redirect:只接受本站内部路径。"""
+    if not target:
+        return url_for("dashboard.index")
+    parsed = urlparse(target)
+    if parsed.scheme or parsed.netloc:
+        return url_for("dashboard.index")
+    if not target.startswith("/"):
+        return url_for("dashboard.index")
+    return target
+
+
+@bp.route("/login", methods=["GET", "POST"])
+def login():
+    next_url = request.args.get("next") or request.form.get("next") or ""
+    if request.method == "POST":
+        username = (request.form.get("username") or "").strip()
+        password = (request.form.get("password") or "").strip()
+        remember = bool(request.form.get("remember"))
+        expected_user = current_app.config.get("AUTH_USERNAME", "")
+        expected_pass = current_app.config.get("AUTH_PASSWORD", "")
+        if username == expected_user and password == expected_pass:
+            session.clear()
+            session["logged_in"] = True
+            session.permanent = remember  # True → 7 天; False → 关浏览器失效
+            return redirect(_safe_next(next_url))
+        flash("账号或密码错误", "danger")
+    return render_template("login.html", next=next_url)
+
+
+@bp.route("/logout", methods=["GET", "POST"])
+def logout():
+    session.clear()
+    flash("已注销", "info")
+    return redirect(url_for("auth.login"))

--- a/apps/PMC跟仓管/配色库存管理/app/routes/pending.py
+++ b/apps/PMC跟仓管/配色库存管理/app/routes/pending.py
@@ -1,0 +1,79 @@
+from flask import Blueprint, render_template, request, redirect, url_for, flash
+
+from app.extensions import db
+from app.models import PendingReview, Pigment, Stock
+from app.services.inventory import stock_in, stock_out, InsufficientStock
+
+bp = Blueprint("pending", __name__)
+
+
+@bp.route("/")
+def index():
+    items = PendingReview.query.order_by(PendingReview.created_at.desc()).all()
+    return render_template("pending/index.html", items=items)
+
+
+@bp.route("/<int:rid>/resolve", methods=["POST"])
+def resolve(rid):
+    item = PendingReview.query.get_or_404(rid)
+    code = (request.form.get("pigment_code") or "").strip()
+    try:
+        qty = float(request.form.get("quantity") or 0)
+    except ValueError:
+        qty = 0.0
+    if not code or qty <= 0:
+        flash("色粉编号和数量必填", "danger")
+        return redirect(url_for("pending.index"))
+
+    pigment = (Pigment.query
+               .filter_by(is_archived=False)
+               .filter((Pigment.code == code) | (Pigment.purchase_code == code))
+               .first())
+
+    if item.type == "in":
+        price_raw = (request.form.get("unit_price") or "").strip()
+        price = float(price_raw) if price_raw else None
+        if pigment is None:
+            pigment = Pigment(
+                brand="未分类", code=code,
+                name=(item.name or code)[:128],
+                purchase_code=item.purchase_code or "",
+                unit_price=price or 0,
+                notes=f"由待审核 #{item.id} 补填",
+            )
+            db.session.add(pigment)
+            db.session.flush()
+        try:
+            stock_in(pigment.id, qty, unit_price=price,
+                     note=f"由待审核 #{item.id} 补填")
+        except Exception as e:
+            flash(f"入库失败:{e}", "danger")
+            return redirect(url_for("pending.index"))
+    else:  # out
+        if pigment is None:
+            flash(f"出库失败:色粉编号 {code} 在库存中找不到,请先建档或改编号", "danger")
+            return redirect(url_for("pending.index"))
+        qty_kg = round(qty / 1000.0, 6)
+        try:
+            stock_out(pigment.id, qty_kg,
+                      note=f"由待审核 #{item.id} 补填 {qty}g")
+        except InsufficientStock as e:
+            flash(f"出库失败:{e}", "danger")
+            return redirect(url_for("pending.index"))
+        except Exception as e:
+            flash(f"出库失败:{e}", "danger")
+            return redirect(url_for("pending.index"))
+
+    db.session.delete(item)
+    db.session.commit()
+    flash(f"已完成 {'入库' if item.type == 'in' else '出库'}", "success")
+    return redirect(url_for("pending.index"))
+
+
+@bp.route("/<int:rid>/reject", methods=["POST"])
+def reject(rid):
+    item = PendingReview.query.get_or_404(rid)
+    db.session.delete(item)
+    db.session.commit()
+    flash("已驳回(未改动库存)", "info")
+    return redirect(url_for("pending.index"))

--- a/apps/PMC跟仓管/配色库存管理/app/routes/transactions.py
+++ b/apps/PMC跟仓管/配色库存管理/app/routes/transactions.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 from flask import Blueprint, render_template, request, redirect, url_for, flash, current_app
 from app.extensions import db
-from app.models import Pigment, Stock, Transaction
+from app.models import Pigment, Stock, Transaction, PendingReview
 from app.services.inventory import stock_in, stock_out, InsufficientStock
 
 bp = Blueprint("transactions", __name__)
@@ -36,12 +36,29 @@ def out_list():
 def in_new():
     if request.method == "POST":
         try:
-            pid = int(request.form["pigment_id"])
+            pid_raw = (request.form.get("pigment_id") or "").strip()
             qty = float(request.form["quantity"])
-            price = request.form.get("unit_price")
+            price_raw = (request.form.get("unit_price") or "").strip()
+            price = float(price_raw) if price_raw else None
             note = request.form.get("note", "")
-            stock_in(pid, qty, unit_price=float(price) if price else None, note=note)
-            flash("已入库", "success")
+            purchase_code = (request.form.get("purchase_code") or "").strip()
+            name = (request.form.get("name") or "").strip()
+            if pid_raw:
+                stock_in(int(pid_raw), qty, unit_price=price, note=note)
+                flash("已入库", "success")
+            else:
+                if not purchase_code and not name:
+                    raise ValueError("未选色粉时,进货编号和商品名至少填一个")
+                pr = PendingReview(
+                    type="in", pigment_code="",
+                    purchase_code=purchase_code, name=name,
+                    quantity=qty, unit_price=price,
+                    reason="未填色粉编号,只有进货编号",
+                    note=note,
+                )
+                db.session.add(pr)
+                db.session.commit()
+                flash("已加入待审核,请到「待审核」页补填色粉编号", "info")
             return redirect(url_for("transactions.in_list"))
         except Exception as e:
             flash(f"失败:{e}", "danger")
@@ -57,13 +74,27 @@ def out_new():
             pid = int(request.form["pigment_id"])
             qty_g = float(request.form["quantity"])  # 输入克
             qty = round(qty_g / 1000.0, 6)
-            note = request.form.get("note", "")
-            if note:
-                note = f"{qty_g}g / {note}"
+            note_raw = request.form.get("note", "")
+            note_full = f"{qty_g}g / {note_raw}" if note_raw else f"{qty_g}g"
+            stock = Stock.query.get(pid)
+            if stock is None or stock.quantity < qty:
+                p = Pigment.query.get(pid)
+                cur = stock.quantity if stock else 0
+                pr = PendingReview(
+                    type="out",
+                    pigment_code=p.code if p else "",
+                    purchase_code=p.purchase_code if p else "",
+                    name=p.name if p else "",
+                    quantity=qty_g,
+                    reason=f"库存不足,扣减后会变负(当前 {cur}kg,需 {qty}kg)",
+                    note=note_full,
+                )
+                db.session.add(pr)
+                db.session.commit()
+                flash("库存不足,已加入待审核", "info")
             else:
-                note = f"{qty_g}g"
-            stock_out(pid, qty, note=note)
-            flash("已出库", "success")
+                stock_out(pid, qty, note=note_full)
+                flash("已出库", "success")
             return redirect(url_for("transactions.out_list"))
         except InsufficientStock as e:
             flash(str(e), "danger")
@@ -99,10 +130,58 @@ def _ocr_upload(tx_type: str):
         code_map = {p.id: p.code for p in Pigment.query.filter_by(is_archived=False).all()}
         for r in rows:
             r["pigment_code"] = code_map.get(r.get("pigment_id"), "")
+        if tx_type == "out":
+            _apply_out_dilution(rows, lookup, code_map)
         if fallback_used:
             flash("LLM 识别不可用,已用本地 OCR 兜底(可能精度较低)", "warning")
         return render_template(template, rows=rows, pigments=_pigments())
     return render_template(template, rows=None, pigments=_pigments())
+
+
+# 出库 OCR 的 A/B 冲淡公式:
+# - B 前缀: 实际 = 数量 × 1%, 余量 (99%) 合并到 33A
+# - A 前缀: 实际 = 数量 × 10%, 余量 (90%) 合并到 33A
+# 前缀检测: 原码不在色粉表 + 去掉首字母后在色粉表 (避免 ABS740 这类编号误判)
+_DILUTION_BASE_CODE = "33A"
+_DILUTION_FACTORS = {"a": 0.1, "b": 0.01}
+
+
+def _apply_out_dilution(rows: list[dict], lookup: dict[str, int], code_map: dict[int, str]) -> None:
+    base_remainder = 0.0
+    for r in rows:
+        code = (r.get("purchase_code") or "").strip()
+        if len(code) < 2:
+            continue
+        first = code[0].lower()
+        factor = _DILUTION_FACTORS.get(first)
+        if factor is None:
+            continue
+        low = code.lower()
+        # 只在 "原码查不到 + 去前缀能查到" 时判定为儿子
+        if low in lookup or low[1:] not in lookup:
+            continue
+        qty = float(r.get("quantity") or 0)
+        if qty <= 0:
+            continue
+        actual = round(qty * factor, 2)
+        base_remainder += qty - actual
+        r["quantity"] = actual
+    if base_remainder <= 0:
+        return
+    base_id = lookup.get(_DILUTION_BASE_CODE.lower())
+    for r in rows:
+        if (r.get("pigment_code") or "").upper() == _DILUTION_BASE_CODE \
+                or (r.get("purchase_code") or "").upper() == _DILUTION_BASE_CODE:
+            r["quantity"] = round(float(r.get("quantity") or 0) + base_remainder, 2)
+            return
+    rows.append({
+        "raw": f"(自动合成) {_DILUTION_BASE_CODE} 余量 {base_remainder:.2f}",
+        "pigment_id": base_id,
+        "pigment_code": code_map.get(base_id, _DILUTION_BASE_CODE) if base_id else _DILUTION_BASE_CODE,
+        "purchase_code": _DILUTION_BASE_CODE,
+        "quantity": round(base_remainder, 2),
+        "unit_price": 0,
+    })
 
 
 @bp.route("/in/ocr", methods=["GET", "POST"])
@@ -127,122 +206,105 @@ def out_ocr_submit():
 
 def _ocr_submit(tx_type: str):
     qtys = request.form.getlist("quantity[]")
-    success = failed = 0
+    success = 0
+    pending_count = 0
     errors = []
-    # 出库:用 pigment_code[] 搜索/手动输入模式;未匹配的自动新建占位色粉,允许负库存
+    # 出库:pigment_code[] 找不到色粉 → 待审核;找到但库存不够 → 待审核
     if tx_type == "out":
         codes = request.form.getlist("pigment_code[]")
-        auto_created = 0
         for i, (code_text, qty) in enumerate(zip(codes, qtys)):
             code_text = (code_text or "").strip()
             if not code_text or not qty or float(qty) <= 0:
                 continue
+            qty_g = float(qty)
+            qty_kg = round(qty_g / 1000.0, 6)
             pigment = (Pigment.query
                        .filter_by(is_archived=False)
                        .filter((Pigment.code == code_text) | (Pigment.purchase_code == code_text))
                        .first())
-            auto_new = False
             if pigment is None:
-                # 未匹配:自动新建占位,code 留空待复核,code_text 写入 purchase_code
-                pigment = Pigment(
-                    brand="未分类", code="", name=code_text[:128] or "待填",
-                    purchase_code=code_text,
-                    notes="OCR 自动新建,待复核",
-                )
-                db.session.add(pigment)
-                db.session.flush()
-                auto_new = True
-                auto_created += 1
+                db.session.add(PendingReview(
+                    type="out", pigment_code=code_text, purchase_code="", name="",
+                    quantity=qty_g,
+                    reason="色粉编号未在库存中找到",
+                    note="拍照识别",
+                ))
+                pending_count += 1
+                continue
+            stock = Stock.query.get(pigment.id)
+            cur = stock.quantity if stock else 0
+            if cur < qty_kg:
+                db.session.add(PendingReview(
+                    type="out",
+                    pigment_code=pigment.code, purchase_code=pigment.purchase_code,
+                    name=pigment.name,
+                    quantity=qty_g,
+                    reason=f"库存不足,扣减后会变负(当前 {cur}kg,需 {qty_kg}kg)",
+                    note="拍照识别",
+                ))
+                pending_count += 1
+                continue
             try:
-                qty_g = float(qty)
-                stock_out(pigment.id, round(qty_g / 1000.0, 6),
-                          note=f"拍照识别 {qty_g}g" + ("(自动新建待复核)" if auto_new else ""),
-                          allow_negative=auto_new)
+                stock_out(pigment.id, qty_kg, note=f"拍照识别 {qty_g}g")
                 success += 1
             except Exception as e:
-                db.session.rollback()
-                failed += 1
                 errors.append(f"第{i+1}行:{e}")
-        msg = f"已记录 {success} 条"
-        if auto_created:
-            msg += f"(其中 {auto_created} 条自动新建待复核)"
+        db.session.commit()
+        parts = []
+        if success:
+            parts.append(f"已出库 {success} 条")
+        if pending_count:
+            parts.append(f"{pending_count} 条进待审核")
+        msg = ",".join(parts) if parts else "无有效数据"
         if errors:
-            flash(f"{msg},失败 {failed}:{'; '.join(errors[:5])}", "warning")
+            flash(f"{msg},失败 {len(errors)}:{'; '.join(errors[:5])}", "warning")
         else:
-            flash(msg, "success")
+            flash(msg, "info" if pending_count else "success")
         return redirect(url_for("transactions.out_list"))
-    # 入库:pigment_id[] 非空且为有效整数 → 已匹配,直接入库;否则按 new_code/purchase_code 自动新建
+
+    # 入库:pigment_id[] 有值 → 直接入库;否则 → 待审核
     pids = request.form.getlist("pigment_id[]")
     prices = request.form.getlist("unit_price[]")
     new_codes = request.form.getlist("new_code[]")
     purchase_codes = request.form.getlist("purchase_code[]")
-    auto_created = 0
     for i, (pid, qty) in enumerate(zip(pids, qtys)):
         if not qty or float(qty) <= 0:
             continue
-        price = prices[i] if i < len(prices) else ""
-        matched_id = None
-        if pid and pid.strip().isdigit():
-            matched_id = int(pid.strip())
+        price_raw = prices[i] if i < len(prices) else ""
+        price = float(price_raw) if price_raw else None
+        matched_id = int(pid.strip()) if pid and pid.strip().isdigit() else None
         if matched_id is not None:
             try:
-                stock_in(matched_id, float(qty),
-                         unit_price=float(price) if price else None,
-                         note="拍照识别")
+                stock_in(matched_id, float(qty), unit_price=price, note="拍照识别")
                 success += 1
             except Exception as e:
-                failed += 1
                 errors.append(f"第{i+1}行:{e}")
             continue
-        # 未匹配:先按 (new_code 填了优先,否则 purchase_code) 二次精确匹配已有色粉;
-        # 找到 → 累加到已有色粉;找不到 → 新建 brand="未分类" 待复核
+        # 未匹配 → 待审核
         new_code = new_codes[i].strip() if i < len(new_codes) else ""
         purchase_code = purchase_codes[i].strip() if i < len(purchase_codes) else ""
-        code = new_code or purchase_code
-        if code:
-            # 二次匹配:先按 code 精确匹配(对应用户原话"色粉编号相同=一致"),
-            # 没找到再按 purchase_code 匹配(对应"进货编号相同也视为同一色粉")
-            existing = Pigment.query.filter_by(code=code, is_archived=False).first()
-            if existing is None:
-                existing = Pigment.query.filter_by(purchase_code=code, is_archived=False).first()
-            if existing:
-                try:
-                    stock_in(existing.id, float(qty),
-                             unit_price=float(price) if price else None,
-                             note="拍照识别(进货编号精确匹配)")
-                    success += 1
-                except Exception as e:
-                    failed += 1
-                    errors.append(f"第{i+1}行:{e}")
-                continue
-        display_name = code or f"待填-{datetime.now():%H%M%S}"
-        try:
-            pigment = Pigment(
-                brand="未分类",
-                code=code,
-                name=display_name,
-                purchase_code=purchase_code,
-                unit_price=float(price) if price else 0,
-                notes="OCR 自动新建,待复核" if not new_code else "",
-            )
-            db.session.add(pigment)
-            db.session.flush()
-            stock_in(pigment.id, float(qty),
-                     unit_price=float(price) if price else None,
-                     note="拍照识别(自动新建)")
-            success += 1
-            auto_created += 1
-        except Exception as e:
-            db.session.rollback()
-            failed += 1
-            errors.append(f"第{i+1}行:{e}")
-    msg = f"已记录 {success} 条"
-    if auto_created:
-        msg += f"(其中 {auto_created} 条自动新建待复核)"
+        db.session.add(PendingReview(
+            type="in",
+            pigment_code=new_code,
+            purchase_code=purchase_code,
+            name=new_code or purchase_code,
+            quantity=float(qty),
+            unit_price=price,
+            reason="未填色粉编号,只有进货编号",
+            note="拍照识别",
+        ))
+        pending_count += 1
+    db.session.commit()
+    parts = []
+    if success:
+        parts.append(f"已入库 {success} 条")
+    if pending_count:
+        parts.append(f"{pending_count} 条进待审核")
+    msg = ",".join(parts) if parts else "无有效数据"
     if errors:
-        flash(f"{msg},失败 {failed}:{'; '.join(errors[:5])}", "warning")
+        flash(f"{msg},失败 {len(errors)}:{'; '.join(errors[:5])}", "warning")
     else:
-        flash(msg, "success")
+        flash(msg, "info" if pending_count else "success")
     return redirect(url_for(f"transactions.{tx_type}_list"))
 
 

--- a/apps/PMC跟仓管/配色库存管理/app/templates/base.html
+++ b/apps/PMC跟仓管/配色库存管理/app/templates/base.html
@@ -10,14 +10,20 @@
 </head>
 <body>
 <div class="d-flex">
-  <nav class="sidebar bg-dark text-white p-3" style="width:220px; min-height:100vh;">
+  <nav class="sidebar bg-dark text-white p-3 d-flex flex-column" style="width:220px; min-height:100vh;">
     <h5 class="mb-4"><i class="bi bi-palette-fill"></i> 配色库存</h5>
-    <ul class="nav flex-column">
+    <ul class="nav flex-column flex-grow-1">
       <li><a class="nav-link text-white" href="{{ url_for('dashboard.index') }}"><i class="bi bi-speedometer2"></i> 仪表盘</a></li>
       <li><a class="nav-link text-white" href="{{ url_for('pigments.index') }}"><i class="bi bi-droplet-fill"></i> 库存</a></li>
       <li><a class="nav-link text-white" href="{{ url_for('transactions.in_list') }}"><i class="bi bi-box-arrow-in-down"></i> 入库</a></li>
       <li><a class="nav-link text-white" href="{{ url_for('transactions.out_list') }}"><i class="bi bi-box-arrow-up"></i> 出库</a></li>
+      <li><a class="nav-link text-white" href="{{ url_for('pending.index') }}"><i class="bi bi-hourglass-split"></i> 待审核</a></li>
     </ul>
+    <form method="post" action="{{ url_for('auth.logout') }}" class="mt-auto">
+      <button type="submit" class="btn btn-outline-light btn-sm w-100">
+        <i class="bi bi-box-arrow-right"></i> 注销
+      </button>
+    </form>
   </nav>
   <main class="flex-grow-1 p-4">
     {% with messages = get_flashed_messages(with_categories=true) %}

--- a/apps/PMC跟仓管/配色库存管理/app/templates/login.html
+++ b/apps/PMC跟仓管/配色库存管理/app/templates/login.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<title>登录 · 配色库存</title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+<div class="container" style="max-width:420px; margin-top:12vh">
+  <div class="card shadow-sm">
+    <div class="card-body p-4">
+      <h4 class="mb-4 text-center"><i class="bi bi-palette-fill text-primary"></i> 配色库存</h4>
+      {% with messages = get_flashed_messages(with_categories=true) %}
+        {% for category, msg in messages %}
+          <div class="alert alert-{{ category }} py-2">{{ msg }}</div>
+        {% endfor %}
+      {% endwith %}
+      <form method="post">
+        <input type="hidden" name="next" value="{{ next }}">
+        <div class="mb-3">
+          <label class="form-label">账号</label>
+          <input name="username" class="form-control" autofocus required autocomplete="username">
+        </div>
+        <div class="mb-3">
+          <label class="form-label">密码</label>
+          <input type="password" name="password" class="form-control" required autocomplete="current-password">
+        </div>
+        <div class="form-check mb-3">
+          <input class="form-check-input" type="checkbox" name="remember" id="remember" value="1">
+          <label class="form-check-label" for="remember">记住我 7 天</label>
+        </div>
+        <button class="btn btn-primary w-100"><i class="bi bi-box-arrow-in-right"></i> 登录</button>
+      </form>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/apps/PMC跟仓管/配色库存管理/app/templates/pending/index.html
+++ b/apps/PMC跟仓管/配色库存管理/app/templates/pending/index.html
@@ -1,0 +1,77 @@
+{% extends "base.html" %}
+{% block content %}
+<h3>待审核</h3>
+<p class="text-muted">
+  入库只有进货编号没填色粉编号、出库色粉查不到、或出库会导致库存变负,都会进到这里。
+  手动补全色粉编号后点"确认",系统会自动找对应色粉做入/出库。
+</p>
+
+{% if not items %}
+<div class="alert alert-secondary">暂无待审核项。</div>
+{% else %}
+
+{# 每行有两个 form(resolve + reject),用 form="id" 属性关联,避免 <form> 跨 <td> 的 HTML 兼容性问题 #}
+{% for it in items %}
+  <form id="resolve-{{ it.id }}" method="post" action="{{ url_for('pending.resolve', rid=it.id) }}"></form>
+  <form id="reject-{{ it.id }}" method="post" action="{{ url_for('pending.reject', rid=it.id) }}"
+        onsubmit="return confirm('确定驳回?不会改动库存')"></form>
+{% endfor %}
+
+<table class="table table-sm align-middle">
+  <thead>
+    <tr>
+      <th>类型</th>
+      <th>色粉编号</th>
+      <th>进货编号</th>
+      <th>商品名</th>
+      <th>数量</th>
+      <th>单价</th>
+      <th>原因</th>
+      <th>备注</th>
+      <th>创建时间</th>
+      <th style="width:210px">操作</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for it in items %}
+    <tr>
+      <td>
+        {% if it.type == 'in' %}
+          <span class="badge bg-success">入库</span>
+        {% else %}
+          <span class="badge bg-danger">出库</span>
+        {% endif %}
+      </td>
+      <td><input form="resolve-{{ it.id }}" name="pigment_code" value="{{ it.pigment_code }}"
+                 class="form-control form-control-sm" placeholder="色粉编号" required></td>
+      <td><small class="text-muted">{{ it.purchase_code or '—' }}</small></td>
+      <td><small class="text-muted">{{ it.name or '—' }}</small></td>
+      <td>
+        <div class="input-group input-group-sm" style="width:140px">
+          <input form="resolve-{{ it.id }}" type="number" name="quantity" step="0.01" min="0.01"
+                 value="{{ '%.2f'|format(it.quantity) }}" class="form-control form-control-sm" required>
+          <span class="input-group-text">{{ 'kg' if it.type == 'in' else 'g' }}</span>
+        </div>
+      </td>
+      <td>
+        {% if it.type == 'in' %}
+          <input form="resolve-{{ it.id }}" type="number" name="unit_price" step="0.01"
+                 value="{% if it.unit_price is not none %}{{ '%.2f'|format(it.unit_price) }}{% endif %}"
+                 class="form-control form-control-sm" style="width:100px">
+        {% else %}—{% endif %}
+      </td>
+      <td><small class="text-danger">{{ it.reason }}</small></td>
+      <td><small class="text-muted">{{ it.note or '—' }}</small></td>
+      <td><small class="text-muted">{{ it.created_at.strftime('%m-%d %H:%M') if it.created_at else '—' }}</small></td>
+      <td>
+        <button form="resolve-{{ it.id }}" class="btn btn-sm btn-primary" type="submit">
+          <i class="bi bi-check2"></i> 确认{{ '入库' if it.type == 'in' else '出库' }}
+        </button>
+        <button form="reject-{{ it.id }}" class="btn btn-sm btn-outline-secondary" type="submit">驳回</button>
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endif %}
+{% endblock %}

--- a/apps/PMC跟仓管/配色库存管理/app/templates/transactions/in_form.html
+++ b/apps/PMC跟仓管/配色库存管理/app/templates/transactions/in_form.html
@@ -2,13 +2,16 @@
 {% block content %}
 <h3>入库</h3>
 <form method="post" style="max-width:600px">
-  <div class="mb-3"><label>色粉</label>
-    <select name="pigment_id" class="form-select" required>
+  <div class="mb-3"><label>色粉(可留空 — 留空走待审核)</label>
+    <select name="pigment_id" class="form-select">
+      <option value="">— 留空(仅填进货编号,走待审核) —</option>
       {% for p in pigments %}
         <option value="{{ p.id }}" {% if preselect==p.id %}selected{% endif %}>{{ p.code or '(待填)' }}{% if p.purchase_code %} / {{ p.purchase_code }}{% endif %}(当前 {{ p.stock.quantity if p.stock else 0 }})</option>
       {% endfor %}
     </select>
   </div>
+  <div class="mb-3"><label>进货编号(色粉留空时必填)</label><input name="purchase_code" class="form-control" placeholder="例如 A-123"></div>
+  <div class="mb-3"><label>商品名(色粉留空时建议填)</label><input name="name" class="form-control" placeholder="例如 红色粉"></div>
   <div class="mb-3"><label>数量</label><input type="number" step="0.01" name="quantity" class="form-control" min="0.01" required> <span class="text-muted">kg</span></div>
   <div class="mb-3"><label>进货单价(元,可选)</label><input type="number" step="0.01" name="unit_price" class="form-control"></div>
   <div class="mb-3"><label>备注</label><textarea name="note" class="form-control"></textarea></div>

--- a/apps/PMC跟仓管/配色库存管理/requirements.txt
+++ b/apps/PMC跟仓管/配色库存管理/requirements.txt
@@ -6,3 +6,4 @@ pytest==8.0.0
 requests>=2.31
 Pillow>=10
 gunicorn>=21
+python-dotenv>=1.0

--- a/docker-compose.cloud.yml
+++ b/docker-compose.cloud.yml
@@ -414,6 +414,10 @@ services:
       - BAILIAN_API_KEY=${PEISE_BAILIAN_API_KEY:-}
       - BAILIAN_MODEL=${PEISE_BAILIAN_MODEL:-qwen-vl-max-latest}
       - BAILIAN_BASE_URL=${PEISE_BAILIAN_BASE_URL:-https://dashscope.aliyuncs.com/compatible-mode/v1}
+      # 登录凭据(默认 ps/ps123456,改要改 .env.cloud 的 PEISE_AUTH_*)
+      # SECRET_KEY 不传,app 会在 instance/.secret_key 自建并持久化
+      - AUTH_USERNAME=${PEISE_AUTH_USERNAME:-ps}
+      - AUTH_PASSWORD=${PEISE_AUTH_PASSWORD:-ps123456}
     volumes:
       - ./apps/PMC跟仓管/配色库存管理/instance:/app/instance
     healthcheck:


### PR DESCRIPTION
- 登录: 单账号 ps/ps123456, 7 天"记住我", SECRET_KEY 自动在 instance/.secret_key 持久化
- 待审核: 入库漏填色粉编号、出库色粉查不到、出库会变负库存,三类都进 /pending/
- OCR: 出库识别套 B=1%/A=10% 冲淡公式,余量汇总到 33A
- 修复: 出库自动新建色粉时, OCR 识别的编号错放到进货编号栏(应该是色粉编号)
- docker-compose.cloud.yml: peise 加 AUTH_USERNAME/AUTH_PASSWORD 默认值(ps/ps123456), 无需改 .env.cloud 即可部署