### PR TITLE
fix(工程啤办单): 啤机部任务单新增「啤办费缺」徽章

### DIFF
--- a/apps/工程部/工程啤办单/public/injection.html
+++ b/apps/工程部/工程啤办单/public/injection.html
@@ -412,6 +412,13 @@ function renderOrders(orders) {
       if (o.status === '已完成') return !(+(it.actual_amount_hkd || 0) > 0);
       return !resolvePrice(it.material, _injMatPrices);
     });
+    // 缺啤办费：已完成订单（非发至模厂/湖南）中有明细未填 injection_cost
+    const isSendTo = o.send_to === '发至模厂' || o.send_to === '发至湖南' || o.workshop === '模厂';
+    const hasMissingInj = o.status === '已完成' && !isSendTo && (o.items || []).some(it => {
+      const raw = it.injection_cost;
+      const hkd = it.injection_cost_hkd;
+      return (raw === null || raw === undefined || raw === '') && (hkd === null || hkd === undefined || hkd === '');
+    });
     return `
     <tr class="order-row" onclick="viewOrder(${o.id})">
       <td><strong>${esc(o.order_number || '-')}</strong></td>
@@ -428,6 +435,7 @@ function renderOrders(orders) {
       <td>
         ${statusBadge(o.status)}
         ${hasMissingPrice ? '<span class="badge bg-warning text-dark ms-1" title="部分原料料费为 0（可能未录入价格或未填实际领料）"><i class="bi bi-exclamation-circle me-1"></i>料价缺</span>' : ''}
+        ${hasMissingInj ? '<span class="badge bg-warning text-dark ms-1" title="部分模具未填啤办费"><i class="bi bi-exclamation-circle me-1"></i>啤办费缺</span>' : ''}
         ${problemsMap[o.id] ? `<span class="badge bg-danger ms-1"><i class="bi bi-exclamation-triangle-fill me-1"></i>${problemsMap[o.id]}个问题</span>` : ''}
       </td>
       <td>


### PR DESCRIPTION
## Summary
啤机部任务单列表新增「啤办费缺」徽章，和现有「料价缺」徽章并列。

**触发条件**（同总费用表逻辑）：
- 订单状态为「已完成」
- 非发至模厂/湖南订单
- 任一明细的 \`injection_cost\` 和 \`injection_cost_hkd\` 都未填

**效果**：啤机部用户一眼看到哪些已完成订单需要补录啤办费，无需进总费用表 Tab。

## Changed files
- \`apps/工程部/工程啤办单/public/injection.html\` — 订单列表 hasMissingInj 判断 + badge 渲染

## Test plan
- [ ] 已完成订单未填 injection_cost → 状态列显示黄色「啤办费缺」
- [ ] 已完成订单填了 injection_cost → 不显示
- [ ] 发至模厂/湖南订单 → 不显示
- [ ] 生产中/待生产订单 → 不显示（只对已完成生效）

🤖 Generated with [Claude Code](https://claude.com/claude-code)