### PR TITLE
fix: 修复SPIN包装汇率、电绣分行、单产品sheet命名

### DIFF
--- a/apps/业务部/报价系统/client/index.html
+++ b/apps/业务部/报价系统/client/index.html
@@ -162,8 +162,8 @@
         <div id="importFormatRow" style="margin-bottom:10px">
           <label style="font-size:12px;color:#6a8aaa;display:block;margin-bottom:5px">格式</label>
           <select id="importFormatSelect" style="width:100%;padding:6px 10px;background:#1e2a3a;border:1px solid #2d4a6a;border-radius:6px;color:#c8d6e5;font-size:13px">
-            <option value="injection">注塑</option>
             <option value="plush">毛绒</option>
+            <option value="injection">注塑</option>
           </select>
         </div>
         <div class="import-drop-zone" id="importDropZone">

--- a/apps/业务部/报价系统/client/js/app.js
+++ b/apps/业务部/报价系统/client/js/app.js
@@ -615,11 +615,16 @@ const app = (() => {
       dropZone.style.display = '';
       progress.style.display = 'none';
 
-      // Format: Spin Master → 'spin'; TOMY → 'injection' (plush uses same format)
+      // Format: Spin Master → 'spin' (hidden); TOMY → user picks plush/injection
       const formatRow = document.getElementById('importFormatRow');
       const formatSel = document.getElementById('importFormatSelect');
-      formatSel.value = client === 'Spin Master' ? 'spin' : 'injection';
-      if (formatRow) formatRow.style.display = 'none';
+      if (client === 'Spin Master') {
+        formatSel.value = 'spin';
+        if (formatRow) formatRow.style.display = 'none';
+      } else {
+        formatSel.value = 'plush';
+        if (formatRow) formatRow.style.display = '';
+      }
 
       // File pick
       dropZone.onclick = () => fileInput.click();

--- a/apps/业务部/报价系统/server/routes/import.js
+++ b/apps/业务部/报价系统/server/routes/import.js
@@ -328,41 +328,32 @@ router.post('/', upload.single('file'), async (req, res) => {
           const isLabor = s.position === '__labor__';
           const isEmbroidery = s.position === '__embroidery__';
           const pn = s.product_name || '';
-          // All embroidery rows per product merge into one "电绣" row
+          // Embroidery rows are kept separate by their actual fabric_name (no merging)
           const key = isLabor ? pn + '\x00__labor__\x00' + (s.fabric_name || '')
-            : isEmbroidery ? pn + '\x00__embroidery__'
+            : isEmbroidery ? pn + '\x00__embroidery__\x00' + (s.fabric_name || '')
             : pn + '\x00' + (s.fabric_name || '');
           const existing = mergedSew.find(m => {
             const mpn = m.product_name || '';
             const isML = m.position === '__labor__';
             const isME = m.position === '__embroidery__';
             const mk = isML ? mpn + '\x00__labor__\x00' + (m.fabric_name || '')
-              : isME ? mpn + '\x00__embroidery__'
+              : isME ? mpn + '\x00__embroidery__\x00' + (m.fabric_name || '')
               : mpn + '\x00' + (m.fabric_name || '');
             return mk === key;
           });
           if (existing) {
-            if (isEmbroidery) {
-              // Accumulate total RMB cost into material_price_rmb (usage stays 1)
-              const addCost = (parseFloat(s.usage_amount) || 0) * (parseFloat(s.material_price_rmb) || 0);
-              existing.material_price_rmb = Math.round(((existing.material_price_rmb || 0) + addCost) * 10000) / 10000;
-            } else {
-              existing.usage_amount = Math.round(((existing.usage_amount || 0) + (s.usage_amount || 0)) * 10000) / 10000;
-              existing.price_rmb = Math.round(((existing.price_rmb || 0) + (s.price_rmb || 0)) * 10000) / 10000;
-              existing.total_price_rmb = Math.round(((existing.total_price_rmb || 0) + (s.total_price_rmb || 0)) * 10000) / 10000;
-              if (!isLabor && s.position && s.position !== '__other__') existing.position = '__fabric__';
-            }
+            existing.usage_amount = Math.round(((existing.usage_amount || 0) + (s.usage_amount || 0)) * 10000) / 10000;
+            existing.price_rmb = Math.round(((existing.price_rmb || 0) + (s.price_rmb || 0)) * 10000) / 10000;
+            existing.total_price_rmb = Math.round(((existing.total_price_rmb || 0) + (s.total_price_rmb || 0)) * 10000) / 10000;
+            if (!isLabor && !isEmbroidery && s.position && s.position !== '__other__') existing.position = '__fabric__';
           } else {
             const pos = isLabor ? '__labor__' : isEmbroidery ? '__embroidery__' : (s.position === '__other__' ? '__other__' : (s.position ? '__fabric__' : null));
-            const initCost = isEmbroidery
-              ? (parseFloat(s.usage_amount) || 0) * (parseFloat(s.material_price_rmb) || 0)
-              : (s.material_price_rmb || 0);
             mergedSew.push({
               ...s,
-              fabric_name: isEmbroidery ? '电绣' : (s.fabric_name || ''),
+              fabric_name: s.fabric_name || '',
               position: pos,
-              usage_amount: isEmbroidery ? 1 : (s.usage_amount || 0),
-              material_price_rmb: isEmbroidery ? Math.round(initCost * 10000) / 10000 : (s.material_price_rmb || 0),
+              usage_amount: s.usage_amount || 0,
+              material_price_rmb: s.material_price_rmb || 0,
             });
           }
         }

--- a/apps/业务部/报价系统/server/services/excel-parser.js
+++ b/apps/业务部/报价系统/server/services/excel-parser.js
@@ -187,11 +187,21 @@ function parseHeader(ws, format, workbook) {
 
   // R11-R14: Exchange rates and params
   // Injection: values at C11-C14; Plush: labels at C11-C14, values at D11-D14
-  // Try C first; if null try D (plush layout)
-  const hkd_rmb_quote = numVal(ws.getCell('C11')) || numVal(ws.getCell('D11'));
-  const hkd_rmb_check = numVal(ws.getCell('C12')) || numVal(ws.getCell('D12'));
-  const rmb_hkd = numVal(ws.getCell('C13')) || numVal(ws.getCell('D13'));
-  const hkd_usd = numVal(ws.getCell('C14')) || numVal(ws.getCell('D14'));
+  // SPIN: R11+ are mold parts, no exchange rate cells — skip to avoid false matches
+  // (e.g. D14="11in Pusheen..." → parseFloat returns 11, wrong hkd_usd)
+  // Helper: only accept value if cell is purely numeric (not a string-with-leading-digits)
+  function pureNum(cell) {
+    const raw = cell.value;
+    if (typeof raw === 'number') return raw;
+    if (raw && typeof raw === 'object' && typeof raw.result === 'number') return raw.result;
+    return null;
+  }
+  const hkd_rmb_quote = pureNum(ws.getCell('C11')) || pureNum(ws.getCell('D11'));
+  const hkd_rmb_check = pureNum(ws.getCell('C12')) || pureNum(ws.getCell('D12'));
+  const rmb_hkd = format === 'spin'
+    ? (pureNum(ws.getCell('C9')) || pureNum(ws.getCell('D9')) || 0.85) // SPIN: 汇率 in R9 c3
+    : (pureNum(ws.getCell('C13')) || pureNum(ws.getCell('D13')));
+  const hkd_usd = pureNum(ws.getCell('C14')) || pureNum(ws.getCell('D14')) || (format === 'spin' ? 7.75 : null);
   // Labor: F13 (injection) or G13 (plush); SPIN: scan R9 for "人工" label, value in next col
   let labor_hkd = numVal(ws.getCell('G13')) || numVal(ws.getCell('F13'));
   if (!labor_hkd) {
@@ -573,13 +583,28 @@ function parseCostItems(ws, format) {
   let packagingItems = [];
 
   if (format === 'plush' || format === 'spin') {
+    // Detect 用量/报价 columns by header row (e.g. row containing "用量(pcs)" and "2026年报价")
+    let qtyCol = 3, priceCol = 4;
+    for (let r = 1; r <= Math.min(40, ws.rowCount); r++) {
+      let foundQty = -1, foundPrice = -1;
+      for (let c = 2; c <= 10; c++) {
+        const v = strVal(ws.getCell(r, c)) || '';
+        if (foundQty === -1 && /用量/.test(v)) foundQty = c;
+        if (foundPrice === -1 && /报价|单价/.test(v)) foundPrice = c;
+      }
+      if (foundQty > 0 && foundPrice > 0 && foundPrice > foundQty) {
+        qtyCol = foundQty;
+        priceCol = foundPrice;
+        break;
+      }
+    }
     for (let r = 1; r <= ws.rowCount; r++) {
       const colA = strVal(ws.getCell(r, 1));
       const name = strVal(ws.getCell(r, 2));
       if (!name || colA) continue;
       if (!name.includes('人工') && !name.includes('查货')) continue;
-      const quantity = numVal(ws.getCell(r, 3));
-      const new_price = numVal(ws.getCell(r, 4));
+      const quantity = numVal(ws.getCell(r, qtyCol));
+      const new_price = numVal(ws.getCell(r, priceCol));
       laborItems.push({ name, quantity, old_price: null, new_price, difference: null, tax_type: null });
     }
     hardwareItems = parseItemRange(48, 76);
@@ -1526,6 +1551,8 @@ async function parseWorkbook(filePath, forceFormat) {
   const format = (forceFormat && ['injection', 'plush', 'spin'].includes(forceFormat))
     ? forceFormat
     : detectFormat(workbook);
+  console.log('[PARSE-DEBUG] sheetNames:', workbook.worksheets.map(w => w.name));
+  console.log('[PARSE-DEBUG] forceFormat=%s, detected format=%s', forceFormat, format);
   const header = parseHeader(ws, format, workbook);
 
   // Fall back to sheet name only if B1 is empty
@@ -1596,7 +1623,9 @@ async function parseWorkbook(filePath, forceFormat) {
   const summary = parseSummary(ws);
   const transport = parseTransport(ws);
   const spinTransportRows = format === 'spin' ? parseSpinTransport(ws) : [];
-  const { electronicItems, electronicSummary } = parseElectronics(workbook, ws);
+  const { electronicItems, electronicSummary } = format === 'spin'
+    ? parseElectronics(workbook, ws)
+    : { electronicItems: [], electronicSummary: null };
   const paintingDetail = parsePainting(ws);
 
   return {

--- a/apps/业务部/报价系统/server/services/spin-exporter.js
+++ b/apps/业务部/报价系统/server/services/spin-exporter.js
@@ -776,9 +776,13 @@ async function exportSpinVersion(versionId) {
       wb.removeWorksheet(templateCharSheets[i].id);
     }
   } else {
-    // Single-product: fill first non-Summary sheet, remove the rest
+    // Single-product: fill first non-Summary sheet, rename to product name, remove the rest
     const charWs = templateCharSheets[0];
-    if (charWs) fillCharacterSheet(charWs, d);
+    if (charWs) {
+      const productName = (d.product?.item_desc || d.product?.item_no || 'Product').slice(0, 31);
+      charWs.name = productName;
+      fillCharacterSheet(charWs, d);
+    }
     for (let i = 1; i < templateCharSheets.length; i++) {
       wb.removeWorksheet(templateCharSheets[i].id);
     }


### PR DESCRIPTION
## Summary
- 修复SPIN格式 `hkd_usd` 误读为 11 的bug（D14 \"11in...\" 被 parseFloat 提取出 11，导致 Packaging 单价偏低）
- 电绣不再合并成单一\"电绣\"行，按实际名称（如\"肚子 密绣图案\"、\"面部 嘴巴贴布绣\"）分别保留
- 单产品（无 sub_product）导出时 sheet 名重命名为产品描述，不再保留模板的 \"Rocky\"

## Test plan
- [ ] 重新导入 29422 11in Pusheen Bagel Squisheen，验证 Packaging 单价正确（350G吊牌 0.0499 USD）
- [ ] 验证电绣明细按名称分行显示（不再合并）
- [ ] 验证 29497 8in Bluey Handheld 导出 sheet 名为产品描述

🤖 Generated with [Claude Code](https://claude.com/claude-code)