### PR TITLE
feat(portal): use Royal Regent logo as favicon

### DIFF
--- a/frontend/index.cloud.html
+++ b/frontend/index.cloud.html
@@ -8,6 +8,8 @@
 <meta http-equiv="Expires" content="0">
 <!-- portal v2.1 -->
 <title>Royal Regent 华登 - 企业管理平台</title>
+<link rel="icon" type="image/png" href="/logo.png">
+<link rel="apple-touch-icon" href="/logo.png">
 <style>
   *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
   body {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,8 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Royal Regent 华登 - 企业管理平台</title>
+<link rel="icon" type="image/png" href="/logo.png">
+<link rel="apple-touch-icon" href="/logo.png">
 <style>
   *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
   body {


### PR DESCRIPTION
## Summary
- Adds `<link rel=\"icon\" href=\"/logo.png\">` + `apple-touch-icon` to `frontend/index.cloud.html` and `frontend/index.html`
- Replaces the default browser lightning icon shown in the tab / PWA window title bar with the green Royal Regent logo

## Test plan
- [ ] After deploy, hard-refresh https://portal URL — confirm tab favicon is the RR logo, not ⚡
- [ ] Confirm `curl -sI -u 'rr:leo123456' http://8.148.146.194/logo.png` still returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)