### PR TITLE
feat(paiji): 订单 inline 编辑 + 色粉/备注列 + 排机搜索 + 目标数永久化

### DIFF
--- a/apps/生产部/注塑啤机排产系统/client/src/pages/OrderImport.jsx
+++ b/apps/生产部/注塑啤机排产系统/client/src/pages/OrderImport.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import { Upload, Button, Table, message, Card, Space, Tag, Popconfirm } from 'antd';
+import { Upload, Button, Table, message, Card, Space, Tag, Popconfirm, Input, InputNumber } from 'antd';
 import { UploadOutlined, DeleteOutlined, ClearOutlined, DownloadOutlined } from '@ant-design/icons';
 import axios from 'axios';
 import { apiUrl } from '../api';
@@ -45,7 +45,7 @@ export default function OrderImport({ workshop = 'B' }) {
       formData.append('file', f);
       formData.append('workshop', workshop);
       try {
-        const { data } = await axios.post(`${API}/import`, formData);
+        const { data } = await axios.post(`${API}/import`, formData, { timeout: 120000 });
         const cnt = data.count || 0;
         totalCount += cnt;
         if (cnt === 0) failNames.push(f.name);
@@ -87,14 +87,79 @@ export default function OrderImport({ workshop = 'B' }) {
     }
   };
 
+  // 单元格编辑状态
+  const [editCell, setEditCell] = useState(null); // { id, field }
+  const [editValue, setEditValue] = useState('');
+
+  const startEdit = (record, field) => {
+    setEditCell({ id: record.id, field });
+    setEditValue(record[field] ?? '');
+  };
+
+  const saveEdit = async (record) => {
+    if (!editCell) return;
+    const field = editCell.field;
+    let value = editValue;
+    // 数字字段转换
+    if (['shot_weight', 'quantity_needed', 'material_kg', 'accumulated', 'cavity', 'cycle_time', 'sprue_pct', 'ratio_pct', 'packing_qty'].includes(field)) {
+      value = parseFloat(value) || 0;
+    }
+    if (value === record[field]) { setEditCell(null); return; }
+    try {
+      await axios.put(`${API}/${record.id}`, { [field]: value });
+      setEditCell(null);
+      fetchOrders();
+    } catch (e) {
+      message.error('保存失败：' + (e.response?.data?.message || e.message));
+    }
+  };
+
+  const renderEditable = (field, record, value, options = {}) => {
+    const isEditing = editCell && editCell.id === record.id && editCell.field === field;
+    if (isEditing) {
+      const InputCmp = options.number ? InputNumber : Input;
+      return (
+        <InputCmp
+          size="small"
+          autoFocus
+          value={editValue}
+          onChange={e => setEditValue(options.number ? e : e.target.value)}
+          onPressEnter={() => saveEdit(record)}
+          onBlur={() => saveEdit(record)}
+          style={{ width: '100%' }}
+        />
+      );
+    }
+    return (
+      <span
+        style={{ cursor: 'pointer', display: 'inline-block', minWidth: '100%', minHeight: 20, color: options.color }}
+        onClick={() => startEdit(record, field)}
+        title="点击编辑"
+      >
+        {value || <span style={{ color: '#ccc' }}>-</span>}
+      </span>
+    );
+  };
+
   const columns = [
-    { title: '产品货号', dataIndex: 'product_code', width: 120 },
-    { title: '模号名称', dataIndex: 'mold_name', width: 150 },
-    { title: '颜色', dataIndex: 'color', width: 80 },
-    { title: '料型', dataIndex: 'material_type', width: 80 },
-    { title: '啤重G', dataIndex: 'shot_weight', width: 80 },
-    { title: '需啤数', dataIndex: 'quantity_needed', width: 80 },
-    { title: '下单单号', dataIndex: 'order_no', width: 120 },
+    { title: '产品货号', dataIndex: 'product_code', width: 120,
+      render: (v, r) => renderEditable('product_code', r, v) },
+    { title: '模号名称', dataIndex: 'mold_name', width: 150,
+      render: (v, r) => renderEditable('mold_name', r, v) },
+    { title: '颜色', dataIndex: 'color', width: 80,
+      render: (v, r) => renderEditable('color', r, v) },
+    { title: '色粉', dataIndex: 'color_powder_no', width: 80,
+      render: (v, r) => renderEditable('color_powder_no', r, v) },
+    { title: '料型', dataIndex: 'material_type', width: 100,
+      render: (v, r) => renderEditable('material_type', r, v) },
+    { title: '啤重G', dataIndex: 'shot_weight', width: 80,
+      render: (v, r) => renderEditable('shot_weight', r, v, { number: true }) },
+    { title: '需啤数', dataIndex: 'quantity_needed', width: 80,
+      render: (v, r) => renderEditable('quantity_needed', r, v, { number: true }) },
+    { title: '下单单号', dataIndex: 'order_no', width: 120,
+      render: (v, r) => renderEditable('order_no', r, v) },
+    { title: '备注', dataIndex: 'order_notes', width: 120,
+      render: (v, r) => renderEditable('order_notes', r, v, { color: '#d46b08' }) },
     { title: '状态', dataIndex: 'status', width: 80,
       render: (s, record) => (
         <Tag
@@ -116,7 +181,7 @@ export default function OrderImport({ workshop = 'B' }) {
     <div>
       <Card size="small" style={{ marginBottom: 16 }}>
         <Space>
-          <Upload beforeUpload={handleUpload} showUploadList={false} accept=".pdf,.xlsx,.xls,.png,.jpg,.jpeg,.webp" multiple>
+          <Upload beforeUpload={handleUpload} showUploadList={false} accept=".pdf,.xlsx,.xls,.png,.jpg,.jpeg,.bmp,.webp" multiple>
             <Button icon={<UploadOutlined />} type="primary">导入订单 (PDF/Excel/图片)</Button>
           </Upload>
           <Button icon={<DownloadOutlined />} onClick={() => window.open(apiUrl('/api/orders/template'))}>下载导入模板</Button>

--- a/apps/生产部/注塑啤机排产系统/client/src/pages/Orders.jsx
+++ b/apps/生产部/注塑啤机排产系统/client/src/pages/Orders.jsx
@@ -5,7 +5,7 @@ import {
 } from 'antd';
 import {
   UploadOutlined, PlusOutlined, DeleteOutlined,
-  EditOutlined, InboxOutlined,
+  EditOutlined, ClearOutlined, InboxOutlined,
 } from '@ant-design/icons';
 import axios from 'axios';
 
@@ -65,6 +65,12 @@ export default function Orders() {
     load();
   };
 
+  const handleClearAll = async () => {
+    await axios.delete('/api/orders');
+    message.success('已清空所有订单');
+    load();
+  };
+
   const handleImport = async (file) => {
     const formData = new FormData();
     formData.append('file', file);
@@ -105,9 +111,12 @@ export default function Orders() {
     <div>
       <Space style={{ marginBottom: 16 }} wrap>
         <Button type="primary" icon={<PlusOutlined />} onClick={openAdd}>新增订单</Button>
-        <Upload beforeUpload={handleImport} showUploadList={false} accept=".xlsx,.xls,.pdf,.png,.jpg,.jpeg,.webp">
+        <Upload beforeUpload={handleImport} showUploadList={false} accept=".xlsx,.xls,.pdf,.png,.jpg,.jpeg,.webp,.bmp">
           <Button icon={<UploadOutlined />}>导入 Excel / PDF / 图片</Button>
         </Upload>
+        <Popconfirm title="确认清空所有订单？" onConfirm={handleClearAll}>
+          <Button danger icon={<ClearOutlined />}>清空订单</Button>
+        </Popconfirm>
         <Tag color="geekblue">共 {orders.length} 条订单</Tag>
       </Space>
 

--- a/apps/生产部/注塑啤机排产系统/client/src/pages/Scheduling.jsx
+++ b/apps/生产部/注塑啤机排产系统/client/src/pages/Scheduling.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Card, Button, DatePicker, Radio, Table, message, Steps, Tag, Space, Alert } from 'antd';
+import { Card, Button, DatePicker, Radio, Table, message, Steps, Tag, Space, Alert, Input } from 'antd';
 import { ThunderboltOutlined, InfoCircleOutlined } from '@ant-design/icons';
 import axios from 'axios';
 import dayjs from 'dayjs';
@@ -15,6 +15,7 @@ export default function Scheduling({ onDone, workshop = 'B' }) {
   const [shift, setShift] = useState('白班');
   const [loading, setLoading] = useState(false);
   const [carryOverInfo, setCarryOverInfo] = useState(null);
+  const [searchText, setSearchText] = useState('');
 
   useEffect(() => {
     axios.get(ORDERS_API, { params: { status: 'pending', workshop } })
@@ -64,10 +65,21 @@ export default function Scheduling({ onDone, workshop = 'B' }) {
     { title: '产品货号', dataIndex: 'product_code', width: 120 },
     { title: '模号名称', dataIndex: 'mold_name', width: 150 },
     { title: '颜色', dataIndex: 'color', width: 80 },
-    { title: '料型', dataIndex: 'material_type', width: 80 },
+    { title: '色粉', dataIndex: 'color_powder_no', width: 80 },
+    { title: '料型', dataIndex: 'material_type', width: 100 },
     { title: '啤重G', dataIndex: 'shot_weight', width: 80 },
     { title: '需啤数', dataIndex: 'quantity_needed', width: 80 },
+    { title: '下单单号', dataIndex: 'order_no', width: 130 },
   ];
+
+  // 按搜索词过滤订单
+  const filteredOrders = searchText.trim()
+    ? orders.filter(o => {
+        const q = searchText.toLowerCase();
+        return ['product_code', 'mold_name', 'color', 'color_powder_no', 'material_type', 'order_no']
+          .some(k => String(o[k] || '').toLowerCase().includes(q));
+      })
+    : orders;
 
   const carryOverColumns = [
     { title: '机台', dataIndex: 'machine_no', width: 70 },
@@ -90,13 +102,28 @@ export default function Scheduling({ onDone, workshop = 'B' }) {
 
       {step === 0 && (
         <div>
+          <Space style={{ marginBottom: 12 }}>
+            <Input.Search
+              placeholder="搜索货号/模号/颜色/色粉/料型/单号"
+              value={searchText}
+              onChange={e => setSearchText(e.target.value)}
+              onSearch={setSearchText}
+              allowClear
+              style={{ width: 360 }}
+            />
+            <span style={{ color: '#999' }}>
+              共 {filteredOrders.length} 条{searchText ? ` / 总 ${orders.length}` : ''}
+              {selectedIds.length > 0 && ` · 已选 ${selectedIds.length}`}
+            </span>
+          </Space>
           <Table
             rowSelection={{
               selectedRowKeys: selectedIds,
               onChange: setSelectedIds,
+              preserveSelectedRowKeys: true,
             }}
             columns={orderColumns}
-            dataSource={orders}
+            dataSource={filteredOrders}
             rowKey="id"
             size="small"
             pagination={{ pageSize: 50 }}

--- a/apps/生产部/注塑啤机排产系统/server/routes/orders.js
+++ b/apps/生产部/注塑啤机排产系统/server/routes/orders.js
@@ -28,7 +28,7 @@ function stmts() {
         UPDATE orders SET product_code=?, mold_no=?, mold_name=?, color=?, color_powder_no=?,
           material_type=?, shot_weight=?, material_kg=?, sprue_pct=?, ratio_pct=?,
           quantity_needed=?, accumulated=?, cavity=?, cycle_time=?, order_no=?,
-          is_three_plate=?, packing_qty=?, status=?
+          is_three_plate=?, packing_qty=?, status=?, order_notes=?
         WHERE id=?
       `),
       deleteOne: db.prepare('DELETE FROM orders WHERE id = ?'),
@@ -97,6 +97,7 @@ router.put('/:id', (req, res) => {
       o.is_three_plate ?? existing.is_three_plate,
       o.packing_qty ?? existing.packing_qty,
       o.status ?? existing.status,
+      o.order_notes ?? existing.order_notes,
       req.params.id
     );
     res.json({ id: Number(req.params.id), ...o });
@@ -112,6 +113,17 @@ router.delete('/:id', (req, res) => {
     res.json({ message: '已删除' });
   } catch (err) {
     res.status(500).json({ message: '删除失败：' + err.message });
+  }
+});
+
+// 清空当前车间所有订单
+router.delete('/', (req, res) => {
+  try {
+    const workshop = req.query.workshop || req.body.workshop || 'B';
+    const result = db.prepare('DELETE FROM orders WHERE workshop = ?').run(workshop);
+    res.json({ message: `已清空 ${result.changes} 条订单`, count: result.changes });
+  } catch (err) {
+    res.status(500).json({ message: '清空失败：' + err.message });
   }
 });
 
@@ -205,7 +217,7 @@ router.post('/import', upload.single('file'), async (req, res) => {
     if (ext === '.pdf') {
       const { parsePdf } = require('../services/pdfParser');
       parsed = await parsePdf(req.file.path);
-    } else if (['.png', '.jpg', '.jpeg', '.webp'].includes(ext)) {
+    } else if (['.png', '.jpg', '.jpeg', '.bmp', '.webp'].includes(ext)) {
       const { parseImageOrders } = require('../services/imageParser');
       const result = await parseImageOrders(req.file.path);
       parsed = result.orders;

--- a/apps/生产部/注塑啤机排产系统/server/routes/scheduling.js
+++ b/apps/生产部/注塑啤机排产系统/server/routes/scheduling.js
@@ -140,7 +140,7 @@ router.put('/:id/items/:itemId', (req, res) => {
     }
   }
 
-  // 目标数更新时自动计算天数
+  // 目标数更新时自动计算天数，并同步到 mold_targets（永久保存，下次排机默认取）
   if (req.body.target_24h !== undefined) {
     const currentItem = db.prepare('SELECT * FROM schedule_items WHERE id = ?').get(itemId);
     if (!currentItem) return res.status(404).json({ message: '记录不存在' });
@@ -150,6 +150,27 @@ router.put('/:id/items/:itemId', (req, res) => {
     const daysNeeded = t24h > 0 ? Math.round((shortage / t24h) * 100) / 100 : 0;
     updates.push('target_24h = ?', 'target_11h = ?', 'days_needed = ?');
     values.push(t24h, t11h, daysNeeded);
+
+    // 同步到 mold_targets：从 mold_name 提取模具编号（首段，去掉中文），存或更新
+    if (t24h > 0 && currentItem.mold_name) {
+      try {
+        const moldCode = currentItem.mold_name.split(' ')[0].replace(/[一-龥].*$/, '').trim();
+        if (moldCode) {
+          const sched = db.prepare('SELECT workshop FROM schedules WHERE id = ?').get(currentItem.schedule_id);
+          const ws = sched?.workshop || 'B';
+          const exists = db.prepare('SELECT id FROM mold_targets WHERE mold_no = ? AND workshop = ?').get(moldCode, ws);
+          if (exists) {
+            db.prepare('UPDATE mold_targets SET target_24h=?, target_11h=?, mold_name=?, updated_at=CURRENT_TIMESTAMP WHERE id=?')
+              .run(t24h, t11h, currentItem.mold_name, exists.id);
+          } else {
+            db.prepare("INSERT INTO mold_targets (mold_no, mold_name, target_24h, target_11h, notes, workshop) VALUES (?, ?, ?, ?, '', ?)")
+              .run(moldCode, currentItem.mold_name, t24h, t11h, ws);
+          }
+        }
+      } catch (e) {
+        console.log('[同步 mold_targets 失败]', e.message);
+      }
+    }
   }
 
   if (updates.length === 0) return res.status(400).json({ message: '没有要更新的字段' });

--- a/apps/生产部/注塑啤机排产系统/server/services/schedulingEngine.js
+++ b/apps/生产部/注塑啤机排产系统/server/services/schedulingEngine.js
@@ -110,6 +110,23 @@ function generateSchedule({ orderIds, date, shift, workshop }) {
     const codeOnly = mt.mold_no.replace(/[\u4e00-\u9fa5].*$/, '').trim();
     if (codeOnly && codeOnly !== mt.mold_no) moldTargetMap[codeOnly] = mt;
   }
+
+  // 2c. \u4ece\u5386\u53f2\u8bb0\u5f55\u6784\u5efa \u515c\u5e95\u76ee\u6807\u6570 \u7d22\u5f15\uff08\u7cbe\u786e\u5339\u914d\u6a21\u5177\u7f16\u53f7\uff0c\u53d6\u4f17\u6570 target_24h\uff09
+  // \u540c\u6a21\u5177\u53f7\u5728\u4e0d\u540c\u65f6\u671f\u53ef\u80fd\u6709\u4e0d\u540c\u76ee\u6807\u503c\uff0c\u53d6\u51fa\u73b0\u6700\u591a\u7684\u90a3\u4e2a\u6700\u53ef\u9760
+  const histTargetRows = db.prepare(`
+    SELECT mold_name, target_24h, COUNT(*) as cnt
+    FROM history_records
+    WHERE workshop = ? AND target_24h > 0 AND mold_name IS NOT NULL AND mold_name != ''
+    GROUP BY mold_name, target_24h
+  `).all(ws);
+  const histTargetMap = {}; // code \u2192 { target_24h, cnt }
+  for (const h of histTargetRows) {
+    const code = (h.mold_name || '').split(' ')[0].replace(/[\u4e00-\u9fa5].*$/, '').trim();
+    if (!code) continue;
+    const cur = histTargetMap[code];
+    if (!cur || h.cnt > cur.cnt) histTargetMap[code] = { target_24h: h.target_24h, cnt: h.cnt };
+  }
+
   const findMoldTarget = (moldNo) => {
     if (!moldNo) return null;
     // 去掉订单模具号末尾中文
@@ -124,6 +141,9 @@ function generateSchedule({ orderIds, date, shift, workshop }) {
     if (noMA !== code && moldTargetMap[noMA]) return moldTargetMap[noMA];
     const noMAparent = noMA.replace(/-\d+$/, '');
     if (noMAparent !== noMA && moldTargetMap[noMAparent]) return moldTargetMap[noMAparent];
+    // 4) 兜底：从历史记录精确匹配（取众数）— 精确 code + 同套模 parentCode
+    if (histTargetMap[code]) return { target_24h: histTargetMap[code].target_24h, target_11h: 0 };
+    if (parentCode !== code && histTargetMap[parentCode]) return { target_24h: histTargetMap[parentCode].target_24h, target_11h: 0 };
     return null;
   };
 


### PR DESCRIPTION
## Summary

在 main 最新 Bailian 集成基础上叠加原 PR #92 的 UI/后端 value-add 部分。

### 前端
- **OrderImport 页**：所有字段点击即可 inline 编辑；新增 色粉 / 备注 列；图片格式支持 .bmp；上传超时放宽到 120s。
- **Scheduling 页**：新增搜索框（货号/模号/颜色/色粉/料型/单号）；订单表新增 色粉 / 下单单号 列。
- **Orders 页**：新增「清空当前车间订单」按钮。

### 后端
- `routes/orders.js`: UPDATE 支持 `order_notes` 列（inline 编辑备注落库）；新增 `DELETE /api/orders` 清空当前车间；图片扩展名加 `.bmp`。
- `routes/scheduling.js`: 编辑 24h 目标时同步保存到 `mold_targets` 表，下次排机永久生效。
- `services/schedulingEngine.js`: 目标数查找兜底从 `history_records` 取同模具号众数，解决「新订单 + 旧模具无 mold_targets 记录」的场景。

## 为什么重写了原 PR

原 commit 86997b8 有几个阻断性问题：
1. 🚨 `qwenOcr.js` 硬编码 Bailian API key 为 fallback，已 push 到 PUBLIC 仓库
2. 路径错误：代码放在 `apps/paiji/` 而 docker-compose build context 指向 `apps/生产部/注塑啤机排产系统/`，合并等于无效部署
3. `app.js` / `main.jsx` / `connection.js` / `init.js` 相对 main 有倒退（CORS 放开、缺 /health endpoint、缺 axios interceptor 导致子路径失效、缺 UNIQUE index）
4. OCR 用 tesseract.js，但 main 已在 ec626b7 接入 Bailian (qwen-vl-max)，PR 相当于回退

此版本：
- 沿用 main 上已经存在的完整 Bailian 集成（`imageParser.js` 直接读 `BAILIAN_API_KEY`）
- 只保留原 PR 真正有价值的 UI + 后端改动

## Test plan

- [ ] `/paiji/` 首页正常加载
- [ ] 订单导入页：上传图片走 Bailian → 订单入库
- [ ] 订单导入页：点击单元格 inline 修改字段 → 保存成功
- [ ] 订单导入页：色粉 / 备注 列显示且可编辑
- [ ] 订单导入页：点清空全部 → 只清当前车间
- [ ] 智能排机页：搜索框过滤订单
- [ ] 智能排机页：编辑 24H 目标 → 保存后下次排机自动带出
- [ ] 后端：`DELETE /api/orders?workshop=B` 返回清空条数

🤖 Generated with [Claude Code](https://claude.com/claude-code)