### PR TITLE
fix(nginx): production-plan CSP allow at.alicdn.com (Luckysheet iconfont)

### DIFF
--- a/nginx/nginx.cloud.conf
+++ b/nginx/nginx.cloud.conf
@@ -436,8 +436,8 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_http_version 1.1;
             proxy_set_header Connection "";
-            # Luckysheet 从 jsdelivr CDN 加载 JS + CSS + iconfont
-            add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; font-src 'self' data: https://cdn.jsdelivr.net; connect-src 'self'; frame-ancestors 'self';" always;
+            # Luckysheet 从 jsdelivr CDN 加载 JS + CSS；iconfont 从 at.alicdn.com 加载 CSS + woff/ttf
+            add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://at.alicdn.com; img-src 'self' data: blob:; font-src 'self' data: https://cdn.jsdelivr.net https://at.alicdn.com; connect-src 'self'; frame-ancestors 'self';" always;
             add_header X-Frame-Options "SAMEORIGIN" always;
             add_header X-Content-Type-Options "nosniff" always;
             add_header X-XSS-Protection "1; mode=block" always;


### PR DESCRIPTION
## Summary
- nginx production-plan CSP block (line 440): add `https://at.alicdn.com` to `style-src` (iconfont.cn CSS) and `font-src` (woff/ttf).
- Luckysheet toolbar iconfont was being blocked → toolbar icons rendered as boxes.

## Supersedes #114
PR #114 was a stale-base disaster: title said "CSP at.alicdn.com" but the diff contained zero `alicdn` references, plus a merge commit with unresolved conflicts that would have reverted PRs #100/104/106/108/110/111/112/113. Closing #114; this PR delivers the actual 1-line intent on a fresh branch off `main`.

## Test plan
- [ ] CI green
- [ ] Post-deploy: `curl -sIu 'rr:leo123456' http://8.148.146.194/production-plan/ | grep -i content-security` shows `at.alicdn.com` in both style-src and font-src
- [ ] User loads `/production-plan/` and Luckysheet toolbar icons render correctly (no console CSP errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)