### PR TITLE
fix(portal): add penyou card + health check to index.cloud.html

### DIFF
--- a/frontend/index.cloud.html
+++ b/frontend/index.cloud.html
@@ -281,6 +281,12 @@
             </div>
             <div class="plugin-item">
               <div class="plugin-info">
+                <div class="plugin-dot gray" id="penyouDot"></div>
+                <span class="plugin-name">喷油部生产管理系统</span>
+              </div>
+            </div>
+            <div class="plugin-item">
+              <div class="plugin-info">
                 <div class="plugin-dot gray" id="productionPlanDot"></div>
                 <span class="plugin-name">生产计划管理系统</span>
               </div>
@@ -447,6 +453,28 @@
       <div class="detail-plugin-right">
         <div class="detail-plugin-status"><div class="plugin-dot gray" id="paijiDetailDot"></div> 检查中...</div>
         <a href="/paiji/" target="_blank" class="btn btn-primary">打开系统</a>
+      </div>
+    </div>
+
+    <div class="detail-plugin-card">
+      <div class="detail-plugin-left">
+        <div class="detail-plugin-icon" style="background:linear-gradient(135deg,#f97316,#c2410c);">&#127912;</div>
+        <div>
+          <div class="detail-plugin-name">喷油部生产管理系统</div>
+          <div class="detail-plugin-desc">喷油部生产管理 — 产品核价、工资标准、排产、每日产量录入、收支表汇总</div>
+          <div class="feature-grid">
+            <div class="feature-tag">&#128202; 产品核价</div>
+            <div class="feature-tag">&#128176; 工资标准</div>
+            <div class="feature-tag">&#128197; 排产</div>
+            <div class="feature-tag">&#128221; 每日录入</div>
+            <div class="feature-tag">&#128200; 收支表</div>
+            <div class="feature-tag">&#128229; PDF/Excel 导入</div>
+          </div>
+        </div>
+      </div>
+      <div class="detail-plugin-right">
+        <div class="detail-plugin-status"><div class="plugin-dot gray" id="penyouDetailDot"></div> 检查中...</div>
+        <a href="/penyou/" target="_blank" class="btn btn-primary">打开系统</a>
       </div>
     </div>
 
@@ -716,6 +744,7 @@ async function checkHealth() {
       { name: 'figureMold', url: '/figure-mold-cost-system/health', dot: 'figureMoldDot', detailDot: 'figureMoldDetailDot' },
       { name: 'jiangping', url: '/jiangping/health', dot: 'jiangpingDot', detailDot: 'jiangpingDetailDot' },
       { name: 'paiji', url: '/paiji/health', dot: 'paijiDot', detailDot: 'paijiDetailDot' },
+      { name: 'penyou', url: '/penyou/api/health', dot: 'penyouDot', detailDot: 'penyouDetailDot' },
       { name: 'productionPlan', url: '/production-plan/health', dot: 'productionPlanDot', detailDot: 'productionPlanDetailDot' },
       { name: 'zuruOrder', url: '/zuru-order-system/health', dot: 'zuruOrderDot', detailDot: 'zuruOrderDetailDot' },
       { name: 'liwenjuan', url: '/liwenjuan/health', dot: 'liwenjuanDot', detailDot: 'liwenjuanDetailDot' },


### PR DESCRIPTION
## Summary

PR #100 missed wiring penyou into the portal landing page. Adds three hooks so the card shows up + status dot turns green.

- 生产部 dept-card: new \`penyouDot\` entry between paiji and production-plan
- New \`detail-plugin-card\` with name / desc / feature tags / open button → \`/penyou/\`
- \`checks[]\` array entry hitting \`/penyou/api/health\` (the actual health endpoint — note \`/api/health\`, not \`/health\`, since penyou's health route is mounted under \`/api/\`)

## Test plan
- [x] HTML structure validates (0 tag mismatches)
- [ ] After deploy: portal home shows 喷油部生产管理系统 card
- [ ] Status dot for penyou turns green within a few seconds (live health check passes)