### PR TITLE
fix(baojia): nginx no-cache for static so deploys land in users' browsers

### DIFF
--- a/nginx/nginx.cloud.conf
+++ b/nginx/nginx.cloud.conf
@@ -536,6 +536,8 @@ http {
         }
         # 静态资源绕开 rate limiter：SPA 冷加载的 JS + CSS 数量超过 burst=20
         # 此 regex location 优先级高于上面的 prefix location，auth_basic 仍从 server 继承
+        # 不长期缓存：index.html 的 <script src="js/app.js"> 没有版本号，
+        # 部署后必须能拿到最新 JS。ETag/Last-Modified 仍提供 304 fast path。
         location ~* ^/baojia/.+\.(js|css|png|jpg|jpeg|gif|svg|ico|woff|woff2|ttf|eot|map)$ {
             set $ups "baojia:3007";
             rewrite ^/baojia/(.*)$ /$1 break;
@@ -546,7 +548,7 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_http_version 1.1;
             proxy_set_header Connection "";
-            expires 1h;
+            add_header Cache-Control "no-cache, must-revalidate" always;
         }
 
         # ─── Standalone: TOMY排期核对系统 (tomy-paiqi) ───


### PR DESCRIPTION
## Summary
- nginx for `/baojia/*.{js,css,...}` swaps `expires 1h` → `Cache-Control: no-cache, must-revalidate`.
- ETag/Last-Modified still give 304 fast-path; only changed files re-download.

## Why
PR #108 (报价系统 SPIN/VQ 改进) merged 21h ago. Code on ECS is correct (sha256 of served JS = source). But users reported "改动没效果" — browser caching ~25 unversioned `<script>` tags for 1h, and open tabs never refetched at all.

## Test plan
- [ ] CI green
- [ ] Post-deploy: `curl -sIu 'rr:leo123456' http://8.148.146.194/baojia/js/app.js | grep -i cache-control` shows `no-cache, must-revalidate`
- [ ] User hard-refreshes (Cmd+Shift+R) → PR #108 features visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)