### PR TITLE
fix(production-plan): CSP img-src 允许 cdn.jsdelivr.net (loading.gif)

### DIFF
--- a/nginx/nginx.cloud.conf
+++ b/nginx/nginx.cloud.conf
@@ -436,9 +436,9 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_http_version 1.1;
             proxy_set_header Connection "";
-            # Luckysheet 从 jsdelivr CDN 加载 JS + CSS；iconfont 从 at.alicdn.com 加载 CSS + woff/ttf + PNG
+            # Luckysheet 从 jsdelivr CDN 加载 JS + CSS + loading.gif；iconfont 从 at.alicdn.com 加载 CSS + woff/ttf + PNG
             # worker-src: Luckysheet 用 `new Worker("data:text/javascript,...")` 创建 inline worker
-            add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net; worker-src 'self' blob: data:; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://at.alicdn.com; img-src 'self' data: blob: https://at.alicdn.com; font-src 'self' data: https://cdn.jsdelivr.net https://at.alicdn.com; connect-src 'self'; frame-ancestors 'self';" always;
+            add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net; worker-src 'self' blob: data:; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://at.alicdn.com; img-src 'self' data: blob: https://cdn.jsdelivr.net https://at.alicdn.com; font-src 'self' data: https://cdn.jsdelivr.net https://at.alicdn.com; connect-src 'self'; frame-ancestors 'self';" always;
             add_header X-Frame-Options "SAMEORIGIN" always;
             add_header X-Content-Type-Options "nosniff" always;
             add_header X-XSS-Protection "1; mode=block" always;


### PR DESCRIPTION
Smoke test 发现 Luckysheet 还从 jsdelivr 加载 `loading.gif`（spinner），img-src 没放行 → console 报一条 CSP 错。功能不受影响但 console 不干净。

把 `https://cdn.jsdelivr.net` 加到 img-src（font-src/style-src 已经有，对称一下）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)