### PR TITLE
fix(production-plan): CSP worker-src + autoheal 误杀 + parser yield

### DIFF
--- a/apps/生产部/生产计划管理系统/server/services/color-reader.js
+++ b/apps/生产部/生产计划管理系统/server/services/color-reader.js
@@ -143,13 +143,18 @@ function colLetterToIndex(letters) {
 /**
  * 从 sheet XML 中提取行数据和颜色
  * 只解析有颜色的行 + 第一行(表头)
+ * async — 每 500 行 yield 一次 event loop，让 /health 等请求能跑（防 autoheal 误杀）
  */
-function parseSheetData(sheetXml, styleColorMap, sharedStrings) {
+async function parseSheetData(sheetXml, styleColorMap, sharedStrings) {
   const rows = sheetXml.match(/<row[^>]*>[\s\S]*?<\/row>/g) || [];
   const headerCandidates = []; // { rowNum, cellData, score }
   const coloredRows = []; // { rowNum, color, cells: {colIndex: value} }
 
-  for (const row of rows) {
+  for (let rowIdx = 0; rowIdx < rows.length; rowIdx++) {
+    if (rowIdx > 0 && rowIdx % 500 === 0) {
+      await new Promise(resolve => setImmediate(resolve));
+    }
+    const row = rows[rowIdx];
     const rowNumMatch = row.match(/r="(\d+)"/);
     if (!rowNumMatch) continue;
     const rowNum = parseInt(rowNumMatch[1]);
@@ -342,7 +347,7 @@ async function parseExcelWithColors(fileBuffer, fileName) {
     const sheetXml = await sheetFile.async('string');
     // 每个 sheet 之前让出 event loop，避免多 sheet 大文件把主线程卡住
     if (sheetIdx > 0) await new Promise(resolve => setImmediate(resolve));
-    const { headerData, coloredRows } = parseSheetData(sheetXml, styleColorMap, sharedStrings);
+    const { headerData, coloredRows } = await parseSheetData(sheetXml, styleColorMap, sharedStrings);
 
     if (coloredRows.length === 0) continue;
 

--- a/docker-compose.cloud.yml
+++ b/docker-compose.cloud.yml
@@ -291,7 +291,9 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
       interval: 10s
       timeout: 5s
-      retries: 3
+      # Excel 上传/解析最长 ~60s 会阻塞 event loop（即使有 yield，单 sheet 内 regex 仍较重）
+      # retries=10 ≈ 100s 容忍窗口，避免 autoheal 杀掉正在上传的容器
+      retries: 10
     mem_limit: 768m
     memswap_limit: 768m
     restart: unless-stopped

--- a/nginx/nginx.cloud.conf
+++ b/nginx/nginx.cloud.conf
@@ -436,8 +436,9 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_http_version 1.1;
             proxy_set_header Connection "";
-            # Luckysheet 从 jsdelivr CDN 加载 JS + CSS；iconfont 从 at.alicdn.com 加载 CSS + woff/ttf
-            add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://at.alicdn.com; img-src 'self' data: blob:; font-src 'self' data: https://cdn.jsdelivr.net https://at.alicdn.com; connect-src 'self'; frame-ancestors 'self';" always;
+            # Luckysheet 从 jsdelivr CDN 加载 JS + CSS；iconfont 从 at.alicdn.com 加载 CSS + woff/ttf + PNG
+            # worker-src: Luckysheet 用 `new Worker("data:text/javascript,...")` 创建 inline worker
+            add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net; worker-src 'self' blob: data:; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://at.alicdn.com; img-src 'self' data: blob: https://at.alicdn.com; font-src 'self' data: https://cdn.jsdelivr.net https://at.alicdn.com; connect-src 'self'; frame-ancestors 'self';" always;
             add_header X-Frame-Options "SAMEORIGIN" always;
             add_header X-Content-Type-Options "nosniff" always;
             add_header X-XSS-Protection "1; mode=block" always;


### PR DESCRIPTION
## 问题

部署后用户反馈 production-plan 上传 Excel 时 console 一堆错（截图），实际表现：
- 工具栏部分图标显示不出（image CSP 拒绝）
- Luckysheet 报错 `sheetmanage.js:1055 Cannot read properties of undefined (reading 'config')`
- 上传时偶发 502 Bad Gateway

## 根因（三个独立 bug）

### 1. CSP 缺 worker-src
Luckysheet umd.js 用 \`new Worker(\"data:text/javascript;chartset=US-ASCII,onmessage=...\")\` 启动 inline worker。当前 CSP 没设 worker-src，浏览器回落到 script-src，但 script-src 不含 \`data:\` → Worker 创建被拒 → 后续依赖 worker 的 config 对象 undefined → sheetmanage.js 崩。

### 2. CSP img-src 缺 at.alicdn.com
PR #115 已把 at.alicdn.com 加到 font-src/style-src（iconfont 字体），但 iconfont CSS 内部还引用 at.alicdn.com 的 PNG 作为 background-image，需要 img-src 也放行。

### 3. autoheal 误杀正在上传的容器
\`parseSheetData\` 同步 regex 迭代所有行，单 sheet >5000 行可阻塞 event loop 30+ 秒。生产环境 healthcheck \`retries=3 × interval=10s\` 仅容忍 ~45s。日志确认上传成功后容器被 autoheal 重启过：

\`\`\`
2026-05-13T02:52:03Z POST /api/upload 200 48676ms 229423B  ← 48 秒
...（之后日志）
数据库初始化完成
生产计划管理系统运行在端口 8080  ← autoheal 重启了
\`\`\`

PR #112 加了 setImmediate yield，但只在 file/sheet 之间 yield，单 sheet 内仍是同步 regex 阻塞。

## 修复

1. \`nginx/nginx.cloud.conf\` — \`/production-plan/\` CSP 加 \`worker-src 'self' blob: data:\` + img-src 加 \`https://at.alicdn.com\`
2. \`docker-compose.cloud.yml\` — production-plan healthcheck retries 3 → 10（容忍 ~100s）
3. \`apps/生产部/生产计划管理系统/server/services/color-reader.js\` — \`parseSheetData\` 改 async，每 500 行 yield setImmediate

## 验证计划

- [ ] curl 部署后的 \`Content-Security-Policy\` 头，确认含 \`worker-src 'self' blob: data:\` 和 \`img-src ... https://at.alicdn.com\`
- [ ] 浏览器打开 \`/production-plan/\`，hard refresh，检查 console 无 worker / image CSP 错
- [ ] 上传一个大 Excel，期间 \`docker inspect rr-portal-production-plan-1 --format '{{.State.Health.Status}}'\` 持续显示 healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)