### PR TITLE
fix(hy-schedule): path traversal + port conflict + hardening

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,7 @@ curl http://localhost:<port>/health
 | liwenjuan 成品核对系统 | Flask | 5004 | /liwenjuan/ |
 | peise 配色库存管理 | Flask | 5006 | /peise/ |
 | huadeng 华登包材管理 | Flask | 5007 | /huadeng/ |
+| hy-schedule-system ZURU河源排期入单 | Flask | 5008 | /hy-schedule/ |
 
 ## 插件类型
 
@@ -411,6 +412,7 @@ const data = JSON.parse(fs.readFileSync('data/data.json'));
 | liwenjuan | 成品核对系统 | PMC跟仓管 | Standalone (Python/Flask) | /liwenjuan/ | — |
 | peise | 配色库存管理 | PMC跟仓管 | Standalone (Python/Flask) | /peise/ | https://github.com/fxxaxxx/peisecangku |
 | huadeng | 华登包材管理 | PMC跟仓管 | Standalone (Python/Flask) | /huadeng/ | — |
+| hy-schedule-system | ZURU河源排期入单 | 业务部 | Standalone (Python/Flask) | /hy-schedule/ | https://github.com/hanson678/hy-schedule-system |
 
 ### 旧插件（已删除）
 

--- a/apps/业务部/ZURU河源排期入单/Dockerfile
+++ b/apps/业务部/ZURU河源排期入单/Dockerfile
@@ -5,7 +5,7 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt gunicorn
 COPY . .
 RUN mkdir -p uploads uploads/schedules exports data
-EXPOSE 5006
+EXPOSE 5008
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD curl -f http://localhost:5006/health || exit 1
-CMD ["gunicorn", "--bind", "0.0.0.0:5006", "--workers", "1", "--threads", "4", "--timeout", "120", "app:app"]
+    CMD curl -f http://localhost:5008/health || exit 1
+CMD ["gunicorn", "--bind", "0.0.0.0:5008", "--workers", "1", "--threads", "4", "--timeout", "120", "app:app"]

--- a/apps/业务部/ZURU河源排期入单/app.py
+++ b/apps/业务部/ZURU河源排期入单/app.py
@@ -95,6 +95,21 @@ os.makedirs(SESSION_DIR, exist_ok=True)
 _sessions_lock = threading.Lock()
 
 
+def _safe_path_under(base_dir, filename):
+    """Resolve filename under base_dir, rejecting traversal and sibling-prefix tricks.
+    Returns absolute path on success, None on rejection."""
+    if not filename:
+        return None
+    abs_base = os.path.abspath(base_dir)
+    abs_target = os.path.abspath(os.path.join(abs_base, filename))
+    try:
+        if os.path.commonpath([abs_base, abs_target]) != abs_base:
+            return None
+    except ValueError:
+        return None
+    return abs_target
+
+
 def _session_path(session_id):
     if not session_id or not re.match(r'^[a-zA-Z0-9_-]+$', str(session_id)):
         return None
@@ -234,8 +249,8 @@ def delete_schedule():
     filename = (request.json or {}).get('filename', '')
     if not filename:
         return jsonify({'error': '缺少文件名'}), 400
-    filepath = os.path.join(SCHEDULE_DIR, filename)
-    if not os.path.abspath(filepath).startswith(os.path.abspath(SCHEDULE_DIR)):
+    filepath = _safe_path_under(SCHEDULE_DIR, filename)
+    if not filepath:
         return jsonify({'error': '非法路径'}), 403
     if not os.path.exists(filepath):
         return jsonify({'error': '文件不存在'}), 404
@@ -307,11 +322,11 @@ def hy_upload():
 
     try:
         analysis = analyze_orders(SCHEDULE_DIR, orders)
-    except Exception as e:
-        logger.error(f'[河源] 分析失败: {e}')
-        return jsonify({'error': f'分析失败: {e}'}), 500
+    except Exception:
+        logger.exception('[河源] 分析失败')
+        return jsonify({'error': '排期分析失败，请稍后重试或联系管理员'}), 500
 
-    session_id = datetime.now().strftime('%Y%m%d%H%M%S%f')
+    session_id = secrets.token_urlsafe(16)
     _save_session(session_id, {
         'orders': orders,
         'analysis': analysis,
@@ -371,9 +386,9 @@ def hy_submit_selection():
         result = write_orders(SCHEDULE_DIR, orders,
                               ambiguous_selections=selections,
                               export_dir=EXPORT_DIR)
-    except Exception as e:
-        logger.error(f'[河源] 提交写入失败: {e}')
-        return jsonify({'error': f'处理失败: {e}'}), 500
+    except Exception:
+        logger.exception('[河源] 提交写入失败')
+        return jsonify({'error': '处理失败，请稍后重试或联系管理员'}), 500
     finally:
         _delete_session(session_id)
 
@@ -409,8 +424,9 @@ def hy_export_only():
     orders = session['orders']
     try:
         analysis = analyze_orders(SCHEDULE_DIR, orders)
-    except Exception as e:
-        return jsonify({'error': f'分析失败: {e}'}), 500
+    except Exception:
+        logger.exception('[河源] 分析失败(export-only)')
+        return jsonify({'error': '排期分析失败，请稍后重试或联系管理员'}), 500
 
     import re
     for amb in analysis['ambiguous']:
@@ -533,8 +549,8 @@ def hy_export_only():
 
 @app.route('/api/hy-export-download/<filename>')
 def hy_export_download(filename):
-    filepath = os.path.join(EXPORT_DIR, filename)
-    if not os.path.abspath(filepath).startswith(os.path.abspath(EXPORT_DIR)):
+    filepath = _safe_path_under(EXPORT_DIR, filename)
+    if not filepath:
         return jsonify({'error': '非法路径'}), 403
     if not os.path.exists(filepath):
         return jsonify({'error': '文件不存在'}), 404
@@ -542,7 +558,7 @@ def hy_export_download(filename):
 
 
 if __name__ == '__main__':
-    port = int(os.environ.get('APP_PORT', 5006))
+    port = int(os.environ.get('APP_PORT', 5008))
     print('=' * 50)
     print('  ZURU 河源排期入单系统（云端版）')
     print(f'  http://localhost:{port}')

--- a/apps/业务部/ZURU河源排期入单/requirements-dev.txt
+++ b/apps/业务部/ZURU河源排期入单/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest>=8.0

--- a/apps/业务部/ZURU河源排期入单/requirements.txt
+++ b/apps/业务部/ZURU河源排期入单/requirements.txt
@@ -3,4 +3,3 @@ openpyxl>=3.1
 pdfplumber>=0.10
 pycountry>=23.12
 babel>=2.14
-pytest>=8.0

--- a/apps/业务部/ZURU河源排期入单/tests/test_basics.py
+++ b/apps/业务部/ZURU河源排期入单/tests/test_basics.py
@@ -10,6 +10,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from app import (
     _session_path, _save_session, _load_session, _delete_session, _cleanup_pending,
+    _safe_path_under, SCHEDULE_DIR, EXPORT_DIR,
     app as flask_app,
 )
 
@@ -74,3 +75,24 @@ def test_path_traversal_in_delete_blocked():
                            json={'filename': '../../../etc/passwd'},
                            headers={'Content-Type': 'application/json'})
         assert resp.status_code in (403, 400)
+
+
+def test_safe_path_rejects_absolute_traversal():
+    assert _safe_path_under(SCHEDULE_DIR, '../../../etc/passwd') is None
+
+
+def test_safe_path_rejects_sibling_prefix_attack():
+    """Regression: abspath(filepath).startswith(abspath(dir)) allowed sibling dirs
+    that share a prefix. commonpath blocks them correctly."""
+    assert _safe_path_under(SCHEDULE_DIR, '../schedules_backup') is None
+    assert _safe_path_under(SCHEDULE_DIR, '../schedulesfoo.xlsx') is None
+    assert _safe_path_under(EXPORT_DIR, '../exports_v2/leak.xlsx') is None
+
+
+def test_safe_path_accepts_normal_filename():
+    assert _safe_path_under(SCHEDULE_DIR, 'schedule_2026.xlsx') is not None
+    assert _safe_path_under(EXPORT_DIR, 'out_123.xlsx') is not None
+
+
+def test_safe_path_rejects_empty():
+    assert _safe_path_under(SCHEDULE_DIR, '') is None

--- a/docker-compose.cloud.yml
+++ b/docker-compose.cloud.yml
@@ -275,13 +275,13 @@ services:
       context: ./apps/业务部/ZURU河源排期入单
       dockerfile: Dockerfile
     environment:
-      - APP_PORT=5006
+      - APP_PORT=5008
     volumes:
       - ./apps/业务部/ZURU河源排期入单/data:/app/data
       - ./apps/业务部/ZURU河源排期入单/uploads:/app/uploads
       - ./apps/业务部/ZURU河源排期入单/exports:/app/exports
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:5006/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:5008/health"]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/nginx/nginx.cloud.conf
+++ b/nginx/nginx.cloud.conf
@@ -572,13 +572,13 @@ http {
         }
         location = /hy-schedule/health {
             auth_basic off;
-            set $ups "hy-schedule-system:5006";
+            set $ups "hy-schedule-system:5008";
             proxy_pass http://$ups/health;
             proxy_set_header Host $host;
         }
         location /hy-schedule/ {
             limit_req zone=upload_limit burst=10 nodelay;
-            set $ups "hy-schedule-system:5006";
+            set $ups "hy-schedule-system:5008";
             rewrite ^/hy-schedule/(.*)$ /$1 break;
             proxy_pass http://$ups;
             proxy_set_header Host $host;


### PR DESCRIPTION
## Summary
PR #86 review 的 follow-up 修复（补 b588a42 没覆盖的问题）。

### Security
- **CRITICAL path traversal（2 处）**：`delete_schedule` 和 `hy_export_download` 用 `abspath(x).startswith(abspath(dir))`，允许 sibling-prefix 绕过（`/app/uploads/schedules_backup` 能通过 `/app/uploads/schedules` 的检查）。改用 `os.path.commonpath`，封装成 `_safe_path_under` helper
- `session_id` 由 `datetime.strftime` 改 `secrets.token_urlsafe(16)`（密码学随机）
- 3 处异常处理不再把 `str(e)` 塞给前端，改 `logger.exception(...)` + 通用错误提示

### Infra
- 内部端口 5006 → 5008（消除和 peise 的隐性冲突；外部 URL `/hy-schedule/` 不变）
- Dockerfile EXPOSE/HEALTHCHECK/CMD、docker-compose 的 APP_PORT + healthcheck、nginx 两处 upstream 同步更新
- `pytest>=8.0` 从生产 `requirements.txt` 拆到新建的 `requirements-dev.txt`

### Docs
- `CLAUDE.md`（仓库内 + 外层镜像）服务端口表和 App 注册表加 `hy-schedule-system` 一行

### Tests
- `tests/test_basics.py` 加 4 个回归测试覆盖 sibling-prefix 攻击、绝对路径穿越、空串、正常文件名

## 部署影响
`docker-compose.cloud.yml` 改动触发 `update-server.sh` **FULL RECREATE**（保守策略，compose 变动会全量 recreate）。所有服务会 recreate 一次，~30 秒；hy-schedule 的 data/uploads/exports 都是 bind mount，数据保留。

## Test plan
- [ ] CI 构建 pass
- [ ] Deploy 完成后 `curl http://8.148.146.194/hy-schedule/health` 返回 200
- [ ] portal 首页 `/hy-schedule/` 卡片仍显示「运行中」
- [ ] 上传 Excel → 分析 → 导出走一遍冒烟

🤖 Generated with [Claude Code](https://claude.com/claude-code)