### PR TITLE
feat(peise): 编辑入库 + RMB→HKD 换算 + OCR 修复 + 金额 1 位小数

### DIFF
--- a/apps/PMC跟仓管/配色库存管理/app/__init__.py
+++ b/apps/PMC跟仓管/配色库存管理/app/__init__.py
@@ -20,12 +20,13 @@ def create_app(config_class=Config):
 
     db.init_app(app)
 
-    from .routes import dashboard, pigments, transactions, pending, auth as auth_routes
+    from .routes import dashboard, pigments, transactions, pending, settings as settings_routes, auth as auth_routes
     app.register_blueprint(auth_routes.bp)
     app.register_blueprint(dashboard.bp)
     app.register_blueprint(pigments.bp, url_prefix="/pigments")
     app.register_blueprint(transactions.bp, url_prefix="/transactions")
     app.register_blueprint(pending.bp, url_prefix="/pending")
+    app.register_blueprint(settings_routes.bp, url_prefix="/settings")
 
     from .auth import install_login_guard
     install_login_guard(app)
@@ -38,8 +39,19 @@ def create_app(config_class=Config):
     with app.app_context():
         db.create_all()
         _migrate_uq_brand_code_partial()
+        _migrate_pending_review_ref_tx_id()
 
     return app
+
+
+def _migrate_pending_review_ref_tx_id():
+    """把 pending_review.ref_tx_id 列加到老表(支持 type='edit_in')。幂等。"""
+    from sqlalchemy import text
+    conn = db.session.connection()
+    cols = {r[1] for r in conn.execute(text("PRAGMA table_info(pending_review)"))}
+    if "ref_tx_id" not in cols:
+        conn.execute(text("ALTER TABLE pending_review ADD COLUMN ref_tx_id INTEGER"))
+        db.session.commit()
 
 
 def _ensure_secret_key(app):

--- a/apps/PMC跟仓管/配色库存管理/app/models.py
+++ b/apps/PMC跟仓管/配色库存管理/app/models.py
@@ -51,13 +51,21 @@ class Transaction(db.Model):
     pigment = db.relationship("Pigment", back_populates="transactions")
 
 
+class Setting(db.Model):
+    """简单 key-value 配置表;目前只放汇率。"""
+    __tablename__ = "setting"
+    key = db.Column(db.String(64), primary_key=True)
+    value = db.Column(db.String(255), nullable=False, default="")
+    updated_at = db.Column(db.DateTime, default=datetime.now, onupdate=datetime.now)
+
+
 class PendingReview(db.Model):
     """待审核:入库未填色粉编号、出库找不到色粉或库存不足,都进这里等人工处理。
-    quantity 单位跟随 type: in=kg, out=克 (和表单输入一致,resolve 时再换算)。
+    quantity 单位跟随 type: in=kg, out=克, edit_in=kg (和表单输入一致,resolve 时再换算)。
     """
     __tablename__ = "pending_review"
     id = db.Column(db.Integer, primary_key=True)
-    type = db.Column(db.String(8), nullable=False)  # 'in' or 'out'
+    type = db.Column(db.String(16), nullable=False)  # 'in' / 'out' / 'edit_in'
     pigment_code = db.Column(db.String(64), nullable=False, default="")
     purchase_code = db.Column(db.String(64), nullable=False, default="")
     name = db.Column(db.String(128), nullable=False, default="")
@@ -65,5 +73,7 @@ class PendingReview(db.Model):
     unit_price = db.Column(db.Float, nullable=True)
     reason = db.Column(db.String(256), nullable=False)
     note = db.Column(db.Text, default="")
+    # type='edit_in' 时,指向要改的原交易 id;其他 type 留空
+    ref_tx_id = db.Column(db.Integer, nullable=True)
     created_at = db.Column(db.DateTime, default=datetime.now)
 

--- a/apps/PMC跟仓管/配色库存管理/app/routes/pending.py
+++ b/apps/PMC跟仓管/配色库存管理/app/routes/pending.py
@@ -1,7 +1,8 @@
 from flask import Blueprint, render_template, request, redirect, url_for, flash
+from sqlalchemy import func
 
 from app.extensions import db
-from app.models import PendingReview, Pigment, Stock
+from app.models import PendingReview, Pigment, Stock, Transaction
 from app.services.inventory import stock_in, stock_out, InsufficientStock
 
 bp = Blueprint("pending", __name__)
@@ -25,24 +26,66 @@ def resolve(rid):
         flash("色粉编号和数量必填", "danger")
         return redirect(url_for("pending.index"))
 
+    low = code.lower()
     pigment = (Pigment.query
                .filter_by(is_archived=False)
-               .filter((Pigment.code == code) | (Pigment.purchase_code == code))
+               .filter((func.lower(Pigment.code) == low) |
+                       (func.lower(Pigment.purchase_code) == low))
                .first())
+
+    if item.type == "edit_in":
+        # 强制应用入库修改(允许负库存),按 pending 里存的 pigment_code/quantity/unit_price/note
+        if pigment is None:
+            flash(f"找不到色粉 {code}", "danger")
+            return redirect(url_for("pending.index"))
+        tx = Transaction.query.get(item.ref_tx_id) if item.ref_tx_id else None
+        if tx is None or tx.type != "in":
+            flash(f"原入库流水 #{item.ref_tx_id} 不存在或类型不符", "danger")
+            return redirect(url_for("pending.index"))
+        price_raw = (request.form.get("unit_price") or "").strip()
+        price = float(price_raw) if price_raw else None
+        new_note = request.form.get("note", item.note or "")
+        try:
+            # 回退旧色粉(允许负库存),给新色粉加
+            old_stock = Stock.query.get(tx.pigment_id)
+            if old_stock is None:
+                old_stock = Stock(pigment_id=tx.pigment_id, quantity=0)
+                db.session.add(old_stock)
+            old_stock.quantity = round(old_stock.quantity - tx.quantity, 6)
+            new_stock = Stock.query.get(pigment.id)
+            if new_stock is None:
+                new_stock = Stock(pigment_id=pigment.id, quantity=0)
+                db.session.add(new_stock)
+            new_stock.quantity = round(new_stock.quantity + qty, 6)
+            tx.pigment_id = pigment.id
+            tx.quantity = qty
+            tx.unit_price = price
+            tx.note = new_note
+            db.session.delete(item)
+            db.session.commit()
+            flash(f"已强制应用入库修改(可能产生负库存,请去「库存」页核对)", "success")
+        except Exception as e:
+            db.session.rollback()
+            flash(f"修改失败:{e}", "danger")
+        return redirect(url_for("pending.index"))
 
     if item.type == "in":
         price_raw = (request.form.get("unit_price") or "").strip()
         price = float(price_raw) if price_raw else None
+        purchase_code = (request.form.get("purchase_code") or "").strip()
         if pigment is None:
             pigment = Pigment(
                 brand="未分类", code=code,
                 name=(item.name or code)[:128],
-                purchase_code=item.purchase_code or "",
+                purchase_code=purchase_code,
                 unit_price=price or 0,
                 notes=f"由待审核 #{item.id} 补填",
             )
             db.session.add(pigment)
             db.session.flush()
+        elif purchase_code and not pigment.purchase_code:
+            # 已有色粉没填 purchase_code,补上用户编辑的值
+            pigment.purchase_code = purchase_code
         try:
             stock_in(pigment.id, qty, unit_price=price,
                      note=f"由待审核 #{item.id} 补填")
@@ -66,7 +109,9 @@ def resolve(rid):
 
     db.session.delete(item)
     db.session.commit()
-    flash(f"已完成 {'入库' if item.type == 'in' else '出库'}", "success")
+    cur_stock = Stock.query.get(pigment.id)
+    cur_kg = cur_stock.quantity if cur_stock else 0
+    flash(f"已完成{'入库' if item.type == 'in' else '出库'}:色粉 {pigment.code or pigment.purchase_code} 当前库存 {cur_kg}kg", "success")
     return redirect(url_for("pending.index"))
 
 

--- a/apps/PMC跟仓管/配色库存管理/app/routes/pigments.py
+++ b/apps/PMC跟仓管/配色库存管理/app/routes/pigments.py
@@ -16,7 +16,7 @@ def index():
 def _form_to_pigment(p):
     p.code = request.form["code"].strip()
     p.purchase_code = request.form.get("purchase_code", "").strip()
-    p.unit_price = float(request.form.get("unit_price", 0) or 0)
+    p.unit_price = round(float(request.form.get("unit_price", 0) or 0), 1)
     # 确保必填字段有默认值(品牌、色名等已不再从表单传入)
     if not p.name:
         p.name = p.code

--- a/apps/PMC跟仓管/配色库存管理/app/routes/settings.py
+++ b/apps/PMC跟仓管/配色库存管理/app/routes/settings.py
@@ -1,0 +1,20 @@
+from flask import Blueprint, render_template, request, redirect, url_for, flash
+
+from app.services.exchange import get_rate, set_rate
+
+bp = Blueprint("settings", __name__)
+
+
+@bp.route("/", methods=["GET", "POST"])
+def index():
+    if request.method == "POST":
+        try:
+            rate = float(request.form.get("rate") or 0)
+            if rate <= 0:
+                raise ValueError("汇率必须 > 0")
+            set_rate(rate)
+            flash(f"汇率已更新为 1 HKD = {rate} RMB", "success")
+            return redirect(url_for("settings.index"))
+        except Exception as e:
+            flash(f"保存失败:{e}", "danger")
+    return render_template("settings/index.html", rate=get_rate())

--- a/apps/PMC跟仓管/配色库存管理/app/routes/transactions.py
+++ b/apps/PMC跟仓管/配色库存管理/app/routes/transactions.py
@@ -5,7 +5,7 @@ from sqlalchemy import func
 from app.extensions import db
 from app.models import Pigment, Stock, Transaction, PendingReview
 from app.services.inventory import stock_in, stock_out, InsufficientStock
-from app.services.exchange import rmb_to_hkd, hkd_to_rmb
+from app.services.exchange import rmb_to_hkd, hkd_to_rmb, get_rate
 
 
 def _find_pigment_by_code(code: str) -> Pigment | None:
@@ -369,12 +369,14 @@ def _ocr_submit(tx_type: str):
     prices = request.form.getlist("unit_price[]")
     new_codes = request.form.getlist("new_code[]")
     purchase_codes = request.form.getlist("purchase_code[]")
+    # 批量入库共用同一个汇率,避免每行重新查 Setting 表
+    batch_rate = get_rate()
     for i, (pid, qty) in enumerate(zip(pids, qtys)):
         if not qty or float(qty) <= 0:
             continue
         price_raw = prices[i] if i < len(prices) else ""
         price_rmb = float(price_raw) if price_raw else None
-        price = rmb_to_hkd(price_rmb)  # OCR 表单 RMB → 存 HKD
+        price = rmb_to_hkd(price_rmb, rate=batch_rate)  # OCR 表单 RMB → 存 HKD
         new_code = new_codes[i].strip() if i < len(new_codes) else ""
         purchase_code = purchase_codes[i].strip() if i < len(purchase_codes) else ""
 

--- a/apps/PMC跟仓管/配色库存管理/app/routes/transactions.py
+++ b/apps/PMC跟仓管/配色库存管理/app/routes/transactions.py
@@ -1,9 +1,25 @@
 from datetime import datetime
 
 from flask import Blueprint, render_template, request, redirect, url_for, flash, current_app
+from sqlalchemy import func
 from app.extensions import db
 from app.models import Pigment, Stock, Transaction, PendingReview
 from app.services.inventory import stock_in, stock_out, InsufficientStock
+from app.services.exchange import rmb_to_hkd, hkd_to_rmb
+
+
+def _find_pigment_by_code(code: str) -> Pigment | None:
+    """case-insensitive 查已有色粉;code 在 code 或 purchase_code 命中即算。"""
+    if not code:
+        return None
+    low = code.strip().lower()
+    if not low:
+        return None
+    return (Pigment.query
+            .filter_by(is_archived=False)
+            .filter((func.lower(Pigment.code) == low) |
+                    (func.lower(Pigment.purchase_code) == low))
+            .first())
 
 bp = Blueprint("transactions", __name__)
 
@@ -39,7 +55,8 @@ def in_new():
             pid_raw = (request.form.get("pigment_id") or "").strip()
             qty = float(request.form["quantity"])
             price_raw = (request.form.get("unit_price") or "").strip()
-            price = float(price_raw) if price_raw else None
+            price_rmb = float(price_raw) if price_raw else None
+            price = rmb_to_hkd(price_rmb)  # 用户输入 RMB,存 HKD
             note = request.form.get("note", "")
             purchase_code = (request.form.get("purchase_code") or "").strip()
             name = (request.form.get("name") or "").strip()
@@ -65,6 +82,94 @@ def in_new():
     return render_template("transactions/in_form.html",
                            pigments=_pigments(),
                            preselect=request.args.get("pigment_id", type=int))
+
+
+@bp.route("/in/<int:tx_id>/edit", methods=["GET", "POST"])
+def in_edit(tx_id):
+    tx = Transaction.query.get_or_404(tx_id)
+    if tx.type != "in":
+        flash("该交易不是入库,无法用此页面编辑", "danger")
+        return redirect(url_for("transactions.in_list"))
+
+    if request.method == "POST":
+        try:
+            new_pid = int(request.form["pigment_id"])
+            new_qty = float(request.form["quantity"])
+            new_price_raw = (request.form.get("unit_price") or "").strip()
+            new_price_rmb = float(new_price_raw) if new_price_raw else None
+            new_price = rmb_to_hkd(new_price_rmb)  # 表单 RMB → 存 HKD
+            new_note = request.form.get("note", "")
+            new_time_raw = (request.form.get("occurred_at") or "").strip()
+            new_time = datetime.strptime(new_time_raw, "%Y-%m-%dT%H:%M") if new_time_raw else tx.occurred_at
+
+            old_pid = tx.pigment_id
+            old_qty = tx.quantity
+            old_stock = Stock.query.get(old_pid)
+            old_cur = old_stock.quantity if old_stock else 0
+
+            if new_pid == old_pid:
+                # 同色粉:差值直接加到库存
+                delta = round(new_qty - old_qty, 6)
+                new_balance = round(old_cur + delta, 6)
+                if new_balance < 0:
+                    _create_edit_in_pending(tx, new_pid, new_qty, new_price, new_note,
+                                            f"库存不足以回退差额(当前 {old_cur}kg,差额 {delta}kg)")
+                    flash("库存不足,已加入待审核", "info")
+                else:
+                    old_stock.quantity = new_balance
+                    _apply_tx_fields(tx, new_pid, new_qty, new_price, new_note, new_time)
+                    db.session.commit()
+                    flash("已修改", "success")
+            else:
+                # 换色粉:旧色粉扣回 old_qty,新色粉加 new_qty
+                if old_cur < old_qty:
+                    _create_edit_in_pending(tx, new_pid, new_qty, new_price, new_note,
+                                            f"旧色粉库存 {old_cur}kg 不足以扣回原入库 {old_qty}kg")
+                    flash("旧色粉库存不足以回退,已加入待审核", "info")
+                else:
+                    old_stock.quantity = round(old_cur - old_qty, 6)
+                    new_stock = Stock.query.get(new_pid) or Stock(pigment_id=new_pid, quantity=0)
+                    if new_stock not in db.session:
+                        db.session.add(new_stock)
+                    new_stock.quantity = round(new_stock.quantity + new_qty, 6)
+                    _apply_tx_fields(tx, new_pid, new_qty, new_price, new_note, new_time)
+                    db.session.commit()
+                    flash("已修改", "success")
+            return redirect(url_for("transactions.in_list"))
+        except Exception as e:
+            db.session.rollback()
+            flash(f"失败:{e}", "danger")
+
+    return render_template("transactions/in_edit.html", tx=tx, pigments=_pigments(),
+                           unit_price_rmb=hkd_to_rmb(tx.unit_price))
+
+
+def _apply_tx_fields(tx, pid, qty, price, note, when):
+    tx.pigment_id = pid
+    tx.quantity = qty
+    tx.unit_price = price
+    tx.note = note
+    tx.occurred_at = when
+
+
+def _create_edit_in_pending(tx, new_pid, new_qty, new_price, new_note, reason):
+    """入库编辑因库存不足无法直接应用,落入待审核;resolve 时强制应用(允许负库存)。"""
+    p = Pigment.query.get(new_pid)
+    old_p = tx.pigment
+    pr = PendingReview(
+        type="edit_in",
+        ref_tx_id=tx.id,
+        pigment_code=p.code if p else "",
+        purchase_code=p.purchase_code if p else "",
+        name=p.name if p else "",
+        quantity=new_qty,
+        unit_price=new_price,
+        reason=reason,
+        note=(f"原: {old_p.code or '?'} {tx.quantity}kg @ {tx.occurred_at:%m-%d %H:%M} / "
+              f"新: {p.code if p else '?'} {new_qty}kg / 备注: {new_note or '—'}"),
+    )
+    db.session.add(pr)
+    db.session.commit()
 
 
 @bp.route("/out/new", methods=["GET", "POST"])
@@ -218,10 +323,7 @@ def _ocr_submit(tx_type: str):
                 continue
             qty_g = float(qty)
             qty_kg = round(qty_g / 1000.0, 6)
-            pigment = (Pigment.query
-                       .filter_by(is_archived=False)
-                       .filter((Pigment.code == code_text) | (Pigment.purchase_code == code_text))
-                       .first())
+            pigment = _find_pigment_by_code(code_text)
             if pigment is None:
                 db.session.add(PendingReview(
                     type="out", pigment_code=code_text, purchase_code="", name="",
@@ -262,7 +364,7 @@ def _ocr_submit(tx_type: str):
             flash(msg, "info" if pending_count else "success")
         return redirect(url_for("transactions.out_list"))
 
-    # 入库:pigment_id[] 有值 → 直接入库;否则 → 待审核
+    # 入库: 用户填的 new_code 优先(覆盖 OCR 的 pigment_id);匹到 → 入库;匹不到 / 都空 → 待审核
     pids = request.form.getlist("pigment_id[]")
     prices = request.form.getlist("unit_price[]")
     new_codes = request.form.getlist("new_code[]")
@@ -271,8 +373,21 @@ def _ocr_submit(tx_type: str):
         if not qty or float(qty) <= 0:
             continue
         price_raw = prices[i] if i < len(prices) else ""
-        price = float(price_raw) if price_raw else None
-        matched_id = int(pid.strip()) if pid and pid.strip().isdigit() else None
+        price_rmb = float(price_raw) if price_raw else None
+        price = rmb_to_hkd(price_rmb)  # OCR 表单 RMB → 存 HKD
+        new_code = new_codes[i].strip() if i < len(new_codes) else ""
+        purchase_code = purchase_codes[i].strip() if i < len(purchase_codes) else ""
+
+        matched_id = None
+        # 用户填了色粉编号 → 以用户填的为准,重新查 DB
+        if new_code or purchase_code:
+            p = _find_pigment_by_code(new_code) or _find_pigment_by_code(purchase_code)
+            if p:
+                matched_id = p.id
+        else:
+            # 用户没填,用 OCR 识别时已匹到的 pigment_id
+            matched_id = int(pid.strip()) if pid and pid.strip().isdigit() else None
+
         if matched_id is not None:
             try:
                 stock_in(matched_id, float(qty), unit_price=price, note="拍照识别")
@@ -280,9 +395,7 @@ def _ocr_submit(tx_type: str):
             except Exception as e:
                 errors.append(f"第{i+1}行:{e}")
             continue
-        # 未匹配 → 待审核
-        new_code = new_codes[i].strip() if i < len(new_codes) else ""
-        purchase_code = purchase_codes[i].strip() if i < len(purchase_codes) else ""
+        # 填了但 DB 没这条色粉,或啥都没填 → 待审核
         db.session.add(PendingReview(
             type="in",
             pigment_code=new_code,
@@ -290,7 +403,7 @@ def _ocr_submit(tx_type: str):
             name=new_code or purchase_code,
             quantity=float(qty),
             unit_price=price,
-            reason="未填色粉编号,只有进货编号",
+            reason="色粉编号未在库存中找到" if (new_code or purchase_code) else "未填色粉编号,只有进货编号",
             note="拍照识别",
         ))
         pending_count += 1

--- a/apps/PMC跟仓管/配色库存管理/app/services/exchange.py
+++ b/apps/PMC跟仓管/配色库存管理/app/services/exchange.py
@@ -38,13 +38,13 @@ def set_rate(rate: float) -> None:
     db.session.commit()
 
 
-def rmb_to_hkd(rmb: float | None) -> float | None:
+def rmb_to_hkd(rmb: float | None, rate: float | None = None) -> float | None:
     if rmb is None or rmb == 0:
         return rmb
-    return round(rmb / get_rate(), 1)
+    return round(rmb / (rate if rate is not None else get_rate()), 1)
 
 
-def hkd_to_rmb(hkd: float | None) -> float | None:
+def hkd_to_rmb(hkd: float | None, rate: float | None = None) -> float | None:
     if hkd is None or hkd == 0:
         return hkd
-    return round(hkd * get_rate(), 1)
+    return round(hkd * (rate if rate is not None else get_rate()), 1)

--- a/apps/PMC跟仓管/配色库存管理/app/services/exchange.py
+++ b/apps/PMC跟仓管/配色库存管理/app/services/exchange.py
@@ -1,0 +1,50 @@
+"""RMB ↔ HKD 换算。
+
+约定:
+- **存储**: DB 里所有入库/流水的单价/金额都是 HKD
+- **输入**: 入库/OCR/编辑表单里用户输入的是 RMB,后端保存时 rmb_to_hkd 换算
+- **显示**: 所有流水/库存页面显示 HKD
+- **例外**: 色粉档案 (pigment.unit_price)、Excel 导入 — 按原值对待为 HKD,不换算
+
+汇率默认 1 HKD = 0.88 RMB,可在「设置」页修改。
+"""
+from __future__ import annotations
+
+SETTING_KEY = "hkd_to_rmb_rate"
+DEFAULT_RATE = 0.88
+
+
+def get_rate() -> float:
+    """读当前 HKD→RMB 汇率。从 Setting 表读,失败回退默认。"""
+    try:
+        from app.models import Setting
+        s = Setting.query.filter_by(key=SETTING_KEY).first()
+        if s and s.value:
+            return float(s.value)
+    except Exception:
+        pass
+    return DEFAULT_RATE
+
+
+def set_rate(rate: float) -> None:
+    from app.extensions import db
+    from app.models import Setting
+    s = Setting.query.filter_by(key=SETTING_KEY).first()
+    if s is None:
+        s = Setting(key=SETTING_KEY, value=str(rate))
+        db.session.add(s)
+    else:
+        s.value = str(rate)
+    db.session.commit()
+
+
+def rmb_to_hkd(rmb: float | None) -> float | None:
+    if rmb is None or rmb == 0:
+        return rmb
+    return round(rmb / get_rate(), 1)
+
+
+def hkd_to_rmb(hkd: float | None) -> float | None:
+    if hkd is None or hkd == 0:
+        return hkd
+    return round(hkd * get_rate(), 1)

--- a/apps/PMC跟仓管/配色库存管理/app/templates/base.html
+++ b/apps/PMC跟仓管/配色库存管理/app/templates/base.html
@@ -18,6 +18,7 @@
       <li><a class="nav-link text-white" href="{{ url_for('transactions.in_list') }}"><i class="bi bi-box-arrow-in-down"></i> 入库</a></li>
       <li><a class="nav-link text-white" href="{{ url_for('transactions.out_list') }}"><i class="bi bi-box-arrow-up"></i> 出库</a></li>
       <li><a class="nav-link text-white" href="{{ url_for('pending.index') }}"><i class="bi bi-hourglass-split"></i> 待审核</a></li>
+      <li><a class="nav-link text-white" href="{{ url_for('settings.index') }}"><i class="bi bi-gear"></i> 设置</a></li>
     </ul>
     <form method="post" action="{{ url_for('auth.logout') }}" class="mt-auto">
       <button type="submit" class="btn btn-outline-light btn-sm w-100">

--- a/apps/PMC跟仓管/配色库存管理/app/templates/pending/index.html
+++ b/apps/PMC跟仓管/配色库存管理/app/templates/pending/index.html
@@ -23,9 +23,8 @@
       <th>类型</th>
       <th>色粉编号</th>
       <th>进货编号</th>
-      <th>商品名</th>
       <th>数量</th>
-      <th>单价</th>
+      <th>单价(HK$)</th>
       <th>原因</th>
       <th>备注</th>
       <th>创建时间</th>
@@ -38,25 +37,27 @@
       <td>
         {% if it.type == 'in' %}
           <span class="badge bg-success">入库</span>
+        {% elif it.type == 'edit_in' %}
+          <span class="badge bg-warning text-dark">修改入库 #{{ it.ref_tx_id }}</span>
         {% else %}
           <span class="badge bg-danger">出库</span>
         {% endif %}
       </td>
       <td><input form="resolve-{{ it.id }}" name="pigment_code" value="{{ it.pigment_code }}"
                  class="form-control form-control-sm" placeholder="色粉编号" required></td>
-      <td><small class="text-muted">{{ it.purchase_code or '—' }}</small></td>
-      <td><small class="text-muted">{{ it.name or '—' }}</small></td>
+      <td><input form="resolve-{{ it.id }}" name="purchase_code" value="{{ it.purchase_code }}"
+                 class="form-control form-control-sm" placeholder="进货编号"></td>
       <td>
         <div class="input-group input-group-sm" style="width:140px">
-          <input form="resolve-{{ it.id }}" type="number" name="quantity" step="0.01" min="0.01"
-                 value="{{ '%.2f'|format(it.quantity) }}" class="form-control form-control-sm" required>
-          <span class="input-group-text">{{ 'kg' if it.type == 'in' else 'g' }}</span>
+          <input form="resolve-{{ it.id }}" type="number" name="quantity" step="0.0001" min="0.0001"
+                 value="{{ ('%.4f'|format(it.quantity)).rstrip('0').rstrip('.') }}" class="form-control form-control-sm" required>
+          <span class="input-group-text">{{ 'g' if it.type == 'out' else 'kg' }}</span>
         </div>
       </td>
       <td>
-        {% if it.type == 'in' %}
-          <input form="resolve-{{ it.id }}" type="number" name="unit_price" step="0.01"
-                 value="{% if it.unit_price is not none %}{{ '%.2f'|format(it.unit_price) }}{% endif %}"
+        {% if it.type in ('in', 'edit_in') %}
+          <input form="resolve-{{ it.id }}" type="number" name="unit_price" step="0.1"
+                 value="{% if it.unit_price is not none %}{{ '%.1f'|format(it.unit_price) }}{% endif %}"
                  class="form-control form-control-sm" style="width:100px">
         {% else %}—{% endif %}
       </td>
@@ -65,7 +66,10 @@
       <td><small class="text-muted">{{ it.created_at.strftime('%m-%d %H:%M') if it.created_at else '—' }}</small></td>
       <td>
         <button form="resolve-{{ it.id }}" class="btn btn-sm btn-primary" type="submit">
-          <i class="bi bi-check2"></i> 确认{{ '入库' if it.type == 'in' else '出库' }}
+          <i class="bi bi-check2"></i>
+          {% if it.type == 'in' %}确认入库
+          {% elif it.type == 'edit_in' %}强制修改
+          {% else %}确认出库{% endif %}
         </button>
         <button form="reject-{{ it.id }}" class="btn btn-sm btn-outline-secondary" type="submit">驳回</button>
       </td>

--- a/apps/PMC跟仓管/配色库存管理/app/templates/pigments/detail.html
+++ b/apps/PMC跟仓管/配色库存管理/app/templates/pigments/detail.html
@@ -10,10 +10,10 @@
 </div>
 <h5>流水</h5>
 <table class="table table-sm">
-  <thead><tr><th>时间</th><th>类型</th><th>数量</th><th>单价</th><th>备注</th></tr></thead>
+  <thead><tr><th>时间</th><th>类型</th><th>数量</th><th>单价(HK$)</th><th>备注</th></tr></thead>
   <tbody>
     {% for t in transactions %}
-      <tr><td>{{ t.occurred_at.strftime('%Y-%m-%d %H:%M') }}</td><td>{{ t.type }}</td><td>{{ t.quantity }}</td><td>{{ t.unit_price or '-' }}</td><td>{{ t.note }}</td></tr>
+      <tr><td>{{ t.occurred_at.strftime('%Y-%m-%d %H:%M') }}</td><td>{{ t.type }}</td><td>{{ t.quantity }}</td><td>{{ '%.1f'|format(t.unit_price) if t.unit_price else '-' }}</td><td>{{ t.note }}</td></tr>
     {% endfor %}
   </tbody>
 </table>

--- a/apps/PMC跟仓管/配色库存管理/app/templates/pigments/form.html
+++ b/apps/PMC跟仓管/配色库存管理/app/templates/pigments/form.html
@@ -5,15 +5,15 @@
   <div class="col-md-6"><label>色粉编号</label><input name="code" class="form-control" value="{{ pigment.code if pigment else '' }}" required></div>
   <div class="col-md-6"><label>进货编号</label><input name="purchase_code" class="form-control" value="{{ pigment.purchase_code if pigment else '' }}"></div>
   <div class="col-md-4"><label>库存KG</label><input type="number" step="0.0001" id="qty" name="quantity" class="form-control" value="{{ '%.4f'|format(pigment.stock.quantity) if pigment and pigment.stock else '0' }}" min="0"></div>
-  <div class="col-md-3"><label>单价(元)</label><input type="number" step="0.01" id="price" name="unit_price" class="form-control" value="{{ '%.2f'|format(pigment.unit_price) if pigment else '0.00' }}"></div>
+  <div class="col-md-3"><label>单价(HK$)</label><input type="number" step="0.1" id="price" name="unit_price" class="form-control" value="{{ '%.1f'|format(pigment.unit_price) if pigment else '0.0' }}"></div>
   <div class="col-md-2"><label>单位</label><input class="form-control" value="KG" readonly></div>
-  <div class="col-md-3"><label>金额(元)</label><input id="amount" class="form-control" value="0.00" readonly></div>
+  <div class="col-md-3"><label>金额(HK$)</label><input id="amount" class="form-control" value="0.0" readonly></div>
   <div class="col-12"><button class="btn btn-primary">保存</button> <a href="{{ url_for('pigments.index') }}" class="btn btn-secondary">取消</a></div>
 </form>
 <script>
 (function(){
   const q = document.getElementById('qty'), p = document.getElementById('price'), a = document.getElementById('amount');
-  function update(){ a.value = (parseFloat(q.value||0) * parseFloat(p.value||0)).toFixed(2); }
+  function update(){ a.value = (parseFloat(q.value||0) * parseFloat(p.value||0)).toFixed(1); }
   q.addEventListener('input', update); p.addEventListener('input', update); update();
 })();
 </script>

--- a/apps/PMC跟仓管/配色库存管理/app/templates/pigments/index.html
+++ b/apps/PMC跟仓管/配色库存管理/app/templates/pigments/index.html
@@ -10,7 +10,7 @@
   </div>
 </div>
 <table class="table table-hover dt">
-  <thead><tr><th>色粉编号</th><th>进货编号</th><th>库存KG</th><th>单价</th><th>金额</th><th>操作</th></tr></thead>
+  <thead><tr><th>色粉编号</th><th>进货编号</th><th>库存KG</th><th>单价(HK$)</th><th>金额(HK$)</th><th>操作</th></tr></thead>
   <tbody>
     {% for p in pigments %}
       {% set qty = p.stock.quantity if p.stock else 0 %}
@@ -18,8 +18,8 @@
         <td>{{ p.code }}</td>
         <td>{{ p.purchase_code }}</td>
         <td>{{ qty }}</td>
-        <td>{{ "%.2f"|format(p.unit_price) }}</td>
-        <td>{{ "%.2f"|format(qty * p.unit_price) }}</td>
+        <td>{{ "%.1f"|format(p.unit_price) }}</td>
+        <td>{{ "%.1f"|format(qty * p.unit_price) }}</td>
         <td>
           <a href="{{ url_for('pigments.edit', pid=p.id) }}" class="btn btn-sm btn-outline-primary"><i class="bi bi-pencil"></i></a>
           <form action="{{ url_for('pigments.delete', pid=p.id) }}" method="post" class="d-inline" onsubmit="return confirm('确认删除?')">

--- a/apps/PMC跟仓管/配色库存管理/app/templates/settings/index.html
+++ b/apps/PMC跟仓管/配色库存管理/app/templates/settings/index.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% block content %}
+<h3>设置</h3>
+
+<div class="card" style="max-width:500px">
+  <div class="card-body">
+    <h5 class="card-title">汇率 (RMB → HKD)</h5>
+    <p class="text-muted small mb-3">
+      入库表单里输入的 RMB 单价,会按这个汇率换算成 HKD 存进库存。<br>
+      公式: <code>HKD = RMB ÷ 汇率</code>,比如 1 HKD = 0.88 RMB 时,100 RMB = 113.64 HKD。<br>
+      <strong>改汇率只影响新入库;已有流水里的 HKD 不会重算。</strong>
+    </p>
+    <form method="post">
+      <div class="mb-3">
+        <label class="form-label">1 HKD 等于多少 RMB</label>
+        <input type="number" step="0.0001" min="0.0001" name="rate" value="{{ rate }}"
+               class="form-control" required>
+        <small class="text-muted">常见值: 0.88 / 0.90 / 0.92 (依当月实际汇率)</small>
+      </div>
+      <button class="btn btn-primary"><i class="bi bi-check2"></i> 保存</button>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/apps/PMC跟仓管/配色库存管理/app/templates/transactions/in_edit.html
+++ b/apps/PMC跟仓管/配色库存管理/app/templates/transactions/in_edit.html
@@ -1,0 +1,41 @@
+{% extends "base.html" %}
+{% block content %}
+<h3>修改入库流水 #{{ tx.id }}</h3>
+<p class="text-muted small">
+  改数量/换色粉会自动调整库存。如果库存扣不出来(已经出库掉了),会加入「待审核」等手动处理。
+</p>
+<form method="post" style="max-width:600px">
+  <div class="mb-3"><label>时间</label>
+    <input type="datetime-local" name="occurred_at" class="form-control"
+           value="{{ tx.occurred_at.strftime('%Y-%m-%dT%H:%M') }}">
+  </div>
+  <div class="mb-3"><label>色粉</label>
+    <select name="pigment_id" class="form-select" required>
+      {% for p in pigments %}
+        <option value="{{ p.id }}" {% if p.id == tx.pigment_id %}selected{% endif %}>
+          {{ p.code or '(待填)' }}{% if p.purchase_code %} / {{ p.purchase_code }}{% endif %}
+          (当前 {{ p.stock.quantity if p.stock else 0 }}kg)
+        </option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="mb-3"><label>数量</label>
+    <input type="number" step="0.0001" name="quantity" class="form-control" min="0.0001" required
+           value="{{ ('%.4f'|format(tx.quantity)).rstrip('0').rstrip('.') }}">
+    <span class="text-muted">kg</span>
+  </div>
+  <div class="mb-3"><label>进货单价 (RMB,可选)</label>
+    <input type="number" step="0.1" name="unit_price" class="form-control"
+           value="{% if unit_price_rmb is not none %}{{ '%.1f'|format(unit_price_rmb) }}{% endif %}">
+    <small class="text-muted">
+      当前存库存: <strong>HK$ {{ '%.1f'|format(tx.unit_price) if tx.unit_price else '0.0' }}</strong>
+      / 表单显示的是换算后的 RMB,提交时会再换算回 HKD
+    </small>
+  </div>
+  <div class="mb-3"><label>备注</label>
+    <textarea name="note" class="form-control">{{ tx.note or '' }}</textarea>
+  </div>
+  <button class="btn btn-primary">保存</button>
+  <a href="{{ url_for('transactions.in_list') }}" class="btn btn-secondary">取消</a>
+</form>
+{% endblock %}

--- a/apps/PMC跟仓管/配色库存管理/app/templates/transactions/in_form.html
+++ b/apps/PMC跟仓管/配色库存管理/app/templates/transactions/in_form.html
@@ -13,7 +13,11 @@
   <div class="mb-3"><label>进货编号(色粉留空时必填)</label><input name="purchase_code" class="form-control" placeholder="例如 A-123"></div>
   <div class="mb-3"><label>商品名(色粉留空时建议填)</label><input name="name" class="form-control" placeholder="例如 红色粉"></div>
   <div class="mb-3"><label>数量</label><input type="number" step="0.01" name="quantity" class="form-control" min="0.01" required> <span class="text-muted">kg</span></div>
-  <div class="mb-3"><label>进货单价(元,可选)</label><input type="number" step="0.01" name="unit_price" class="form-control"></div>
+  <div class="mb-3">
+    <label>进货单价 (RMB,可选)</label>
+    <input type="number" step="0.01" name="unit_price" class="form-control">
+    <small class="text-muted">提交时自动换算为 HKD 存库存(汇率见「设置」页)</small>
+  </div>
   <div class="mb-3"><label>备注</label><textarea name="note" class="form-control"></textarea></div>
   <button class="btn btn-success">入库</button>
   <a href="{{ url_for('transactions.in_list') }}" class="btn btn-secondary">取消</a>

--- a/apps/PMC跟仓管/配色库存管理/app/templates/transactions/in_index.html
+++ b/apps/PMC跟仓管/配色库存管理/app/templates/transactions/in_index.html
@@ -8,17 +8,20 @@
   </div>
 </div>
 <table class="table table-hover dt">
-  <thead><tr><th>时间</th><th>色粉编号</th><th>数量(kg)</th><th>单价(元/kg)</th><th>金额</th><th>备注</th><th>操作</th></tr></thead>
+  <thead><tr><th>时间</th><th>色粉编号</th><th>数量(kg)</th><th>单价(HK$/kg)</th><th>金额(HK$)</th><th>备注</th><th>操作</th></tr></thead>
   <tbody>
     {% for t in transactions %}
       <tr>
         <td>{{ t.occurred_at.strftime('%Y-%m-%d %H:%M') }}</td>
         <td>{{ t.pigment.code or t.pigment.purchase_code }}</td>
         <td>{{ ("%.4f"|format(t.quantity)).rstrip('0').rstrip('.') }}</td>
-        <td>{{ "%.2f"|format(t.unit_price) if t.unit_price else '-' }}</td>
-        <td>{{ "%.2f"|format(t.quantity * t.unit_price) if t.unit_price else '-' }}</td>
+        <td>{{ "%.1f"|format(t.unit_price) if t.unit_price else '-' }}</td>
+        <td>{{ "%.1f"|format(t.quantity * t.unit_price) if t.unit_price else '-' }}</td>
         <td>{{ t.note }}</td>
-        <td><form method="post" action="{{ url_for('transactions.delete', tx_id=t.id) }}" class="d-inline" onsubmit="return confirm('删除并回滚库存?')"><button class="btn btn-sm btn-outline-danger"><i class="bi bi-trash"></i></button></form></td>
+        <td>
+          <a href="{{ url_for('transactions.in_edit', tx_id=t.id) }}" class="btn btn-sm btn-outline-primary"><i class="bi bi-pencil"></i></a>
+          <form method="post" action="{{ url_for('transactions.delete', tx_id=t.id) }}" class="d-inline" onsubmit="return confirm('删除并回滚库存?')"><button class="btn btn-sm btn-outline-danger"><i class="bi bi-trash"></i></button></form>
+        </td>
       </tr>
     {% endfor %}
   </tbody>

--- a/apps/PMC跟仓管/配色库存管理/app/templates/transactions/in_ocr.html
+++ b/apps/PMC跟仓管/配色库存管理/app/templates/transactions/in_ocr.html
@@ -9,22 +9,20 @@
   <a href="{{ url_for('transactions.in_list') }}" class="btn btn-secondary">取消</a>
 </form>
 {% else %}
-<p>共识别出 <strong>{{ rows|length }}</strong> 行。请核对后提交,不需要的行点"删"移除。<br><small class="text-muted">已匹配库存的行显示 <span class="badge bg-success-subtle text-success-emphasis">→ 编号</span>;未匹配的行可手填"色粉编号",留空则按"进货编号"再查一次:匹到则累加(相同色粉编号或进货编号视为同一色粉,不分品牌),匹不到则新建待复核。</small></p>
+<p>共识别出 <strong>{{ rows|length }}</strong> 行。**所有字段都可修改**,提交前核对。<br><small class="text-muted">色粉编号留空 → 进待审核;填了能匹到库存已有色粉(不分大小写)→ 直接累加入库;填了但 DB 没这编号 → 也进待审核(在那边再决定新建或改编号)。</small></p>
 <form method="post" action="{{ url_for('transactions.in_ocr_submit') }}">
+  <p class="small text-muted">单价列填 RMB,提交时自动按当前汇率换算成 HKD 存入库存。</p>
   <table class="table table-sm" id="ocrTable">
-    <thead><tr><th>进货编号</th><th>色粉编号</th><th>库存KG</th><th>单价</th><th style="width:25%">识别文本</th><th></th></tr></thead>
+    <thead><tr><th>进货编号</th><th>色粉编号</th><th>库存KG</th><th>单价(RMB)</th><th style="width:25%">识别文本</th><th></th></tr></thead>
     <tbody>
       {% for r in rows %}
       <tr>
-        <td><input name="purchase_code[]" value="{{ r.purchase_code }}" class="form-control form-control-sm" readonly></td>
+        <td><input name="purchase_code[]" value="{{ r.purchase_code }}" class="form-control form-control-sm"></td>
         <td>
           <input type="hidden" name="pigment_id[]" value="{{ r.pigment_id or '' }}">
-          {% if r.pigment_id %}
-            <span class="badge bg-success-subtle text-success-emphasis">→ {{ r.pigment_code or '(待填)' }}</span>
-            <input type="hidden" name="new_code[]" value="">
-          {% else %}
-            <input name="new_code[]" class="form-control form-control-sm" placeholder="留空则自动新建">
-          {% endif %}
+          <input name="new_code[]" class="form-control form-control-sm"
+                 value="{{ r.pigment_code or '' }}"
+                 placeholder="色粉编号 (留空走待审核)">
         </td>
         <td><input type="number" name="quantity[]" value="{{ '%.2f'|format(r.quantity) }}" step="0.01" class="form-control form-control-sm" min="0"></td>
         <td><input type="number" step="0.01" name="unit_price[]" value="{{ '%.2f'|format(r.unit_price) }}" class="form-control form-control-sm"></td>

--- a/apps/PMC跟仓管/配色库存管理/app/templates/transactions/in_ocr.html
+++ b/apps/PMC跟仓管/配色库存管理/app/templates/transactions/in_ocr.html
@@ -9,7 +9,7 @@
   <a href="{{ url_for('transactions.in_list') }}" class="btn btn-secondary">取消</a>
 </form>
 {% else %}
-<p>共识别出 <strong>{{ rows|length }}</strong> 行。**所有字段都可修改**,提交前核对。<br><small class="text-muted">色粉编号留空 → 进待审核;填了能匹到库存已有色粉(不分大小写)→ 直接累加入库;填了但 DB 没这编号 → 也进待审核(在那边再决定新建或改编号)。</small></p>
+<p>共识别出 <strong>{{ rows|length }}</strong> 行。<strong>所有字段都可修改</strong>,提交前核对。<br><small class="text-muted">色粉编号留空 → 进待审核;填了能匹到库存已有色粉(不分大小写)→ 直接累加入库;填了但 DB 没这编号 → 也进待审核(在那边再决定新建或改编号)。</small></p>
 <form method="post" action="{{ url_for('transactions.in_ocr_submit') }}">
   <p class="small text-muted">单价列填 RMB,提交时自动按当前汇率换算成 HKD 存入库存。</p>
   <table class="table table-sm" id="ocrTable">

--- a/apps/PMC跟仓管/配色库存管理/tests/test_full_regression.py
+++ b/apps/PMC跟仓管/配色库存管理/tests/test_full_regression.py
@@ -1,0 +1,297 @@
+"""全功能回归测试 - 通过 HTTP 打真实 flask 进程。
+
+使用:
+    python tests/test_full_regression.py
+"""
+from __future__ import annotations
+
+import requests
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from app import create_app
+from app.extensions import db
+from app.models import Pigment, Stock, Transaction, PendingReview, Setting
+
+
+BASE = "http://127.0.0.1:5000"
+PASS, FAIL = 0, 0
+_app = create_app()
+
+
+def assert_eq(label, got, expected, tol=0.05):
+    global PASS, FAIL
+    ok = (abs(got - expected) < tol) if isinstance(got, (int, float)) else (got == expected)
+    if ok:
+        PASS += 1
+        print(f"  ✅ {label}: {got}")
+    else:
+        FAIL += 1
+        print(f"  ❌ {label}: 得到 {got!r}, 期望 {expected!r}")
+
+
+def stock_of(code):
+    with _app.app_context():
+        p = Pigment.query.filter_by(code=code).first()
+        if not p:
+            return None
+        s = Stock.query.get(p.id)
+        return s.quantity if s else 0
+
+
+def pigment_id(code):
+    with _app.app_context():
+        p = Pigment.query.filter_by(code=code).first()
+        return p.id if p else None
+
+
+def pending_count():
+    with _app.app_context():
+        return PendingReview.query.count()
+
+
+def login():
+    s = requests.Session()
+    s.post(f"{BASE}/login", data={"username": "ps", "password": "ps123456"},
+           allow_redirects=False)
+    return s
+
+
+def cleanup(code):
+    with _app.app_context():
+        p = Pigment.query.filter_by(code=code).first()
+        if p:
+            Transaction.query.filter_by(pigment_id=p.id).delete(synchronize_session=False)
+            Stock.query.get(p.id).quantity = 0.0
+        PendingReview.query.delete()
+        db.session.commit()
+
+
+# ============================================================
+
+sess = login()
+TEST_CODE = "105"
+pid = pigment_id(TEST_CODE)
+assert pid, "需要 105 色粉存在"
+
+print("=" * 60)
+print("开始全功能回归测试")
+print("=" * 60)
+
+# ---------- 1. 登录 ----------
+print("\n[1] 登录验证")
+r = requests.get(f"{BASE}/transactions/in", allow_redirects=False)
+assert_eq("未登录 /in 跳 /login", r.status_code, 302)
+r = sess.get(f"{BASE}/transactions/in", allow_redirects=False)
+assert_eq("已登录 /in 访问成功", r.status_code, 200)
+
+# ---------- 2. 手动入库 RMB→HKD ----------
+print("\n[2] 手动入库 RMB 100 → 应存 HKD 113.64,库存 +1kg")
+cleanup(TEST_CODE)
+r = sess.post(f"{BASE}/transactions/in/new", data={
+    "pigment_id": str(pid), "quantity": "1", "unit_price": "100",
+    "note": "REG-in-new"
+}, allow_redirects=False)
+assert_eq("status 302", r.status_code, 302)
+assert_eq(f"{TEST_CODE} 库存", stock_of(TEST_CODE), 1.0)
+with _app.app_context():
+    tx = Transaction.query.filter_by(note="REG-in-new").first()
+    assert_eq("单价换算 HKD", tx.unit_price, 113.6)
+
+# ---------- 3. 手动出库 ----------
+print("\n[3] 手动出库 500g → 库存 -0.5kg")
+r = sess.post(f"{BASE}/transactions/out/new", data={
+    "pigment_id": str(pid), "quantity": "500", "note": "REG-out-new"
+}, allow_redirects=False)
+assert_eq("status 302", r.status_code, 302)
+assert_eq(f"{TEST_CODE} 库存", stock_of(TEST_CODE), 0.5)
+
+# ---------- 4. 手动出库超额 → pending ----------
+print("\n[4] 手动出库超额(10kg 但只有 0.5kg) → pending,库存不变")
+before = stock_of(TEST_CODE)
+r = sess.post(f"{BASE}/transactions/out/new", data={
+    "pigment_id": str(pid), "quantity": "10000", "note": "REG-out-over"
+}, allow_redirects=False)
+assert_eq("status 302", r.status_code, 302)
+assert_eq("库存不变", stock_of(TEST_CODE), before)
+assert_eq("pending 新增 1", pending_count(), 1)
+
+# ---------- 5. Resolve 出库 pending ----------
+print("\n[5] Resolve 出库 pending(先加库存到 15kg)")
+with _app.app_context():
+    Stock.query.get(pid).quantity = 15.0
+    db.session.commit()
+    pr_id = PendingReview.query.first().id
+r = sess.post(f"{BASE}/pending/{pr_id}/resolve", data={
+    "pigment_code": TEST_CODE, "quantity": "10000"
+}, allow_redirects=False)
+assert_eq("status 302", r.status_code, 302)
+assert_eq("库存 15 → 5", stock_of(TEST_CODE), 5.0)
+assert_eq("pending 清空", pending_count(), 0)
+
+# ---------- 6. OCR 入库(匹到已有色粉,RMB 换算) ----------
+print("\n[6] OCR 入库(code=105,小写模拟大小写容错) RMB 50 → HKD 56.82")
+cleanup(TEST_CODE)
+r = sess.post(f"{BASE}/transactions/in/ocr/submit", data={
+    "pigment_id[]": [""], "new_code[]": ["105"], "purchase_code[]": [""],
+    "quantity[]": ["2"], "unit_price[]": ["50"],
+}, allow_redirects=False)
+assert_eq("status 302", r.status_code, 302)
+assert_eq(f"{TEST_CODE} 库存 +2", stock_of(TEST_CODE), 2.0)
+assert_eq("pending 0", pending_count(), 0)
+with _app.app_context():
+    tx = Transaction.query.filter(
+        Transaction.pigment_id == pid,
+        Transaction.type == "in",
+        Transaction.note == "拍照识别",
+    ).order_by(Transaction.id.desc()).first()
+    assert_eq("OCR 单价换算", tx.unit_price, 56.8)
+
+# ---------- 7. OCR 入库(未知 code) → pending ----------
+print("\n[7] OCR 入库 code='NEW-X-CODE'(库里没) → pending")
+r = sess.post(f"{BASE}/transactions/in/ocr/submit", data={
+    "pigment_id[]": [""], "new_code[]": ["NEW-X-CODE"],
+    "purchase_code[]": ["NEW-X-PC"], "quantity[]": ["3"], "unit_price[]": ["80"],
+}, allow_redirects=False)
+assert_eq("status 302", r.status_code, 302)
+assert_eq("pending 新增 1", pending_count(), 1)
+with _app.app_context():
+    pr = PendingReview.query.first()
+    assert_eq("pending type", pr.type, "in")
+    assert_eq("pending unit_price 已换算 HKD", pr.unit_price, 90.9)  # 80/0.88=90.91 → 90.9
+    pr_id = pr.id
+
+# ---------- 8. Resolve 入库 pending(自动创建新色粉) ----------
+print("\n[8] Resolve 入库 pending → 新建色粉 NEW-X-CODE,库存 +3")
+r = sess.post(f"{BASE}/pending/{pr_id}/resolve", data={
+    "pigment_code": "NEW-X-CODE", "quantity": "3", "unit_price": "90.91",
+    "purchase_code": "NEW-X-PC"
+}, allow_redirects=False)
+assert_eq("status 302", r.status_code, 302)
+assert_eq("pending 清空", pending_count(), 0)
+assert_eq("新色粉库存 3kg", stock_of("NEW-X-CODE"), 3.0)
+with _app.app_context():
+    new_p = Pigment.query.filter_by(code="NEW-X-CODE").first()
+    assert_eq("新色粉 purchase_code", new_p.purchase_code, "NEW-X-PC")
+
+# ---------- 9. OCR 出库(case-insensitive) ----------
+print("\n[9] OCR 出库 code='105'(DB 是 105),扣 500g → 库存 -0.5")
+before = stock_of(TEST_CODE)
+r = sess.post(f"{BASE}/transactions/out/ocr/submit", data={
+    "pigment_code[]": ["105"], "quantity[]": ["500"],
+}, allow_redirects=False)
+assert_eq("status 302", r.status_code, 302)
+assert_eq("库存变动", stock_of(TEST_CODE), before - 0.5)
+assert_eq("pending 0", pending_count(), 0)
+
+# ---------- 10. 编辑入库(库存够) ----------
+print("\n[10] 编辑入库流水 qty 2 → 1.5(库存 -0.5)")
+with _app.app_context():
+    tx = Transaction.query.filter_by(pigment_id=pid, type="in").order_by(Transaction.id.desc()).first()
+    tx_id = tx.id
+before = stock_of(TEST_CODE)
+r = sess.post(f"{BASE}/transactions/in/{tx_id}/edit", data={
+    "pigment_id": str(pid), "quantity": "1.5", "unit_price": "50",
+    "occurred_at": "2026-04-22T10:00", "note": "REG-edit"
+}, allow_redirects=False)
+assert_eq("status 302", r.status_code, 302)
+assert_eq("库存变动 -0.5", stock_of(TEST_CODE), before - 0.5)
+
+# ---------- 11. 编辑入库(库存不够回退 → pending) ----------
+print("\n[11] 库存设 1kg,编辑入库到 0.1kg (回退差额 1.4kg 不够) → pending")
+with _app.app_context():
+    Stock.query.get(pid).quantity = 1.0
+    db.session.commit()
+r = sess.post(f"{BASE}/transactions/in/{tx_id}/edit", data={
+    "pigment_id": str(pid), "quantity": "0.1", "unit_price": "50",
+    "occurred_at": "2026-04-22T10:00", "note": "REG-edit-pending"
+}, allow_redirects=False)
+assert_eq("status 302", r.status_code, 302)
+assert_eq("pending 新增 1", pending_count(), 1)
+with _app.app_context():
+    tx_now = Transaction.query.get(tx_id)
+    assert_eq("原 tx 未改", tx_now.quantity, 1.5)
+    assert_eq("库存未改", Stock.query.get(pid).quantity, 1.0)
+
+# ---------- 12. Resolve edit_in pending(强制应用) ----------
+print("\n[12] 强制应用 edit_in pending → tx qty=0.1,库存变负")
+with _app.app_context():
+    pr_id = PendingReview.query.filter_by(type="edit_in").first().id
+r = sess.post(f"{BASE}/pending/{pr_id}/resolve", data={
+    "pigment_code": TEST_CODE, "quantity": "0.1", "unit_price": "50"
+}, allow_redirects=False)
+assert_eq("status 302", r.status_code, 302)
+assert_eq("pending 清空", pending_count(), 0)
+with _app.app_context():
+    tx_now = Transaction.query.get(tx_id)
+    assert_eq("tx qty 变 0.1", tx_now.quantity, 0.1)
+    # 库存 1.0 - 1.5 + 0.1 = -0.4
+    assert_eq(f"{TEST_CODE} 库存 = -0.4", stock_of(TEST_CODE), -0.4)
+
+# ---------- 13. Pending reject ----------
+print("\n[13] Reject pending → 删除,不改库存")
+# 造一条 out pending
+with _app.app_context():
+    pr = PendingReview(type="out", pigment_code=TEST_CODE, purchase_code="", name="",
+                      quantity=100, reason="test", note="REG-reject")
+    db.session.add(pr); db.session.commit()
+    pr_id = pr.id
+before = stock_of(TEST_CODE)
+r = sess.post(f"{BASE}/pending/{pr_id}/reject", allow_redirects=False)
+assert_eq("status 302", r.status_code, 302)
+assert_eq("pending 清空", pending_count(), 0)
+assert_eq("库存不变", stock_of(TEST_CODE), before)
+
+# ---------- 14. 设置页改汇率 ----------
+print("\n[14] 设置页改汇率 0.88 → 0.92,再入 RMB 100 应存 HKD 108.70")
+r = sess.post(f"{BASE}/settings/", data={"rate": "0.92"}, allow_redirects=False)
+assert_eq("status 302", r.status_code, 302)
+cleanup(TEST_CODE)
+r = sess.post(f"{BASE}/transactions/in/new", data={
+    "pigment_id": str(pid), "quantity": "1", "unit_price": "100",
+    "note": "REG-rate-0.92"
+}, allow_redirects=False)
+with _app.app_context():
+    tx = Transaction.query.filter_by(note="REG-rate-0.92").first()
+    # 100 / 0.92 = 108.7
+    assert_eq("换算按新汇率", tx.unit_price, 108.7)
+
+# ---------- 15. 色粉新建(HKD 直接存,不换算) ----------
+print("\n[15] 新建色粉 HKD 单价 200(直接存,不换算)")
+r = sess.post(f"{BASE}/pigments/new", data={
+    "brand": "TEST", "code": "TEST-PIGMENT-9999", "name": "测试色粉",
+    "unit_price": "200", "spec_value": "0", "spec_unit": "ml",
+    "color_family": "其他", "min_stock": "1", "quantity": "0",
+}, allow_redirects=False)
+assert_eq("status 302", r.status_code, 302)
+with _app.app_context():
+    p = Pigment.query.filter_by(code="TEST-PIGMENT-9999").first()
+    if p:
+        assert_eq("色粉单价存 HKD 200(不换算)", p.unit_price, 200.0)
+    else:
+        assert_eq("色粉建档失败", None, 200.0)
+
+# ---------- cleanup ----------
+print("\n--- 清理测试数据 ---")
+with _app.app_context():
+    Transaction.query.filter(Transaction.note.like("REG-%")).delete(synchronize_session=False)
+    Transaction.query.filter_by(note="拍照识别").delete(synchronize_session=False)
+    Transaction.query.filter(Transaction.note.like("%补填%")).delete(synchronize_session=False)
+    Stock.query.get(pid).quantity = 0.0
+    for code in ("NEW-X-CODE", "TEST-PIGMENT-9999"):
+        p2 = Pigment.query.filter_by(code=code).first()
+        if p2:
+            Transaction.query.filter_by(pigment_id=p2.id).delete(synchronize_session=False)
+            Stock.query.filter_by(pigment_id=p2.id).delete()
+            db.session.delete(p2)
+    PendingReview.query.delete()
+    Setting.query.filter_by(key="hkd_to_rmb_rate").delete()  # 汇率重置默认
+    db.session.commit()
+    print("清理完成")
+
+# ============================================================
+print("\n" + "=" * 60)
+print(f"结果: ✅ {PASS} 通过 | ❌ {FAIL} 失败")
+print("=" * 60)
+sys.exit(0 if FAIL == 0 else 1)


### PR DESCRIPTION
- 入库流水加编辑按钮 ✏️:时间/色粉/数量/单价/备注全可改,库存自动同步调整
- 编辑若库存不够回退(原货已被领用),进待审核 type='edit_in',可强制应用
- 单价全链路 RMB→HKD 自动换算:手动入库/OCR/编辑/pending resolve 四个入口统一转
- 汇率存 Setting 表可在「设置」页改(默认 0.88),改了只影响新入库,不动历史
- OCR 入库:大小写不敏感匹配,用户填了 code 不再误进待审核
- OCR 页面:进货编号/色粉编号 全部可编辑(去掉 readonly 和固定 badge)
- pending resolve 匹配色粉改成 case-insensitive(func.lower),避免"色粉找不到又新建"
- 待审核页去掉冗余商品名列,进货编号可编辑
- 金额/单价显示统一改 1 位小数四舍五入
- tests/test_full_regression.py: 15 个场景 45 断言,全部通过