### PR TITLE
fix(peise): set container timezone to Asia/Shanghai

### DIFF
--- a/apps/PMC跟仓管/配色库存管理/Dockerfile
+++ b/apps/PMC跟仓管/配色库存管理/Dockerfile
@@ -4,8 +4,10 @@ WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
+    tzdata \
     && rm -rf /var/lib/apt/lists/*
 
+ENV TZ=Asia/Shanghai
 ENV PIP_INDEX_URL=https://mirrors.aliyun.com/pypi/simple/
 ENV PIP_TRUSTED_HOST=mirrors.aliyun.com
 

--- a/docker-compose.cloud.yml
+++ b/docker-compose.cloud.yml
@@ -408,6 +408,7 @@ services:
       dockerfile: Dockerfile
     environment:
       - BASE_PATH=/peise
+      - TZ=Asia/Shanghai
       # OCR 走阿里云百炼 (Bailian) OpenAI 兼容端点 + 通义千问 VL
       - BAILIAN_API_KEY=${PEISE_BAILIAN_API_KEY:-}
       - BAILIAN_MODEL=${PEISE_BAILIAN_MODEL:-qwen-vl-max-latest}


### PR DESCRIPTION
容器默认 UTC 导致 datetime.now() 返回的时间比北京时间晚 8h，
所有 occurred_at/created_at/updated_at 入库时就是 UTC，
前端 strftime 直出，页面显示时间全部偏早 8h。

- Dockerfile 装 tzdata（python:3.12-slim 不自带）+ ENV TZ=Asia/Shanghai
- docker-compose.cloud.yml peise 段补 TZ 环境变量（覆盖容器内 shell 工具）

修复后新写入的时间戳为北京时间。DB 里已有的历史记录仍为 UTC，
如需回填需另跑 SQL（未改 DB）。