### PR TITLE
fix: SPIN导出多项修复 — 行扩展、人工计算、PP胶粒

### DIFF
--- a/client/js/tabs/spin-labor.js
+++ b/client/js/tabs/spin-labor.js
@@ -17,18 +17,18 @@ const tab_spin_labor = {
     const LABOR_NAMES = /^(裁床人工|车缝人工|手工人工)/;
     const laborItems = filtered.filter(d => d.position === '__labor__' && LABOR_NAMES.test(d.fabric_name || ''));
     const laborTotal = laborItems.reduce((s, d) => {
-      // US$/toy = price_rmb (HKD from col D) / hkd_usd
-      const usdPerToy = (parseFloat(d.price_rmb) || 0) / hkd_usd;
+      // US$/toy = price_rmb (stored as HKD) × rmb_hkd / hkd_usd
+      const usdPerToy = (parseFloat(d.price_rmb) || 0) / rmb_hkd / hkd_usd;
       return s + usdPerToy;
     }, 0);
 
     // Fixed labor rate from params: labor_hkd / 11hr / hkd_usd (e.g. 275/11/7.75 = 3.226)
     const laborHkd = parseFloat(params.labor_hkd) || 0;
-    const LABOR_RATE_USD = laborHkd ? laborHkd / 11 / hkd_usd : 3.226;
+    const LABOR_RATE_USD = laborHkd ? Math.round(laborHkd / 11 / hkd_usd * 1000) / 1000 : 3.226;
 
     const laborRows = laborItems.map(d => {
       const rateUsd = LABOR_RATE_USD;
-      const usdPerToy = (parseFloat(d.price_rmb) || 0) / hkd_usd;           // col D HKD → USD
+      const usdPerToy = (parseFloat(d.price_rmb) || 0) / rmb_hkd / hkd_usd;
       const stdHour = rateUsd > 0 ? usdPerToy / rateUsd : 0;                // standard hour
       return `
         <tr>

--- a/client/js/tabs/spin-labor.js
+++ b/client/js/tabs/spin-labor.js
@@ -17,7 +17,7 @@ const tab_spin_labor = {
     const LABOR_NAMES = /^(裁床人工|车缝人工|手工人工)/;
     const laborItems = filtered.filter(d => d.position === '__labor__' && LABOR_NAMES.test(d.fabric_name || ''));
     const laborTotal = laborItems.reduce((s, d) => {
-      // US$/toy = price_rmb (stored as HKD) × rmb_hkd / hkd_usd
+      // US$/toy = price_rmb (RMB) / rmb_hkd / hkd_usd
       const usdPerToy = (parseFloat(d.price_rmb) || 0) / rmb_hkd / hkd_usd;
       return s + usdPerToy;
     }, 0);

--- a/server/services/db.js
+++ b/server/services/db.js
@@ -356,6 +356,30 @@ function initDb() {
     db.exec("ALTER TABLE SewingDetail ADD COLUMN merge_group TEXT");
   }
 
+  // ── One-time migration: SPIN labor price_rmb stored unit changes from HKD to RMB.
+  // Pre-fix code (parseSpinLaborFromMain override) wrote col-D HKD into price_rmb.
+  // Post-fix code reads 车缝明细 col H which is RMB. The display formula now
+  // assumes RMB (price_rmb / rmb_hkd / hkd_usd). Without conversion, legacy rows
+  // would show ~17.6% inflated US$/toy — silently wrong on every old SPIN export.
+  //
+  // Gate column `price_rmb_unit` (default 'rmb') ensures the conversion runs once.
+  // Convert price_rmb = HKD × 0.85 → RMB on rows that match the legacy labor signature
+  // (position='__labor__' and fabric_name contains 人工).
+  if (!sewCols.includes('price_rmb_unit')) {
+    db.exec("ALTER TABLE SewingDetail ADD COLUMN price_rmb_unit TEXT DEFAULT 'rmb'");
+    const result = db.prepare(`
+      UPDATE SewingDetail
+      SET price_rmb = ROUND(price_rmb * 0.85, 4)
+      WHERE position = '__labor__'
+        AND fabric_name LIKE '%人工%'
+        AND price_rmb IS NOT NULL
+        AND price_rmb > 0
+    `).run();
+    if (result.changes > 0) {
+      console.log(`[migration] spin_labor_hkd_to_rmb: converted ${result.changes} legacy labor rows (price_rmb × 0.85)`);
+    }
+  }
+
   // Migrate: add eng_name and SPIN molding fields to MoldPart
   const moldCols = db.prepare('PRAGMA table_info(MoldPart)').all().map(c => c.name);
   if (!moldCols.includes('eng_name'))           db.exec("ALTER TABLE MoldPart ADD COLUMN eng_name TEXT");

--- a/server/services/excel-parser.js
+++ b/server/services/excel-parser.js
@@ -1137,9 +1137,10 @@ function parseSpinLaborFromMain(ws) {
       if (costHkd == null || costHkd <= 0) return;
       // Store labor rate as RMB equivalent (display recovers: rateUsd = material_price_rmb / rmbUsdRate)
       const laborRateRmb = laborRateUsd * 0.85 * 7.75;
-      // Store HKD cost in price_rmb field; display converts: usdPerToy = price_rmb / hkd_usd
+      // Store RMB cost in price_rmb field; display converts: usdPerToy = price_rmb / rmb_hkd / hkd_usd
+      const costRmb = costHkd * 0.85;    // HKD → RMB (consistent with 车缝明细 H column)
       const defaultHkdUsd = 7.75;
-      const usdPerToy = costHkd / defaultHkdUsd;
+      const usdPerToy = costRmb / 0.85 / defaultHkdUsd;
       const stdHour = laborRateUsd > 0 ? usdPerToy / laborRateUsd : 0;
       items.push({
         fabric_name: label,
@@ -1147,9 +1148,9 @@ function parseSpinLaborFromMain(ws) {
         sub_product: charName,
         product_name: charName,
         product_eng: charName,
-        usage_amount: stdHour,            // Standard Hour (approximate; display recomputes using actual hkd_usd)
-        material_price_rmb: laborRateRmb, // Labor rate encoded as RMB-equivalent
-        price_rmb: costHkd,              // HKD cost from col D
+        usage_amount: stdHour,
+        material_price_rmb: laborRateRmb,
+        price_rmb: costRmb,              // RMB cost (HKD × 0.85)
         sort_order: items.length,
       });
     });
@@ -1598,34 +1599,24 @@ async function parseWorkbook(filePath, forceFormat) {
   try { rotocastItems = format === 'plush' ? parseRotocastItems(ws) : []; } catch(e) { throw new Error('parseRotocastItems: ' + e.message); }
   // plush(TOMY) 用旧版单 sheet 解析；spin 用多 sheet 版本
   try { sewingDetails = format === 'spin' ? parseSewingDetails(workbook) : format === 'plush' ? parseSewingDetailsPlush(workbook) : []; } catch(e) { throw new Error('parseSewingDetails: ' + e.message); }
-  // For SPIN: replace labor items with values from main sheet
-  if (format === 'spin') {
-    const mainLaborItems = parseSpinLaborFromMain(ws);
-    if (mainLaborItems.length > 0) {
-      sewingDetails = [
-        ...sewingDetails.filter(d => !/人工/.test(d.fabric_name || '')),
-        ...mainLaborItems,
-      ];
-    }
-  }
+  // SPIN: labor items come from 车缝明细 (unified RMB source)
   // SPIN: fill PP胶粒 price from main sheet (PP胶料 row)
   // SPIN: fill PP胶粒 price from main sheet (PP胶料 row)
-  // The price in main sheet c6 is HKD/g, need to convert to match Other Cost USD formula:
-  // UI: usd = material_price_rmb / rmb_hkd / hkd_usd * 1.06
-  // PP actual: usd = hkd_price / hkd_usd * 1.06
-  // So store as: material_price_rmb = hkd_price * rmb_hkd (so the division cancels out)
+  // PP胶粒 price: find "PP" column in material table (row 1), read 料单价 (row 4) as HKD/g
+  // Store as pseudo-RMB so UI formula (material_price_rmb / rmb_hkd / hkd_usd * 1.06) gives correct USD
   if (format === 'spin') {
-    let ppPriceHkd = 0;
-    for (let r = 1; r <= 60; r++) {
-      const b = strVal(ws.getCell(r, 2));
-      if (b && /PP胶/.test(b)) {
-        ppPriceHkd = numVal(ws.getCell(r, 6)) || 0;
+    let ppPriceHkdPerG = 0;
+    // Find PP column in row 1 material headers
+    for (let col = 2; col <= 22; col++) {
+      const matType = strVal(ws.getCell(1, col));
+      if (matType && /^PP$/i.test(matType.trim())) {
+        ppPriceHkdPerG = numVal(ws.getCell(4, col)) || 0;
         break;
       }
     }
-    if (ppPriceHkd) {
+    if (ppPriceHkdPerG) {
       const rmbHkd = parseFloat(header.params && header.params.rmb_hkd) || 0.85;
-      const ppAsRmb = ppPriceHkd * rmbHkd; // store as pseudo-RMB so UI formula gives correct USD
+      const ppAsRmb = ppPriceHkdPerG * rmbHkd;
       sewingDetails = sewingDetails.map(d => {
         if (/PP胶/.test(d.fabric_name || '') && !d.material_price_rmb) {
           return { ...d, material_price_rmb: ppAsRmb };

--- a/server/services/excel-parser.js
+++ b/server/services/excel-parser.js
@@ -1114,50 +1114,6 @@ function parseHardwareSheet(workbook, mainWs) {
   return items;
 }
 
-// ─── SPIN Labor Parser (reads 人工 rows from main 报价明细 sheet) ──────────────
-
-function parseSpinLaborFromMain(ws) {
-  if (!ws) return [];
-  // Row 15: English character names in cols 4–9 (Rocky, Skye, Marshall, Rex, Chase, Rubble)
-  const chars = [];
-  for (let c = 4; c <= 9; c++) {
-    const name = strVal(ws.getCell(15, c));
-    if (name) chars.push({ col: c, name });
-  }
-  if (!chars.length) return [];
-
-  const LABOR_WHITELIST = /^(半成品人工|裁床人工|车缝人工|手工人工)/;
-  const items = [];
-  for (let r = 1; r <= ws.rowCount; r++) {
-    const label = strVal(ws.getCell(r, 2));
-    if (!label || !LABOR_WHITELIST.test(label)) continue;
-    const laborRateUsd = numVal(ws.getCell(r, 6)) || 0; // col F = labor rate USD/hr (3.226)
-    chars.forEach(({ col, name: charName }) => {
-      const costHkd = numVal(ws.getCell(r, col)); // col D = HKD cost per toy
-      if (costHkd == null || costHkd <= 0) return;
-      // Store labor rate as RMB equivalent (display recovers: rateUsd = material_price_rmb / rmbUsdRate)
-      const laborRateRmb = laborRateUsd * 0.85 * 7.75;
-      // Store RMB cost in price_rmb field; display converts: usdPerToy = price_rmb / rmb_hkd / hkd_usd
-      const costRmb = costHkd * 0.85;    // HKD → RMB (consistent with 车缝明细 H column)
-      const defaultHkdUsd = 7.75;
-      const usdPerToy = costRmb / 0.85 / defaultHkdUsd;
-      const stdHour = laborRateUsd > 0 ? usdPerToy / laborRateUsd : 0;
-      items.push({
-        fabric_name: label,
-        position: '__labor__',
-        sub_product: charName,
-        product_name: charName,
-        product_eng: charName,
-        usage_amount: stdHour,
-        material_price_rmb: laborRateRmb,
-        price_rmb: costRmb,              // RMB cost (HKD × 0.85)
-        sort_order: items.length,
-      });
-    });
-  }
-  return items;
-}
-
 // ─── SPIN In-Housed Molding Parser ───────────────────────────────────────────
 // Supports two layouts:
 //   Chinese: 模号|名称|料型|料重(G)|料价(G)|机型(A)|件数|套数|目标数|工|料金额|模费人民币|...|实际秒数|报客秒数|报客模费
@@ -1600,16 +1556,17 @@ async function parseWorkbook(filePath, forceFormat) {
   // plush(TOMY) 用旧版单 sheet 解析；spin 用多 sheet 版本
   try { sewingDetails = format === 'spin' ? parseSewingDetails(workbook) : format === 'plush' ? parseSewingDetailsPlush(workbook) : []; } catch(e) { throw new Error('parseSewingDetails: ' + e.message); }
   // SPIN: labor items come from 车缝明细 (unified RMB source)
-  // SPIN: fill PP胶粒 price from main sheet (PP胶料 row)
-  // SPIN: fill PP胶粒 price from main sheet (PP胶料 row)
-  // PP胶粒 price: find "PP" column in material table (row 1), read 料单价 (row 4) as HKD/g
-  // Store as pseudo-RMB so UI formula (material_price_rmb / rmb_hkd / hkd_usd * 1.06) gives correct USD
+  // SPIN: fill PP胶粒 price from material table — find "PP" column in row 1, read 料单价 (row 4) as HKD/g.
+  // Store as pseudo-RMB so UI formula (material_price_rmb / rmb_hkd / hkd_usd * 1.06) gives correct USD.
+  // Header regex matches PP / PP料 / PP胶 / PP胶料 / PP-1 / PP（白）but rejects sibling plastics
+  // (PPS / PPE / PPA / PPO) which would otherwise be silently mis-priced as PP.
+  const PP_HEADER_RE = /^PP(?![A-Za-z])/i;
   if (format === 'spin') {
     let ppPriceHkdPerG = 0;
     // Find PP column in row 1 material headers
     for (let col = 2; col <= 22; col++) {
       const matType = strVal(ws.getCell(1, col));
-      if (matType && /^PP$/i.test(matType.trim())) {
+      if (matType && PP_HEADER_RE.test(matType.trim())) {
         ppPriceHkdPerG = numVal(ws.getCell(4, col)) || 0;
         break;
       }

--- a/server/services/spin-exporter.js
+++ b/server/services/spin-exporter.js
@@ -235,20 +235,54 @@ function fillCharacterSheet(ws, d) {
   const OTHERS_SLOTS = 11;
   const othersOverflow = Math.max(0, sortedOthers.length - OTHERS_SLOTS);
 
-  // Helper: duplicate rows and shift formulas at/after threshold
+  // Helper: duplicate rows and shift formulas with range awareness.
+  // Three cases handled per formula reference:
+  //   (a) Range END equals lastSlotRow      → grow end (subtotal SUM picks up overflow rows)
+  //   (b) Row reference >= threshold         → shift by overflow (rows physically moved down)
+  //   (c) Row reference  < threshold (and != lastSlotRow as range end) → unchanged
   function expandSection(startRow, slots, overflow) {
     if (overflow <= 0) return;
-    ws.duplicateRow(startRow + slots - 1, overflow, true);
-    const re = /([A-Z]+)(\d+)/g;
+    const lastSlotRow = startRow + slots - 1;   // template's last data slot before duplication
+    const threshold   = startRow + slots;        // first row PHYSICALLY shifted by duplicateRow
+    ws.duplicateRow(lastSlotRow, overflow, true);
+
+    // Range pattern: A23:A35, $A$23:$A$35 — capture column+row pairs
+    const rangeRe = /(\$?[A-Z]+\$?)(\d+):(\$?[A-Z]+\$?)(\d+)/g;
+    const cellRe  = /(\$?[A-Z]+\$?)(\d+)/g;
+    // Placeholder uses control chars only (no [A-Z]) so cellRe cannot match it
+    const placeholder = i => `\x01\x02${i}\x02\x01`;
+    const placeholderRe = /\x01\x02(\d+)\x02\x01/g;
+
     ws.eachRow({ includeEmpty: false }, row => {
       row.eachCell({ includeEmpty: false }, cell => {
         const v = cell.value;
         if (!v || typeof v !== 'object' || !v.formula) return;
-        const newF = v.formula.replace(re, (match, col, rowStr) => {
-          const rn = parseInt(rowStr, 10);
-          return rn >= startRow + slots ? col + (rn + overflow) : match;
+
+        // Step 1: replace ranges with placeholders carrying the rewritten ref,
+        // so the single-cell pass below doesn't double-shift their endpoints.
+        const ranges = [];
+        let f = v.formula.replace(rangeRe, (_m, c1, r1, c2, r2) => {
+          const rn1 = parseInt(r1, 10);
+          const rn2 = parseInt(r2, 10);
+          const new1 = rn1 >= threshold ? rn1 + overflow : rn1;
+          let   new2;
+          if (rn2 === lastSlotRow)   new2 = rn2 + overflow;   // grow end (case a)
+          else if (rn2 >= threshold) new2 = rn2 + overflow;   // shift end (case b)
+          else                       new2 = rn2;              // unchanged (case c)
+          ranges.push(`${c1}${new1}:${c2}${new2}`);
+          return placeholder(ranges.length - 1);
         });
-        if (newF !== v.formula) cell.value = { formula: newF, result: v.result };
+
+        // Step 2: shift remaining single-cell refs (those outside any range)
+        f = f.replace(cellRe, (m, col, rowStr) => {
+          const rn = parseInt(rowStr, 10);
+          return rn >= threshold ? col + (rn + overflow) : m;
+        });
+
+        // Step 3: restore ranges
+        f = f.replace(placeholderRe, (_, idx) => ranges[parseInt(idx, 10)]);
+
+        if (f !== v.formula) cell.value = { formula: f, result: v.result };
       });
     });
   }

--- a/server/services/spin-exporter.js
+++ b/server/services/spin-exporter.js
@@ -188,12 +188,57 @@ function fillCharacterSheet(ws, d) {
   const hkd_usd = parseFloat(params.hkd_usd) || 7.75;
   const rmbUsdRate = rmb_hkd * hkd_usd;
 
+  // ── Fabric Cost: merge & sort data ──────────────────────────────────────────
+  const mergedFabrics = [];
+  for (const item of fabricItems) {
+    const name = item.fabric_name || '';
+    const pn = item.product_name || '';
+    const existing = mergedFabrics.find(m => m.fabric_name === name && (m.product_name || '') === pn);
+    if (existing) {
+      existing.usage_amount = (parseFloat(existing.usage_amount) || 0) + (parseFloat(item.usage_amount) || 0);
+    } else {
+      mergedFabrics.push({ ...item, usage_amount: parseFloat(item.usage_amount) || 0 });
+    }
+  }
+  const productNames = [...new Set(fabricItems.map(d => d.product_name || '').filter(Boolean))];
+  const showProductCol = productNames.length > 1;
+  const sortedFabrics = showProductCol
+    ? [...mergedFabrics].sort((a, b) => (a.product_name || '').localeCompare(b.product_name || ''))
+    : mergedFabrics;
+
+  // ── Others Cost: sort data ────────────────────────────────────────────────────
+  const otherProductNames = [...new Set(otherItems.map(d => d.product_name || '').filter(Boolean))];
+  const showOtherProductCol = otherProductNames.length > 1;
+  const sortedOthers = showOtherProductCol
+    ? [...otherItems].sort((a, b) => (a.product_name || '').localeCompare(b.product_name || ''))
+    : otherItems;
+
+  // ── Row expansion: Fabric Cost, Electronic, Others Cost ─────────────────────
+  // Process bottom-up so earlier expansions don't invalidate later row numbers.
+  // Each expansion uses duplicateRow + shiftFormulas, same pattern as Electronic.
+
+  const FABRIC_SLOTS = 13;   // rows 23-35
+  const FABRIC_START = 23;
+  const fabricOverflow = Math.max(0, sortedFabrics.length - FABRIC_SLOTS);
+
   const elecList = electronicItems || [];
   const ELEC_SLOTS = 10;
-  const S = Math.max(0, elecList.length - ELEC_SLOTS);
-  if (S > 0) {
-    ws.duplicateRow(48 + ELEC_SLOTS - 1, S, true);
-    // Fix formula references: rows >= 58 shift by S
+  const ELEC_START = 48;
+  const elecOverflow = Math.max(0, elecList.length - ELEC_SLOTS);
+
+  // Others Cost: find header row first (before any expansion)
+  let othersHeaderRow = 60;
+  for (let r = 55; r <= 80; r++) {
+    const c = ws.getCell(r, 3).value;
+    if (c && /Others Cost/i.test(String(c))) { othersHeaderRow = r; break; }
+  }
+  const OTHERS_SLOTS = 11;
+  const othersOverflow = Math.max(0, sortedOthers.length - OTHERS_SLOTS);
+
+  // Helper: duplicate rows and shift formulas at/after threshold
+  function expandSection(startRow, slots, overflow) {
+    if (overflow <= 0) return;
+    ws.duplicateRow(startRow + slots - 1, overflow, true);
     const re = /([A-Z]+)(\d+)/g;
     ws.eachRow({ includeEmpty: false }, row => {
       row.eachCell({ includeEmpty: false }, cell => {
@@ -201,12 +246,17 @@ function fillCharacterSheet(ws, d) {
         if (!v || typeof v !== 'object' || !v.formula) return;
         const newF = v.formula.replace(re, (match, col, rowStr) => {
           const rn = parseInt(rowStr, 10);
-          return rn >= 48 + ELEC_SLOTS ? col + (rn + S) : match;
+          return rn >= startRow + slots ? col + (rn + overflow) : match;
         });
         if (newF !== v.formula) cell.value = { formula: newF, result: v.result };
       });
     });
   }
+
+  // Expand bottom-up: Others → Electronic → Fabric
+  expandSection(othersHeaderRow + 1, OTHERS_SLOTS, othersOverflow);
+  expandSection(ELEC_START, ELEC_SLOTS, elecOverflow);
+  expandSection(FABRIC_START, FABRIC_SLOTS, fabricOverflow);
 
   // ── Header (force-write to bypass formula cells) ────────────────────────────
   ws.getCell(3, 3).value = 'ROYAL REGENT PRODUCTS INDUSTRIES LIMITED';
@@ -219,42 +269,16 @@ function fillCharacterSheet(ws, d) {
   const charSuffix = d.charName ? `--${d.charName}` : '';
   ws.getCell(7, 3).value = product ? ((product.item_desc || '') + charSuffix) : '';
 
-  // ── Fabric Cost (R23-R35): cols C=3 eng desc, D=4 cn desc, J=10 USD price, K=11 qty ──
-  // Merge rows with the same fabric_name + product_name: sum usage_amount
-  const mergedFabrics = [];
-  for (const item of fabricItems) {
-    const name = item.fabric_name || '';
-    const pn = item.product_name || '';
-    const existing = mergedFabrics.find(m => m.fabric_name === name && (m.product_name || '') === pn);
-    if (existing) {
-      existing.usage_amount = (parseFloat(existing.usage_amount) || 0) + (parseFloat(item.usage_amount) || 0);
-    } else {
-      mergedFabrics.push({ ...item, usage_amount: parseFloat(item.usage_amount) || 0 });
-    }
-  }
-
-  // Check if multiple product_names exist (need to show 款式 column)
-  const productNames = [...new Set(fabricItems.map(d => d.product_name || '').filter(Boolean))];
-  const showProductCol = productNames.length > 1;
-
-  // Sort by product_name for grouped display
-  const sortedFabrics = showProductCol
-    ? [...mergedFabrics].sort((a, b) => (a.product_name || '').localeCompare(b.product_name || ''))
-    : mergedFabrics;
-
-  clearRows(ws, 23, 35, [3, 4, 5, 10, 11, 12]);
-  sortedFabrics.slice(0, 13).forEach((item, i) => {
+  // ── Fabric Cost (R23+): cols C=3 eng desc, D=4 cn desc, J=10 USD price, K=11 qty ──
+  const fabricEndRow = FABRIC_START + Math.max(FABRIC_SLOTS, sortedFabrics.length) - 1;
+  clearRows(ws, FABRIC_START, fabricEndRow, [3, 4, 5, 10, 11, 12]);
+  sortedFabrics.forEach((item, i) => {
     const r = 23 + i;
     const engName = item.eng_name || '';
     const cnName = item.fabric_name || '';
-    // C = eng + cn combined when multi-product, otherwise eng in C, cn in D
-    if (showProductCol) {
-      setVal(ws, r, 3, engName && cnName && engName !== cnName ? `${engName}\n${cnName}` : (cnName || engName));
-      setVal(ws, r, 4, item.product_name || '');
-    } else {
-      setVal(ws, r, 3, engName || cnName);
-      setVal(ws, r, 4, engName ? cnName : '');
-    }
+    setVal(ws, r, 3, engName || cnName);
+    setVal(ws, r, 4, engName ? cnName : '');
+    if (showProductCol) setVal(ws, r, 5, item.product_name || '');
     const unitPriceUsd = r2((parseFloat(item.material_price_rmb) || 0) / 0.85 / 7.75 * 1.06);
     const usage = r2(item.usage_amount);
     setVal(ws, r, 10, unitPriceUsd);
@@ -268,30 +292,21 @@ function fillCharacterSheet(ws, d) {
     ws.getCell(r, 12).alignment = { horizontal: 'right' };
   });
 
-  // ── Others Cost: find dynamically ────────────────────────────────────────────
+  // ── Others Cost: find dynamically (post-expansion) ─────────────────────────
   let othersRow = 60;
-  for (let r = 55; r <= 80; r++) {
+  for (let r = 55; r <= 100; r++) {
     const c = ws.getCell(r, 3).value;
     if (c && /Others Cost/i.test(String(c))) { othersRow = r + 1; break; }
   }
-  const otherProductNames = [...new Set(otherItems.map(d => d.product_name || '').filter(Boolean))];
-  const showOtherProductCol = otherProductNames.length > 1;
-  const sortedOthers = showOtherProductCol
-    ? [...otherItems].sort((a, b) => (a.product_name || '').localeCompare(b.product_name || ''))
-    : otherItems;
-
-  clearRows(ws, othersRow, othersRow + 10, [3, 4, 10, 11, 12]);
-  sortedOthers.slice(0, 11).forEach((item, i) => {
+  const othersEndRow = othersRow + Math.max(OTHERS_SLOTS, sortedOthers.length) - 1;
+  clearRows(ws, othersRow, othersEndRow, [3, 4, 10, 11, 12]);
+  sortedOthers.forEach((item, i) => {
     const r = othersRow + i;
     const oEngName = item.eng_name || '';
     const oCnName = item.fabric_name || '';
-    if (showOtherProductCol) {
-      setVal(ws, r, 3, oEngName && oCnName && oEngName !== oCnName ? `${oEngName}\n${oCnName}` : (oCnName || oEngName));
-      setVal(ws, r, 4, item.product_name || '');
-    } else {
-      setVal(ws, r, 3, oEngName || oCnName);
-      setVal(ws, r, 4, oEngName ? oCnName : '');
-    }
+    setVal(ws, r, 3, oEngName || oCnName);
+    setVal(ws, r, 4, oEngName ? oCnName : '');
+    if (showOtherProductCol) setVal(ws, r, 5, item.product_name || '');
     const rmb = parseFloat(item.material_price_rmb) || 0;
     const unitPriceUsd = item.position === '__embroidery__'
       ? r2(rmb / 0.85 / 7.75)
@@ -313,7 +328,7 @@ function fillCharacterSheet(ws, d) {
   const cartonPkgs = packagingItems.filter(p => p.pkg_section === 'carton');
 
   let retailRow = 86, masterRow = 92;
-  for (let r = 80; r <= 110; r++) {
+  for (let r = 80; r <= 130; r++) {
     const c = ws.getCell(r, 3).value;
     if (c && /^Retail box$/i.test(String(c).trim())) retailRow = r + 1;
     if (c && /^Master carton$/i.test(String(c).trim())) masterRow = r + 1;
@@ -380,7 +395,7 @@ function fillCharacterSheet(ws, d) {
 
   // Fixed labor rate from params: labor_hkd / 11hr / hkd_usd (e.g. 275/11/7.75 = 3.226)
   const laborHkd = parseFloat(params.labor_hkd) || 0;
-  const laborRate = laborHkd ? r2(laborHkd / 11 / hkd_usd) : 3.226;
+  const laborRate = laborHkd ? Math.round(laborHkd / 11 / hkd_usd * 1000) / 1000 : 3.226;
   const sewLabor = findLabor(['车缝', 'sew']);
   const cutLabor = findLabor(['裁床', 'cut']);
   const stuffLabor = findLabor(['手工', 'stuff']);
@@ -399,7 +414,7 @@ function fillCharacterSheet(ws, d) {
       const elecHrs = laborRate ? r2(elecLaborUsd / laborRate) : 0;
       // Find Electronics Assembly row dynamically
       let elecAssyRow = 124;
-      for (let r = 120; r <= 140; r++) {
+      for (let r = 120; r <= 170; r++) {
         const c = ws.getCell(r, 3).value;
         if (c && /Electronics Assembly/i.test(String(c))) { elecAssyRow = r; break; }
       }
@@ -409,13 +424,13 @@ function fillCharacterSheet(ws, d) {
 
   // Find Sewing row dynamically
   let sewingRow = 126;
-  for (let r = 120; r <= 140; r++) {
+  for (let r = 120; r <= 170; r++) {
     const c = ws.getCell(r, 3).value;
     if (c && /^Sewing$/i.test(String(c).trim())) { sewingRow = r; break; }
   }
-  // Standard Hour = price_rmb (HKD) / hkd_usd / laborRate (same as UI)
+  // Standard Hour = price_rmb / rmb_hkd / hkd_usd / laborRate
   function laborHrs(item) {
-    const usdPerToy = (parseFloat(item.price_rmb) || 0) / hkd_usd;
+    const usdPerToy = (parseFloat(item.price_rmb) || 0) / rmb_hkd / hkd_usd;
     return laborRate > 0 ? r2(usdPerToy / laborRate) : 0;
   }
   if (sewLabor)   writeLaborRow(sewingRow, laborRate, laborHrs(sewLabor));
@@ -512,11 +527,12 @@ function fillCharacterSheet(ws, d) {
   const metalItems = (d.hardwareItems || []).filter(
     h => !h.part_category || !['electronic', 'labor_assembly'].includes(h.part_category.toLowerCase())
   );
-  // Metal: clear all data + L col formulas
-  clearRows(ws, 38, 45, [3, 4, 10, 11]);
-  for (let r = 38; r <= 45; r++) { const c = ws.getCell(r, 12); delete c._sharedFormula; c.value = null; }
+  // Metal: clear all data + L col formulas (shifted by fabric expansion)
+  const metalStart = 38 + fabricOverflow;
+  clearRows(ws, metalStart, metalStart + 7, [3, 4, 10, 11]);
+  for (let r = metalStart; r <= metalStart + 7; r++) { const c = ws.getCell(r, 12); delete c._sharedFormula; c.value = null; }
   metalItems.slice(0, 8).forEach((item, i) => {
-    const r = 38 + i;
+    const r = metalStart + i;
     ws.getCell(r, 3).value = item.eng_name || item.name || '';
     ws.getCell(r, 4).value = item.eng_name ? (item.name || '') : '';
     const unitUsd = r2((parseFloat(item.new_price) || 0) / rmb_hkd / hkd_usd * 1.06);
@@ -534,10 +550,11 @@ function fillCharacterSheet(ws, d) {
     mCell.alignment = { horizontal: 'right' };
   });
 
-  // ── Electronic Parts Cost (R48+) ─────────────────────────────────────────────
-  clearRows(ws, 48, 48 + Math.max(ELEC_SLOTS, elecList.length) - 1, [3, 4, 10, 11]);
+  // ── Electronic Parts Cost (post-expansion) ──────────────────────────────────
+  const elecStart = ELEC_START + fabricOverflow;
+  clearRows(ws, elecStart, elecStart + Math.max(ELEC_SLOTS, elecList.length) - 1, [3, 4, 10, 11]);
   elecList.forEach((item, i) => {
-    const r = 48 + i;
+    const r = elecStart + i;
     setVal(ws, r, 3,  item.eng_name || item.part_name || '');
     setVal(ws, r, 4,  item.part_name || item.spec || '');
     const unitUsd = r2(parseFloat(item.unit_price_usd) || 0);
@@ -561,7 +578,7 @@ function fillCharacterSheet(ws, d) {
   const spinTr = d.spinTransport || [];
   // Find actual CHINA FCL row dynamically (in case of row shifts)
   let fclRow = 162;
-  for (let r = 160; r <= 200; r++) {
+  for (let r = 160; r <= 230; r++) {
     const b = ws.getCell(r, 2).value;
     if (b && /CHINA FCL/i.test(String(b))) { fclRow = r; break; }
   }
@@ -609,7 +626,7 @@ function fillCharacterSheet(ws, d) {
 
   // ── Markup: find dynamically ──────────────────────────────────────────────────
   let markupRow = 135;
-  for (let r = 130; r <= 160; r++) {
+  for (let r = 130; r <= 190; r++) {
     const b = ws.getCell(r, 2).value;
     if (b && /Material.*EXCLUDING/i.test(String(b))) { markupRow = r; break; }
   }
@@ -742,7 +759,7 @@ async function exportSpinVersion(versionId) {
     let rowShift = 0;
     if (actualSheets.length > 0) {
       const cs = actualSheets[0];
-      for (let r = 175; r <= 210; r++) {
+      for (let r = 175; r <= 240; r++) {
         const a = cs.getCell(r, 1).value;
         if (a && /Ex-Factory/i.test(String(a))) {
           rowShift = r - 179; // template Ex-Factory is at R179


### PR DESCRIPTION
## Summary
- Others Cost / Fabric Cost 超出模板slot时用 `duplicateRow` 扩展并修正公式偏移
- 中英文分列显示：C列英文、D列中文、E列款式名
- Labor Rate 四舍五入到3位小数 (3.226)
- Labor US$/toy 统一公式: `price_rmb / rmb_hkd / hkd_usd`
- SPIN人工数据统一从车缝明细H列(RMB)提取，移除报价明细覆盖逻辑
- PP胶粒单价改为从材料表PP列 row4 读取 (HKD/g)，修复读错列的bug
- Metal Parts / Electronic 行号偏移修正，动态扫描范围加宽

## Test plan
- [ ] 导出超过11项Others Cost的版本，验证所有行完整显示
- [ ] 导出超过13项Fabric Cost的版本，验证扩展正常
- [ ] 验证Labor Misc值与正确Excel一致（裁床/车缝/手工）
- [ ] 验证PP胶粒单价正确（重新导入后）
- [ ] 验证多款式版本中英文分列显示正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)