### PR TITLE
fix(baojia): translate-all swap Baidu (no creds) back to Bailian/Qwen

### DIFF
--- a/apps/业务部/报价系统/server/routes/versions.js
+++ b/apps/业务部/报价系统/server/routes/versions.js
@@ -497,18 +497,35 @@ router.post('/:id/translate-all', async (req, res) => {
     if (!version) return res.status(404).json({ error: 'Version not found' });
     const vid = req.params.id;
 
-    // 百度翻译 API
+    // 用阿里云百炼（Bailian）OpenAI 兼容端点 + Qwen 文本模型做翻译。
+    // API key 由 docker-compose 注入（BAOJIA_BAILIAN_API_KEY → 容器内 BAILIAN_API_KEY），
+    // 与 paiji / peise 共用同一把 key 的 per-app 前缀惯例。
+    // 注: PR #97 / #108 两次 sync 把这块退回成百度 API,但 ECS 从未配过 BAIDU 凭据,导致翻译静默失败。
     async function translate(text) {
-      const appid = process.env.BAIDU_APPID;
-      const key = process.env.BAIDU_KEY;
-      if (!appid || !key) throw new Error('BAIDU_APPID/BAIDU_KEY 未配置');
-      const salt = Date.now().toString();
-      const sign = crypto.createHash('md5').update(appid + text + salt + key).digest('hex');
-      const url = `https://fanyi-api.baidu.com/api/trans/vip/translate?q=${encodeURIComponent(text)}&from=zh&to=en&appid=${appid}&salt=${salt}&sign=${sign}`;
-      const resp = await fetch(url);
+      const apiKey = process.env.BAILIAN_API_KEY;
+      if (!apiKey) throw new Error('BAILIAN_API_KEY 未配置');
+      const baseUrl = (process.env.BAILIAN_BASE_URL || 'https://dashscope.aliyuncs.com/compatible-mode/v1').replace(/\/$/, '');
+      const model = process.env.BAILIAN_TEXT_MODEL || 'qwen-turbo';
+      const resp = await fetch(`${baseUrl}/chat/completions`, {
+        method: 'POST',
+        headers: { 'Authorization': `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model,
+          messages: [
+            { role: 'system', content: '你是玩具/模具/包装制造业术语专业翻译。把中文短语译成简洁的英文物料名。只输出翻译结果，不要加引号、解释、前缀。' },
+            { role: 'user', content: text },
+          ],
+          temperature: 0,
+        }),
+      });
+      if (!resp.ok) {
+        const body = await resp.text().catch(() => '');
+        throw new Error(`Bailian ${resp.status}: ${body.slice(0, 200)}`);
+      }
       const data = await resp.json();
-      if (data.trans_result && data.trans_result[0]) return data.trans_result[0].dst;
-      throw new Error(data.error_msg || 'Translation failed');
+      const out = data?.choices?.[0]?.message?.content?.trim();
+      if (!out) throw new Error('Bailian returned empty translation');
+      return out;
     }
 
     const EMPTY = "(eng_name IS NULL OR eng_name = '')";


### PR DESCRIPTION
## Summary
- `apps/业务部/报价系统/server/routes/versions.js` translate function: Baidu API → Bailian (Qwen) chat completions.
- ECS never had `BAIDU_APPID` / `BAIDU_KEY`; container env verified `BAILIAN_API_KEY` is set (35-char).
- Restores commit `bd8652b` (2026-05-04) implementation. Verbatim port.

## Root cause
PR #108 silently regressed translation back to Baidu (second time after #97 → bd8652b). Combined with `versions.js` line 568's silent `catch (_)` swallowing every API failure, the symptom was "translate button returns success with 0 rows translated" — looks fine, does nothing.

## Test plan
- [ ] CI green
- [ ] Post-deploy: container env still has `BAILIAN_API_KEY` (length 35)
- [ ] User clicks `自动翻译英文` on a quote → real English names land in `eng_name` column, no "已翻译 0 条" false-success

🤖 Generated with [Claude Code](https://claude.com/claude-code)