### PR TITLE
feat(penyou): AI 图片识别导入 + 订单平铺拖拽排单 + Excel 导出 + PDF alias (supersedes #123)

### DIFF
--- a/apps/生产部/喷油部生产管理系统/client/package-lock.json
+++ b/apps/生产部/喷油部生产管理系统/client/package-lock.json
@@ -8,6 +8,9 @@
       "name": "client",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "antd": "^6.3.5",
         "axios": "^1.15.0",
         "dayjs": "^1.11.20",
@@ -367,6 +370,59 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -3699,9 +3755,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/apps/生产部/喷油部生产管理系统/client/package.json
+++ b/apps/生产部/喷油部生产管理系统/client/package.json
@@ -10,6 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "antd": "^6.3.5",
     "axios": "^1.15.0",
     "dayjs": "^1.11.20",

--- a/apps/生产部/喷油部生产管理系统/client/src/pages/DailyRecords.jsx
+++ b/apps/生产部/喷油部生产管理系统/client/src/pages/DailyRecords.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useRef, useCallback } from 'react';
 import { DatePicker, Select, InputNumber, Input, Button, Space, Card, Table, Popconfirm, message, Tabs, Modal } from 'antd';
-import { PlayCircleOutlined, CheckCircleOutlined, RedoOutlined, HistoryOutlined } from '@ant-design/icons';
+import { PlayCircleOutlined, CheckCircleOutlined, RedoOutlined, HistoryOutlined, DownloadOutlined } from '@ant-design/icons';
 import dayjs from 'dayjs';
 import api from '../api';
 
@@ -317,6 +317,25 @@ export default function DailyRecords() {
     load();
   };
 
+  const onExport = async () => {
+    try {
+      const resp = await api.get('/daily-records/export', {
+        params: { date: dateStr },
+        responseType: 'blob',
+      });
+      const url = URL.createObjectURL(new Blob([resp.data]));
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `daily_${dateStr}.xlsx`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      message.error('导出失败: ' + (e?.message || e));
+    }
+  };
+
   const openHistory = async (sl) => {
     const params = { product_process_id: sl.product_process_id };
     if (sl.line_id) params.line_id = sl.line_id;
@@ -348,6 +367,7 @@ export default function DailyRecords() {
           <Input.Search placeholder="搜索货号 / 货名" allowClear
             value={q} onChange={e => setQ(e.target.value)}
             style={{ width: 240 }} />
+          <Button icon={<DownloadOutlined />} onClick={onExport}>导出 Excel</Button>
         </Space>
         <Card size="small" styles={{ body: { padding: 8 } }}>
           今日排产 <b>{active.length}</b> 条 · 已录 <b>{recordCount}</b> 条 |

--- a/apps/生产部/喷油部生产管理系统/client/src/pages/Orders.jsx
+++ b/apps/生产部/喷油部生产管理系统/client/src/pages/Orders.jsx
@@ -1,12 +1,20 @@
-import { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import {
   Tabs, Form, Input, InputNumber, DatePicker, Button, Select, Table,
-  Space, Tag, message, Popconfirm, Card, Upload, Modal, Alert, InputNumber as AntInputNumber,
+  Space, Tag, message, Popconfirm, Upload, Modal, Alert, InputNumber as AntInputNumber,
 } from 'antd';
 import {
-  PlayCircleOutlined, CheckCircleOutlined, RedoOutlined, DeleteOutlined, FilePdfOutlined,
+  PlayCircleOutlined, CheckCircleOutlined, RedoOutlined, DeleteOutlined, FilePdfOutlined, HolderOutlined,
 } from '@ant-design/icons';
 import dayjs from 'dayjs';
+import { useNavigate } from 'react-router-dom';
+import {
+  DndContext, PointerSensor, useSensor, useSensors, closestCenter,
+} from '@dnd-kit/core';
+import {
+  SortableContext, useSortable, verticalListSortingStrategy, arrayMove,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import api from '../api';
 
 function fmtTime(s) {
@@ -22,6 +30,36 @@ function normalizeTechnique(t) {
   if (s.includes('散枪')) return '散枪';
   if (s.includes('洗')) return '洗货';
   return s;
+}
+
+// dnd-kit 用的可拖拽 antd Table 行;data-row-key 由 antd 自动塞进 props
+function SortableRow(props) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id: props['data-row-key'] });
+  const style = {
+    ...props.style,
+    transform: CSS.Transform.toString(transform && { ...transform, scaleY: 1 }),
+    transition,
+    ...(isDragging ? { position: 'relative', zIndex: 9, background: '#e6f4ff' } : {}),
+  };
+  // listeners/attributes 通过 context 给 DragHandle 用
+  return (
+    <SortableRowContext.Provider value={{ attributes, listeners }}>
+      <tr {...props} ref={setNodeRef} style={style} />
+    </SortableRowContext.Provider>
+  );
+}
+
+const SortableRowContext = React.createContext({ attributes: {}, listeners: {} });
+
+function DragHandle() {
+  const { attributes, listeners } = React.useContext(SortableRowContext);
+  return (
+    <HolderOutlined
+      {...attributes} {...listeners}
+      style={{ cursor: 'grab', color: '#999', fontSize: 14, padding: 4 }}
+    />
+  );
 }
 
 function NumCell({ value, min = 1, onSave }) {
@@ -42,11 +80,11 @@ function NumCell({ value, min = 1, onSave }) {
 }
 
 export default function Orders() {
-  const [activeTab, setActiveTab] = useState('list');
+  const navigate = useNavigate();
+  const [activeTab, setActiveTab] = useState('flat');
   const [productOptions, setProductOptions] = useState([]);
   const [lines, setLines] = useState([]);
-  const [list, setList] = useState([]);
-  const [detailMap, setDetailMap] = useState({}); // orderId -> schedule_lines
+  const [flat, setFlat] = useState([]); // 平铺的 schedule_lines
   const [month, setMonth] = useState(dayjs());
   const [q, setQ] = useState('');
   const [form] = Form.useForm();
@@ -60,10 +98,10 @@ export default function Orders() {
   const monthStr = month ? month.format('YYYY-MM') : '';
 
   const loadList = useCallback(async () => {
-    const { data } = await api.get('/orders', {
+    const { data } = await api.get('/orders/schedule-lines/flat', {
       params: { month: monthStr || undefined, q: q || undefined },
     });
-    setList(data);
+    setFlat(data);
   }, [monthStr, q]);
 
   useEffect(() => { loadList(); }, [loadList]);
@@ -75,11 +113,6 @@ export default function Orders() {
       label: `${p.code} - ${p.name}`,
       quote_price: p.quote_price,
     })));
-  };
-
-  const loadDetail = async (orderId) => {
-    const { data } = await api.get(`/orders/${orderId}`);
-    setDetailMap(prev => ({ ...prev, [orderId]: data.schedule_lines }));
   };
 
   const onCreate = async () => {
@@ -111,37 +144,45 @@ export default function Orders() {
 
   const onUpdateSL = async (oid, slId, patch) => {
     await api.put(`/orders/${oid}/schedule-lines/${slId}`, patch);
-    loadDetail(oid);
     loadList();
   };
 
   const onClock = async (oid, slId, action) => {
     await api.post(`/orders/${oid}/schedule-lines/${slId}/${action}`);
-    loadDetail(oid);
     loadList();
   };
 
-  // PDF 导入预览
+  const onReorder = async (ids) => {
+    await api.put('/orders/schedule-lines/reorder', { ids });
+    // 乐观更新已经在前端先做了,这里不需要再 loadList(避免抖动)
+  };
+
+  // PDF / 图片 导入预览(根据文件类型分流,后端不同路由,前端预览 Modal 共用)
   const onPdfUpload = async (file) => {
+    const isImage = (file.type && file.type.startsWith('image/')) ||
+      /\.(jpg|jpeg|png|webp|bmp|gif)$/i.test(file.name || '');
+    const endpoint = isImage ? '/orders/import-image' : '/orders/import-pdf';
+    const errLabel = isImage ? '图片识别' : 'PDF 解析';
     setPdfLoading(true);
     setPdfPreview(null);
     setPdfModalOpen(true);
     try {
       const fd = new FormData();
       fd.append('file', file);
-      const { data } = await api.post('/orders/import-pdf', fd, {
+      const { data } = await api.post(endpoint, fd, {
         headers: { 'Content-Type': 'multipart/form-data' },
       });
-      // 给每个 PDF item 默认勾选所有 matched_processes(用户可改 qty 或取消)
       const items = (data.items || []).map(it => ({
         ...it,
-        // 选中的工序 ids:默认全选
         selected_process_ids: (it.matched_processes || []).map(p => p.id),
         edit_qty: it.pdf_qty,
       }));
-      setPdfPreview({ ...data, items });
+      const initDate = data.header?.order_date
+        ? dayjs(data.header.order_date)
+        : dayjs();
+      setPdfPreview({ ...data, items, start_date: initDate, source: isImage ? 'image' : 'pdf' });
     } catch (e) {
-      message.error('PDF 解析失败: ' + (e.response?.data?.error || e.message));
+      message.error(`${errLabel}失败: ` + (e.response?.data?.error || e.message));
       setPdfModalOpen(false);
     } finally {
       setPdfLoading(false);
@@ -151,11 +192,44 @@ export default function Orders() {
 
   const onPdfConfirm = async () => {
     if (!pdfPreview || !pdfPreview.matched) return;
-    // 把每行的 PDF 部位 × 选中工序 都展开成 (product_process_id, qty)
+    // 三条路径:
+    //  1) 自动 / alias 命中的 matched_processes — 直接用 selected_process_ids,不重复学
+    //  2) 没命中但用户从「全工序下拉」勾了 — picked_process_ids,learn_alias=true 写映射
+    //  3) 没命中且填了 工艺+工价 — new_process 新建到核价表,learn_alias=true 把 PDF 名→新工序也记下
     const items = [];
+    let newProcCount = 0;
+    let learnCount = 0;
     for (const it of pdfPreview.items) {
-      for (const ppid of (it.selected_process_ids || [])) {
-        items.push({ product_process_id: ppid, qty: Number(it.edit_qty) || 0 });
+      const qty = Number(it.edit_qty) || 0;
+      const pdf_part_name = it.pdf_part_name;
+      if (it.matched_processes && it.matched_processes.length) {
+        for (const ppid of (it.selected_process_ids || [])) {
+          items.push({ product_process_id: ppid, qty });
+        }
+        continue;
+      }
+      // 未匹配 — 看手动挑的
+      const picked = it.picked_process_ids || [];
+      for (const ppid of picked) {
+        items.push({ product_process_id: ppid, qty, pdf_part_name, learn_alias: true });
+        learnCount++;
+      }
+      // 未匹配 — 看新建表单
+      const np = it.new_process;
+      if (np && np.part_name && np.technique && np.unit_wage != null && np.unit_wage !== '') {
+        items.push({
+          new_process: {
+            part_name: String(np.part_name).trim(),
+            technique: String(np.technique).trim(),
+            unit_wage: Number(np.unit_wage) || 0,
+            target_qty: Number(np.target_qty) || 0,
+          },
+          qty,
+          pdf_part_name,
+          learn_alias: true,
+        });
+        newProcCount++;
+        learnCount++;
       }
     }
     if (!items.length) {
@@ -163,14 +237,20 @@ export default function Orders() {
       return;
     }
     try {
+      const startDate = pdfPreview.start_date
+        ? pdfPreview.start_date.format('YYYY-MM-DD')
+        : (pdfPreview.header.order_date || dayjs().format('YYYY-MM-DD'));
       const payload = {
         product_id: pdfPreview.product.id,
         order_name: pdfPreview.header.order_no || `PDF-${dayjs().format('YYYYMMDDHHmm')}`,
-        start_date: pdfPreview.header.order_date || dayjs().format('YYYY-MM-DD'),
+        start_date: startDate,
         items,
       };
-      await api.post('/orders/import-pdf/confirm', payload);
-      message.success(`已创建订单,${items.length} 条工序`);
+      const { data } = await api.post('/orders/import-pdf/confirm', payload);
+      const parts = [`${items.length} 条工序`];
+      if (newProcCount) parts.push(`新建核价表 ${newProcCount} 条`);
+      if (data.learned_aliases) parts.push(`记住映射 ${data.learned_aliases} 条`);
+      message.success(`已创建订单,${parts.join(',')}`);
       setPdfModalOpen(false);
       setPdfPreview(null);
       // 自动把月份切到订单起始日所在月,免得列表看不到
@@ -185,10 +265,31 @@ export default function Orders() {
 
   const lineOptions = lines.map(l => ({ value: l.id, label: l.name }));
 
-  const monthlyOutput = list.reduce(
-    (s, o) => s + Number(o.total_qty || 0) * Number(o.quote_price || 0),
-    0,
-  );
+  // 按订单去重算产值,避免一单多工序被乘很多次
+  const monthlyOutput = useMemo(() => {
+    const byOrder = new Map();
+    for (const r of flat) {
+      if (!byOrder.has(r.order_id)) byOrder.set(r.order_id, { qty: r.qty, price: r.quote_price });
+      else {
+        const cur = byOrder.get(r.order_id);
+        if (Number(r.qty) > Number(cur.qty)) cur.qty = r.qty;
+      }
+    }
+    let sum = 0;
+    for (const v of byOrder.values()) sum += Number(v.qty || 0) * Number(v.price || 0);
+    return sum;
+  }, [flat]);
+
+  const flatStats = useMemo(() => {
+    let pending = 0, started = 0, done = 0, noLine = 0;
+    for (const r of flat) {
+      if (r.completed_at) done++;
+      else if (r.started_at) started++;
+      else pending++;
+      if (!r.line_id) noLine++;
+    }
+    return { total: flat.length, pending, started, done, noLine };
+  }, [flat]);
 
   const renderCreateForm = () => (
     <Form form={form} layout="vertical" style={{ maxWidth: 600 }}
@@ -225,228 +326,162 @@ export default function Orders() {
     </Form>
   );
 
-  const expandedRowRender = (order) => {
-    const slList = detailMap[order.id] || [];
-    const columns = [
-      { title: '部位', dataIndex: 'part_name', width: 110 },
-      {
-        title: '件数', dataIndex: 'qty', width: 100, align: 'right',
-        render: (v, row) => (
-          <NumCell value={v} min={0}
-            onSave={nv => onUpdateSL(order.id, row.id, { qty: nv })} />
-        ),
-      },
-      {
-        title: '累计数', dataIndex: 'produced_total', width: 90, align: 'right',
-        render: v => <span style={{ color: '#1677ff' }}>{Number(v || 0)}</span>,
-      },
-      {
-        title: '欠数', width: 90, align: 'right',
-        render: (_, row) => {
-          const owed = Number(row.qty || 0) - Number(row.produced_total || 0);
-          if (owed <= 0) return <span style={{ color: '#52c41a' }}>已完</span>;
-          return <span style={{ color: '#cf1322' }}>{owed}</span>;
-        },
-      },
-      {
-        title: '日产能', dataIndex: 'daily_capacity', width: 100, align: 'right',
-        render: (v, row) => (
-          <NumCell value={v}
-            onSave={nv => onUpdateSL(order.id, row.id, { daily_capacity: nv })} />
-        ),
-      },
-      {
-        title: '实际产能', dataIndex: 'actual_capacity', width: 100, align: 'right',
-        render: (v, row) => (
-          <NumCell value={v ?? row.daily_capacity}
-            onSave={nv => onUpdateSL(order.id, row.id, { actual_capacity: nv })} />
-        ),
-      },
-      { title: '预计天数', dataIndex: 'est_days', width: 80, align: 'right' },
-      {
-        title: '起-止日', width: 180,
-        render: (_, row) => <span>{row.start_date} ~ {row.end_date}</span>,
-      },
-      {
-        title: '分到拉', width: 140,
-        render: (_, row) => (
-          <Select
-            size="small"
-            style={{ width: 120 }}
-            placeholder={row.technique === '喷油' ? '喷油(手选)' : '选拉'}
-            value={row.line_id || undefined}
-            onChange={(v) => onUpdateSL(order.id, row.id, { line_id: v || null })}
-            options={lineOptions}
-            allowClear
-          />
-        ),
-      },
-      {
-        title: '生产时间', width: 100,
-        render: (_, row) => row.started_at
-          ? <span style={{ color: '#1677ff' }}>{fmtTime(row.started_at)}</span>
-          : <span style={{ color: '#ccc' }}>—</span>,
-      },
-      {
-        title: '完成时间', width: 100,
-        render: (_, row) => row.completed_at
-          ? <span style={{ color: '#52c41a' }}>{fmtTime(row.completed_at)}</span>
-          : <span style={{ color: '#ccc' }}>—</span>,
-      },
-      {
-        title: '操作', width: 220,
-        render: (_, row) => (
-          <Space size={4}>
-            <Button size="small" type="primary" icon={<PlayCircleOutlined />}
-              disabled={!!row.started_at}
-              onClick={() => onClock(order.id, row.id, 'start')}>开始</Button>
-            <Button size="small" icon={<CheckCircleOutlined />}
-              disabled={!row.started_at || !!row.completed_at}
-              onClick={() => onClock(order.id, row.id, 'complete')}>完成</Button>
-            {(row.started_at || row.completed_at) && (
-              <Popconfirm title="重置开始/完成时间?"
-                onConfirm={() => onClock(order.id, row.id, 'reset')}>
-                <Button size="small" icon={<RedoOutlined />} />
-              </Popconfirm>
-            )}
-          </Space>
-        ),
-      },
-    ];
-
-    // 按工艺分组(喷油 / 移印 / UV / ...) — 用 normalize 把杂乱字段归一
-    const groups = {};
-    for (const sl of slList) {
-      const t = normalizeTechnique(sl.technique);
-      if (!groups[t]) groups[t] = [];
-      groups[t].push(sl);
-    }
-    const techniqueOrder = Object.keys(groups).sort();
-    const groupColors = { '喷油': '#fa8c16', '移印': '#1677ff', 'UV': '#722ed1', '散枪': '#13c2c2', '洗货': '#a0d911' };
-
-    return (
-      <div>
-        {techniqueOrder.map(technique => {
-          const lines = groups[technique];
-          const done = lines.filter(l => l.completed_at).length;
-          return (
-            <div key={technique} style={{ marginBottom: 12 }}>
-              <div style={{
-                background: groupColors[technique] || '#595959',
-                color: '#fff',
-                padding: '6px 14px',
-                borderRadius: '4px 4px 0 0',
-                fontWeight: 600,
-                fontSize: 14,
-              }}>
-                {technique} <span style={{ opacity: 0.85, fontSize: 12, marginLeft: 8 }}>
-                  共 {lines.length} 道工序 · 已完成 {done}/{lines.length}
-                </span>
-              </div>
-              <Table
-                rowKey="id"
-                size="small"
-                dataSource={lines}
-                columns={columns}
-                pagination={false}
-                scroll={{ x: 'max-content' }}
-                style={{ borderTop: 0 }}
-              />
-            </div>
-          );
-        })}
-      </div>
-    );
-  };
-
-  const listColumns = [
-    { title: '订单名', dataIndex: 'order_name', width: 160 },
+  const flatColumns = [
     {
-      title: '货号 - 货名', width: 260,
-      render: (_, row) => `${row.product_code} - ${row.product_name}`,
+      title: '', key: 'drag', width: 32,
+      render: (_, row) => <DragHandle id={row.id} />,
     },
-    { title: '数量', dataIndex: 'total_qty', width: 90, align: 'right' },
-    { title: '起始日', dataIndex: 'start_date', width: 110 },
+    { title: '订单', dataIndex: 'order_name', width: 130, fixed: 'left' },
     {
-      title: '进度', width: 100, align: 'center',
-      render: (_, row) => {
-        const done = row.completed_count || 0;
-        const total = row.line_count || 0;
-        const color = total > 0 && done === total ? 'green' : 'blue';
-        return <Tag color={color}>{done} / {total}</Tag>;
-      },
-    },
-    {
-      title: '产值', width: 110, align: 'right',
-      render: (_, row) => (Number(row.total_qty || 0) * Number(row.quote_price || 0)).toFixed(2),
-    },
-    {
-      title: '完成时间', width: 140,
-      render: (_, row) => {
-        const done = row.completed_count || 0;
-        const total = row.line_count || 0;
-        if (!total) return <span style={{ color: '#ccc' }}>—</span>;
-        if (done === total && row.last_completed_at) {
-          return <span style={{ color: '#52c41a' }}>{dayjs(row.last_completed_at).format('MM-DD HH:mm')}</span>;
-        }
-        return <span style={{ color: '#999' }}>未完工</span>;
-      },
-    },
-    {
-      title: '操作', width: 100,
+      title: '货号 - 货名', width: 220, fixed: 'left',
       render: (_, row) => (
-        <Popconfirm title="确认删除此订单?" onConfirm={() => onDeleteOrder(row.id)}>
-          <Button size="small" danger icon={<DeleteOutlined />}>删除</Button>
-        </Popconfirm>
+        <span>
+          <b>{row.product_code}</b>
+          <span style={{ color: '#666', marginLeft: 4 }}>{row.product_name}</span>
+        </span>
+      ),
+    },
+    { title: '部位', dataIndex: 'part_name', width: 130 },
+    {
+      title: '工艺', dataIndex: 'technique', width: 90,
+      render: v => {
+        const t = normalizeTechnique(v);
+        const colors = { '喷油': '#fa8c16', '移印': '#1677ff', 'UV': '#722ed1', '散枪': '#13c2c2', '洗货': '#a0d911' };
+        return <Tag color={colors[t] || 'default'}>{v || '-'}</Tag>;
+      },
+    },
+    {
+      title: '分到拉', width: 130,
+      render: (_, row) => (
+        <Select size="small" style={{ width: 110 }}
+          placeholder={!row.line_id ? '⚠ 选拉' : '选拉'}
+          value={row.line_id || undefined}
+          onChange={v => onUpdateSL(row.order_id, row.id, { line_id: v || null })}
+          options={lineOptions}
+          allowClear
+          status={!row.line_id ? 'warning' : undefined}
+        />
+      ),
+    },
+    {
+      title: '数量', dataIndex: 'qty', width: 90, align: 'right',
+      render: (v, row) => (
+        <NumCell value={v} min={0}
+          onSave={nv => onUpdateSL(row.order_id, row.id, { qty: nv })} />
+      ),
+    },
+    {
+      title: '累计', dataIndex: 'produced_total', width: 70, align: 'right',
+      render: v => <span style={{ color: '#1677ff' }}>{Number(v || 0)}</span>,
+    },
+    {
+      title: '欠数', width: 70, align: 'right',
+      render: (_, row) => {
+        const owed = Number(row.qty || 0) - Number(row.produced_total || 0);
+        if (owed <= 0) return <span style={{ color: '#52c41a' }}>已完</span>;
+        return <span style={{ color: '#cf1322' }}>{owed}</span>;
+      },
+    },
+    {
+      title: '日产能', dataIndex: 'daily_capacity', width: 90, align: 'right',
+      render: (v, row) => (
+        <NumCell value={v}
+          onSave={nv => onUpdateSL(row.order_id, row.id, { daily_capacity: nv })} />
+      ),
+    },
+    {
+      title: '起-止', width: 170,
+      render: (_, row) => <span style={{ fontSize: 12 }}>{row.start_date} ~ {row.end_date}</span>,
+    },
+    {
+      title: '状态', width: 90,
+      render: (_, row) => {
+        if (row.completed_at) return <Tag color="success">完成 {fmtTime(row.completed_at)}</Tag>;
+        if (row.started_at) return <Tag color="processing">生产中</Tag>;
+        return <Tag>未开始</Tag>;
+      },
+    },
+    {
+      title: '操作', width: 200, fixed: 'right',
+      render: (_, row) => (
+        <Space size={2}>
+          {!row.started_at && (
+            <Button size="small" type="primary" icon={<PlayCircleOutlined />}
+              onClick={async () => {
+                await onClock(row.order_id, row.id, 'start');
+                navigate('/daily-records');
+              }}>排单</Button>
+          )}
+          {row.started_at && !row.completed_at && (
+            <Button size="small" icon={<CheckCircleOutlined />}
+              onClick={() => onClock(row.order_id, row.id, 'complete')}>完成</Button>
+          )}
+          {(row.started_at || row.completed_at) && (
+            <Popconfirm title="重置开始/完成时间?"
+              onConfirm={() => onClock(row.order_id, row.id, 'reset')}>
+              <Button size="small" icon={<RedoOutlined />} />
+            </Popconfirm>
+          )}
+          <Popconfirm title={`删除整个订单 ${row.order_name}?该单全部工序一并删除`}
+            onConfirm={() => onDeleteOrder(row.order_id)}>
+            <Button size="small" danger icon={<DeleteOutlined />} />
+          </Popconfirm>
+        </Space>
       ),
     },
   ];
 
-  const renderList = () => (
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
+
+  const onDragEnd = ({ active, over }) => {
+    if (!over || active.id === over.id) return;
+    const oldIndex = flat.findIndex(r => r.id === active.id);
+    const newIndex = flat.findIndex(r => r.id === over.id);
+    if (oldIndex < 0 || newIndex < 0) return;
+    const next = arrayMove(flat, oldIndex, newIndex);
+    setFlat(next); // 乐观更新
+    onReorder(next.map(r => r.id)).catch(e => {
+      message.error('保存顺序失败,刷新重试');
+      loadList();
+    });
+  };
+
+  const renderFlat = () => (
     <div>
-      <Space style={{ marginBottom: 16 }} wrap>
+      <Space style={{ marginBottom: 12 }} wrap>
         月份:
-        <DatePicker
-          picker="month"
-          value={month}
-          onChange={setMonth}
-          allowClear
-        />
-        <Input.Search
-          placeholder="搜索订单名 / 货号 / 货名"
-          style={{ width: 280 }}
-          allowClear
+        <DatePicker picker="month" value={month} onChange={setMonth} allowClear />
+        <Input.Search placeholder="搜索订单/货号/货名/部位" style={{ width: 280 }} allowClear
           onSearch={v => setQ(v)}
-          onChange={e => { if (!e.target.value) setQ(''); }}
-        />
+          onChange={e => { if (!e.target.value) setQ(''); }} />
       </Space>
 
-      <Card style={{ marginBottom: 16, background: '#fffbe6' }}>
-        <Space size="large">
-          <span><b>当月订单数:</b> {list.length}</span>
-          <span>
-            <b>当月总产值:</b>{' '}
-            <span style={{ fontSize: 20, color: '#d4380d' }}>
-              {monthlyOutput.toFixed(2)}
-            </span>
-          </span>
-        </Space>
-      </Card>
+      <div style={{
+        marginBottom: 12, padding: '8px 14px', background: '#fafafa',
+        border: '1px solid #f0f0f0', borderRadius: 4, display: 'flex', gap: 16, flexWrap: 'wrap',
+      }}>
+        <span>共 <b>{flatStats.total}</b> 件</span>
+        <span style={{ color: '#faad14' }}>待排拉 <b>{flatStats.noLine}</b></span>
+        <span>未开始 <b>{flatStats.pending}</b></span>
+        <span style={{ color: '#1677ff' }}>生产中 <b>{flatStats.started}</b></span>
+        <span style={{ color: '#52c41a' }}>已完成 <b>{flatStats.done}</b></span>
+        <span style={{ marginLeft: 'auto', color: '#d4380d' }}>当月产值 <b>¥{monthlyOutput.toFixed(2)}</b></span>
+      </div>
 
-      <Table
-        rowKey="id"
-        size="middle"
-        dataSource={list}
-        columns={listColumns}
-        pagination={false}
-        scroll={{ x: 'max-content' }}
-        expandable={{
-          expandedRowRender,
-          onExpand: (expanded, record) => {
-            if (expanded) loadDetail(record.id);
-          },
-        }}
-      />
+      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
+        <SortableContext items={flat.map(r => r.id)} strategy={verticalListSortingStrategy}>
+          <Table
+            rowKey="id"
+            size="small"
+            dataSource={flat}
+            columns={flatColumns}
+            pagination={false}
+            scroll={{ x: 'max-content' }}
+            components={{ body: { row: SortableRow } }}
+            locale={{ emptyText: '本月还没有件 — 点右上「导入订单」或「新建订单」' }}
+          />
+        </SortableContext>
+      </DndContext>
     </div>
   );
 
@@ -454,15 +489,22 @@ export default function Orders() {
     <div>
       <Space style={{ marginBottom: 8, display: 'flex', justifyContent: 'space-between', width: '100%' }}>
         <h2 style={{ margin: 0 }}>订单排产</h2>
-        <Upload accept=".pdf" beforeUpload={onPdfUpload} showUploadList={false}>
-          <Button icon={<FilePdfOutlined />} type="primary" ghost>从 PDF 导入订单</Button>
+        <Upload accept=".pdf,image/*" beforeUpload={onPdfUpload} showUploadList={false}>
+          <Button icon={<FilePdfOutlined />} type="primary" ghost>导入订单(PDF / 图片)</Button>
         </Upload>
       </Space>
-      {renderList()}
+      <Tabs
+        activeKey={activeTab}
+        onChange={setActiveTab}
+        items={[
+          { key: 'flat', label: '所有件(可拖拽手动排)', children: renderFlat() },
+          { key: 'new', label: '新建订单', children: renderCreateForm() },
+        ]}
+      />
 
       <Modal
         open={pdfModalOpen}
-        title="PDF 订单导入预览"
+        title={pdfPreview?.source === 'image' ? '图片订单识别预览(AI)' : 'PDF 订单导入预览'}
         onCancel={() => { setPdfModalOpen(false); setPdfPreview(null); }}
         onOk={onPdfConfirm}
         okText="确认导入"
@@ -471,14 +513,28 @@ export default function Orders() {
         width={900}
         confirmLoading={pdfLoading}
       >
-        {pdfLoading && <div style={{ textAlign: 'center', padding: 30 }}>解析中...</div>}
+        {pdfLoading && (
+          <div style={{ textAlign: 'center', padding: 30, color: '#888' }}>
+            正在识别...(图片走 AI 通常 5-15 秒)
+          </div>
+        )}
         {pdfPreview && (
           <div>
-            <div style={{ marginBottom: 12, color: '#666' }}>
-              订单号 <b>{pdfPreview.header?.order_no || '-'}</b> ·
-              日期 <b>{pdfPreview.header?.order_date || '-'}</b> ·
-              交货 <b>{pdfPreview.header?.due_date || '-'}</b> ·
-              工序 <b>{pdfPreview.header?.technique_label || '-'}</b>
+            <div style={{ marginBottom: 12, color: '#666', display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
+              <span>订单号 <b>{pdfPreview.header?.order_no || '-'}</b></span>
+              <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                排产起始日:
+                <DatePicker size="small" allowClear={false}
+                  value={pdfPreview.start_date}
+                  onChange={d => setPdfPreview({ ...pdfPreview, start_date: d || dayjs() })} />
+                {pdfPreview.header?.order_date && (
+                  <span style={{ fontSize: 11, color: '#999' }}>
+                    (PDF 写 {pdfPreview.header.order_date})
+                  </span>
+                )}
+              </span>
+              <span>交货 <b>{pdfPreview.header?.due_date || '-'}</b></span>
+              <span>工序 <b>{pdfPreview.header?.technique_label || '-'}</b></span>
             </div>
             <div style={{ marginBottom: 12 }}>
               款号:<b style={{ marginLeft: 6 }}>{pdfPreview.code}</b>
@@ -510,36 +566,97 @@ export default function Orders() {
                 { title: '匹配工序', render: (_, r, i) => {
                   if (!pdfPreview.matched) return <span style={{ color: '#999' }}>—</span>;
                   if (!r.matched_processes?.length) {
-                    return <Tag color="warning">未匹配,跳过</Tag>;
+                    const np = r.new_process || {};
+                    const updateNP = (patch) => {
+                      const next = [...pdfPreview.items];
+                      next[i] = { ...next[i], new_process: { ...(next[i].new_process || {}), ...patch } };
+                      setPdfPreview({ ...pdfPreview, items: next });
+                    };
+                    const updatePicked = (ids) => {
+                      const next = [...pdfPreview.items];
+                      next[i] = { ...next[i], picked_process_ids: ids };
+                      setPdfPreview({ ...pdfPreview, items: next });
+                    };
+                    const ready = np.part_name && np.technique && np.unit_wage != null && np.unit_wage !== '';
+                    const ppOptions = (pdfPreview.all_processes || []).map(pp => ({
+                      value: pp.id,
+                      label: `${pp.part_name}·${pp.technique}`,
+                    }));
+                    const pickedCount = (r.picked_process_ids || []).length;
+                    return (
+                      <Space direction="vertical" size={4} style={{ width: '100%' }}>
+                        <Select mode="multiple" size="small" allowClear
+                          placeholder="从核价表挑对应工序(可多选,首次需手动绑定)"
+                          value={r.picked_process_ids || []}
+                          style={{ width: '100%', minWidth: 360 }}
+                          options={ppOptions}
+                          filterOption={(input, opt) =>
+                            String(opt?.label || '').toLowerCase().includes(input.toLowerCase())
+                          }
+                          onChange={updatePicked} />
+                        <details style={{ fontSize: 12 }}>
+                          <summary style={{ cursor: 'pointer', color: '#888' }}>核价表没有?手动新建一条</summary>
+                          <Space size={4} wrap style={{ marginTop: 4 }}>
+                            <Input size="small" placeholder="部位名"
+                              value={np.part_name ?? r.pdf_part_name}
+                              style={{ width: 130 }}
+                              onChange={e => updateNP({ part_name: e.target.value })} />
+                            <Select size="small" placeholder="工艺"
+                              value={np.technique}
+                              style={{ width: 90 }}
+                              options={['喷油','移印','UV','散枪','洗货'].map(v => ({ value: v, label: v }))}
+                              onChange={v => updateNP({ technique: v })} />
+                            <AntInputNumber size="small" placeholder="工价" min={0} step={0.01}
+                              value={np.unit_wage} style={{ width: 80 }}
+                              onChange={v => updateNP({ unit_wage: v })} />
+                            <AntInputNumber size="small" placeholder="目标数" min={0}
+                              value={np.target_qty} style={{ width: 80 }}
+                              onChange={v => updateNP({ target_qty: v })} />
+                          </Space>
+                        </details>
+                        <span style={{ fontSize: 12, color: (pickedCount || ready) ? '#52c41a' : '#faad14' }}>
+                          {pickedCount
+                            ? `✓ 已选 ${pickedCount} 个工序,确认后将记住:"${r.pdf_part_name}" → 这 ${pickedCount} 条`
+                            : ready
+                              ? `✓ 将新建到核价表并记住:"${r.pdf_part_name}" → 新工序`
+                              : '未匹配 · 从下拉选(推荐)或手动新建'}
+                        </span>
+                      </Space>
+                    );
                   }
                   return (
-                    <Space wrap>
-                      {r.matched_processes.map(pp => {
-                        const checked = (r.selected_process_ids || []).includes(pp.id);
-                        return (
-                          <Tag.CheckableTag key={pp.id} checked={checked}
-                            onChange={c => {
-                              const next = [...pdfPreview.items];
-                              const cur = next[i].selected_process_ids || [];
-                              next[i] = {
-                                ...next[i],
-                                selected_process_ids: c
-                                  ? [...cur, pp.id]
-                                  : cur.filter(x => x !== pp.id),
-                              };
-                              setPdfPreview({ ...pdfPreview, items: next });
-                            }}>
-                            {pp.part_name}·{pp.technique}
-                          </Tag.CheckableTag>
-                        );
-                      })}
+                    <Space direction="vertical" size={2} style={{ width: '100%' }}>
+                      {r.from_alias && (
+                        <span style={{ fontSize: 11, color: '#1677ff' }}>已记住的映射 ✓</span>
+                      )}
+                      <Space wrap>
+                        {r.matched_processes.map(pp => {
+                          const checked = (r.selected_process_ids || []).includes(pp.id);
+                          return (
+                            <Tag.CheckableTag key={pp.id} checked={checked}
+                              onChange={c => {
+                                const next = [...pdfPreview.items];
+                                const cur = next[i].selected_process_ids || [];
+                                next[i] = {
+                                  ...next[i],
+                                  selected_process_ids: c
+                                    ? [...cur, pp.id]
+                                    : cur.filter(x => x !== pp.id),
+                                };
+                                setPdfPreview({ ...pdfPreview, items: next });
+                              }}>
+                              {pp.part_name}·{pp.technique}
+                            </Tag.CheckableTag>
+                          );
+                        })}
+                      </Space>
                     </Space>
                   );
                 }},
               ]}
             />
             <div style={{ marginTop: 8, color: '#888', fontSize: 12 }}>
-              提示:点击工序标签切换是否导入。同部位多工艺(如喷油+移印)默认都勾上,数量相同。
+              提示:首次导某个 PDF 部位若没自动命中,从下拉选对应的核价表工序(可多选);确认后系统会记住,下次同款 PDF 自动套用。
             </div>
           </div>
         )}

--- a/apps/生产部/喷油部生产管理系统/server/.gitignore
+++ b/apps/生产部/喷油部生产管理系统/server/.gitignore
@@ -4,3 +4,4 @@ db/*.db-journal
 db/*.db-shm
 db/*.db-wal
 uploads/
+.env

--- a/apps/生产部/喷油部生产管理系统/server/app.js
+++ b/apps/生产部/喷油部生产管理系统/server/app.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const express = require('express');
 const cors = require('cors');
 const path = require('path');

--- a/apps/生产部/喷油部生产管理系统/server/db/index.js
+++ b/apps/生产部/喷油部生产管理系统/server/db/index.js
@@ -22,6 +22,8 @@ addColumnIfMissing('dispatches', 'completed_at', 'DATETIME');
 addColumnIfMissing('order_schedule_lines', 'actual_capacity', 'INTEGER');
 db.exec(`UPDATE order_schedule_lines SET actual_capacity = daily_capacity WHERE actual_capacity IS NULL`);
 addColumnIfMissing('product_processes', 'default_line_id', 'INTEGER');
+addColumnIfMissing('order_schedule_lines', 'sort_order', 'INTEGER');
+db.exec(`UPDATE order_schedule_lines SET sort_order = id WHERE sort_order IS NULL`);
 
 const { seedLines, seedLineDefaults, seedWorkshops, seedLinesPerWorkshop } = require('./seed');
 seedWorkshops(db);

--- a/apps/生产部/喷油部生产管理系统/server/db/init.sql
+++ b/apps/生产部/喷油部生产管理系统/server/db/init.sql
@@ -126,6 +126,19 @@ CREATE TABLE IF NOT EXISTS order_schedule_lines (
 );
 CREATE INDEX IF NOT EXISTS idx_schedule_order ON order_schedule_lines(order_id);
 
+CREATE TABLE IF NOT EXISTS pdf_part_alias (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  product_id INTEGER NOT NULL,
+  pdf_part_name TEXT NOT NULL,
+  product_process_id INTEGER NOT NULL,
+  workshop_id INTEGER NOT NULL DEFAULT 2,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE(product_id, pdf_part_name, product_process_id),
+  FOREIGN KEY(product_id) REFERENCES products(id),
+  FOREIGN KEY(product_process_id) REFERENCES product_processes(id)
+);
+CREATE INDEX IF NOT EXISTS idx_pdf_alias_lookup ON pdf_part_alias(product_id, pdf_part_name);
+
 CREATE TABLE IF NOT EXISTS daily_records (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   record_date DATE NOT NULL,

--- a/apps/生产部/喷油部生产管理系统/server/package-lock.json
+++ b/apps/生产部/喷油部生产管理系统/server/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "better-sqlite3": "^12.9.0",
         "cors": "^2.8.5",
+        "dotenv": "^17.4.2",
         "exceljs": "^4.4.0",
         "express": "^4.19.2",
         "multer": "^1.4.5-lts.1",
@@ -827,6 +828,18 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/apps/生产部/喷油部生产管理系统/server/package.json
+++ b/apps/生产部/喷油部生产管理系统/server/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "better-sqlite3": "^12.9.0",
     "cors": "^2.8.5",
+    "dotenv": "^17.4.2",
     "exceljs": "^4.4.0",
     "express": "^4.19.2",
     "multer": "^1.4.5-lts.1",

--- a/apps/生产部/喷油部生产管理系统/server/routes/daily-records.js
+++ b/apps/生产部/喷油部生产管理系统/server/routes/daily-records.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const ExcelJS = require('exceljs');
 const db = require('../db');
 const router = express.Router();
 
@@ -35,6 +36,66 @@ router.post('/', (req, res) => {
     return res.status(400).json({ error: 'all fields required' });
   upsertRecord(db, req.body, req.workshopId);
   res.json({ ok: true });
+});
+
+// 导出当日生产记录为 Excel(给班长/老板发的那个表)
+router.get('/export', async (req, res) => {
+  const date = req.query.date;
+  if (!date) return res.status(400).json({ error: 'date required' });
+  const rows = db.prepare(`
+    SELECT dr.record_date, l.name AS line_name,
+           p.code AS product_code, p.name AS product_name,
+           pp.part_name, pp.technique, pp.unit_wage, p.quote_price,
+           dr.produced_qty, dr.worker_count, dr.remarks
+    FROM daily_records dr
+    JOIN lines l ON l.id = dr.line_id
+    JOIN products p ON p.id = dr.product_id
+    JOIN product_processes pp ON pp.id = dr.product_process_id
+    WHERE dr.record_date = ? AND dr.workshop_id = ?
+    ORDER BY p.code, pp.technique, l.name
+  `).all(date, req.workshopId);
+
+  const wb = new ExcelJS.Workbook();
+  const ws = wb.addWorksheet(`${date} 生产记录`);
+  ws.columns = [
+    { header: '日期', key: 'record_date', width: 12 },
+    { header: '货号', key: 'product_code', width: 12 },
+    { header: '货名', key: 'product_name', width: 22 },
+    { header: '部位', key: 'part_name', width: 16 },
+    { header: '工艺', key: 'technique', width: 10 },
+    { header: '拉', key: 'line_name', width: 10 },
+    { header: '生产数', key: 'produced_qty', width: 10 },
+    { header: '工人数', key: 'worker_count', width: 8 },
+    { header: '工价', key: 'unit_wage', width: 10 },
+    { header: '工资', key: 'wage', width: 12 },
+    { header: '报价', key: 'quote_price', width: 10 },
+    { header: '产值', key: 'output', width: 12 },
+    { header: '备注', key: 'remarks', width: 20 },
+  ];
+  ws.getRow(1).font = { bold: true };
+  let totalOutput = 0, totalWage = 0;
+  for (const r of rows) {
+    const wage = Number(r.unit_wage || 0) * Number(r.produced_qty || 0);
+    const output = Number(r.quote_price || 0) * Number(r.produced_qty || 0);
+    totalOutput += output;
+    totalWage += wage;
+    ws.addRow({ ...r, wage: Number(wage.toFixed(2)), output: Number(output.toFixed(2)) });
+  }
+  if (rows.length) {
+    ws.addRow({});
+    const sumRow = ws.addRow({
+      part_name: '合计',
+      produced_qty: rows.reduce((s, r) => s + Number(r.produced_qty || 0), 0),
+      wage: Number(totalWage.toFixed(2)),
+      output: Number(totalOutput.toFixed(2)),
+    });
+    sumRow.font = { bold: true };
+  }
+  const buf = await wb.xlsx.writeBuffer();
+  res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+  res.setHeader('Content-Disposition',
+    `attachment; filename="daily_${date}.xlsx"`);
+  res.send(Buffer.from(buf));
 });
 
 // 查某条工序的逐日生产历史(可选按 line_id 过滤)

--- a/apps/生产部/喷油部生产管理系统/server/routes/orders.js
+++ b/apps/生产部/喷油部生产管理系统/server/routes/orders.js
@@ -4,6 +4,8 @@ const path = require('path');
 const multer = require('multer');
 const db = require('../db');
 const { parsePDFOrder } = require('../services/pdf-order-parser');
+const { parseImageOrder } = require('../services/image-order-parser');
+const { calcPrices } = require('../lib/pricing');
 const router = express.Router();
 const UPLOAD_DIR = path.join(process.env.DATA_PATH || path.join(__dirname, '..'), 'uploads');
 fs.mkdirSync(UPLOAD_DIR, { recursive: true });
@@ -14,6 +16,17 @@ function addDays(yyyymmdd, days) {
   const d = new Date(yyyymmdd + 'T00:00:00Z');
   d.setUTCDate(d.getUTCDate() + days);
   return d.toISOString().slice(0, 10);
+}
+
+function nextSortOrder(dbi, workshop_id) {
+  // 新行排到最末:取该车间下当前最大 sort_order + 1
+  const row = dbi.prepare(`
+    SELECT COALESCE(MAX(osl.sort_order), 0) AS m
+    FROM order_schedule_lines osl
+    JOIN production_orders po ON po.id = osl.order_id
+    WHERE po.workshop_id = ?
+  `).get(workshop_id);
+  return (row.m || 0) + 1;
 }
 
 function createOrder(dbi, { order_name, product_id, total_qty, start_date, remarks, workshop_id }) {
@@ -29,9 +42,10 @@ function createOrder(dbi, { order_name, product_id, total_qty, start_date, remar
     ).all(product_id);
     const insertLine = dbi.prepare(`
       INSERT INTO order_schedule_lines
-      (order_id, product_process_id, line_id, qty, daily_capacity, actual_capacity, est_days, start_date, end_date)
-      VALUES (?,?,?,?,?,?,?,?,?)
+      (order_id, product_process_id, line_id, qty, daily_capacity, actual_capacity, est_days, start_date, end_date, sort_order)
+      VALUES (?,?,?,?,?,?,?,?,?,?)
     `);
+    let sortOrder = nextSortOrder(dbi, workshop_id);
     for (const pp of procs) {
       // 优先用产品工序级记忆(上次为该具体工序选的拉),没有再用车间级默认映射
       let line_id = pp.default_line_id || null;
@@ -42,7 +56,7 @@ function createOrder(dbi, { order_name, product_id, total_qty, start_date, remar
       const capacity = pp.target_qty || 1;
       const est_days = ceilDiv(total_qty, capacity);
       const end_date = addDays(start_date, Math.max(est_days - 1, 0));
-      insertLine.run(oid, pp.id, line_id, total_qty, capacity, capacity, est_days, start_date, end_date);
+      insertLine.run(oid, pp.id, line_id, total_qty, capacity, capacity, est_days, start_date, end_date, sortOrder++);
     }
     return oid;
   })();
@@ -113,7 +127,7 @@ function updateScheduleLine(dbi, slId, patch) {
   }
 }
 
-function listActiveScheduleLines(dbi, date, workshop_id) {
+function listActiveScheduleLines(dbi, workshop_id) {
   return dbi.prepare(`
     SELECT
       osl.id AS schedule_line_id,
@@ -140,19 +154,18 @@ function listActiveScheduleLines(dbi, date, workshop_id) {
     JOIN product_processes pp ON pp.id = osl.product_process_id
     WHERE po.deleted = 0
       AND po.workshop_id = ?
-      AND osl.start_date <= ? AND osl.end_date >= ?
+      AND osl.started_at IS NOT NULL
       AND osl.completed_at IS NULL
-    ORDER BY po.id, pp.technique, osl.id
-  `).all(workshop_id, date, date);
+    ORDER BY osl.sort_order, osl.id
+  `).all(workshop_id);
 }
 
 router.get('/', (req, res) =>
   res.json(listOrders(db, { workshop_id: req.workshopId, month: req.query.month, q: req.query.q })));
 
 router.get('/active', (req, res) => {
-  const date = req.query.date;
-  if (!date) return res.status(400).json({ error: 'date required' });
-  res.json(listActiveScheduleLines(db, date, req.workshopId));
+  // 改:不再按日期过滤,只要「已排单 + 未完成」就返回,跨日存在
+  res.json(listActiveScheduleLines(db, req.workshopId));
 });
 
 router.get('/:id', (req, res) => {
@@ -172,6 +185,88 @@ router.post('/', (req, res) => {
   res.json({ id });
 });
 
+// 拿 parsed = {header, code, items:[{part_name,qty}]} 做款号/工序匹配 + alias 查找
+// 返回 preview 响应体(写不写 res 由调用者决定)
+function buildOrderPreview(parsed, workshopId) {
+  if (!parsed.code) return { status: 400, body: { error: '无法提取款号' } };
+
+  const codeVariants = [parsed.code, parsed.code.replace(/[-\s].*$/, '')];
+  let product = null;
+  for (const v of codeVariants) {
+    product = db.prepare('SELECT * FROM products WHERE code=? AND deleted=0 AND workshop_id=?')
+      .get(v, workshopId);
+    if (product) break;
+  }
+  if (!product) {
+    return {
+      status: 200,
+      body: {
+        header: parsed.header,
+        code: parsed.code,
+        items: parsed.items,
+        matched: false,
+        error: `核价表里没有款号 ${parsed.code}(去尾后试 ${codeVariants[1]} 也没有),请先去核价表新建产品`,
+      },
+    };
+  }
+
+  const processes = db.prepare(
+    'SELECT * FROM product_processes WHERE product_id=? AND deleted=0 ORDER BY id'
+  ).all(product.id);
+  const procById = new Map(processes.map(pp => [pp.id, pp]));
+
+  const aliasRows = db.prepare(
+    'SELECT pdf_part_name, product_process_id FROM pdf_part_alias WHERE product_id=? AND workshop_id=?'
+  ).all(product.id, workshopId);
+  const aliasMap = new Map();
+  for (const a of aliasRows) {
+    if (!aliasMap.has(a.pdf_part_name)) aliasMap.set(a.pdf_part_name, []);
+    aliasMap.get(a.pdf_part_name).push(a.product_process_id);
+  }
+
+  const normalize = s => String(s || '').replace(/\s|\(印喷件\)|（印喷件）/g, '').toLowerCase();
+  const matchedItems = parsed.items.map(it => {
+    let matched = [];
+    let from_alias = false;
+    const aliasIds = aliasMap.get(it.part_name);
+    if (aliasIds && aliasIds.length) {
+      matched = aliasIds.map(id => procById.get(id)).filter(Boolean);
+      from_alias = true;
+    } else {
+      const k = normalize(it.part_name);
+      matched = processes.filter(pp => {
+        const pk = normalize(pp.part_name);
+        return pk === k || pk.includes(k) || k.includes(pk);
+      });
+    }
+    return {
+      pdf_part_name: it.part_name,
+      pdf_qty: it.qty,
+      from_alias,
+      matched_processes: matched.map(pp => ({
+        id: pp.id, part_name: pp.part_name, technique: pp.technique,
+        target_qty: pp.target_qty, unit_wage: pp.unit_wage,
+      })),
+    };
+  });
+
+  return {
+    status: 200,
+    body: {
+      header: parsed.header,
+      code: parsed.code,
+      product: { id: product.id, code: product.code, name: product.name },
+      items: matchedItems,
+      matched: true,
+      unmatched_count: matchedItems.filter(x => x.matched_processes.length === 0).length,
+      all_processes: processes.map(pp => ({
+        id: pp.id, part_name: pp.part_name, technique: pp.technique,
+        target_qty: pp.target_qty, unit_wage: pp.unit_wage,
+      })),
+    },
+  };
+}
+
 // PDF 导入 - 预览(不写库,返回匹配结果让用户确认)
 router.post('/import-pdf', upload.single('file'), async (req, res) => {
   if (!req.file) return res.status(400).json({ error: 'file required' });
@@ -180,60 +275,26 @@ router.post('/import-pdf', upload.single('file'), async (req, res) => {
     const buf = fs.readFileSync(req.file.path);
     const parsed = await parsePDFOrder(buf);
     fs.unlinkSync(req.file.path);
-
-    if (!parsed.code) return res.status(400).json({ error: '无法从 PDF 提取款号' });
-
-    // 款号匹配:先按完整 code,然后剥后缀(去掉 -总MA 等)再匹配
-    const codeVariants = [parsed.code, parsed.code.replace(/[-\s].*$/, '')];
-    let product = null;
-    for (const v of codeVariants) {
-      product = db.prepare('SELECT * FROM products WHERE code=? AND deleted=0 AND workshop_id=?')
-        .get(v, req.workshopId);
-      if (product) break;
-    }
-
-    if (!product) {
-      return res.json({
-        header: parsed.header,
-        code: parsed.code,
-        items: parsed.items,
-        matched: false,
-        error: `核价表里没有款号 ${parsed.code}(去尾后试 ${codeVariants[1]} 也没有),请先去核价表新建产品`,
-      });
-    }
-
-    // 拿产品的所有工序
-    const processes = db.prepare(
-      'SELECT * FROM product_processes WHERE product_id=? AND deleted=0 ORDER BY id'
-    ).all(product.id);
-
-    // 模糊匹配:PDF 部位 ↔ 核价表 part_name
-    const normalize = s => String(s || '').replace(/\s|\(印喷件\)|（印喷件）/g, '').toLowerCase();
-    const matchedItems = parsed.items.map(it => {
-      const pdfKey = normalize(it.part_name);
-      const matched = processes.filter(pp => {
-        const pk = normalize(pp.part_name);
-        return pk === pdfKey || pk.includes(pdfKey) || pdfKey.includes(pk);
-      });
-      return {
-        pdf_part_name: it.part_name,
-        pdf_qty: it.qty,
-        matched_processes: matched.map(pp => ({
-          id: pp.id, part_name: pp.part_name, technique: pp.technique,
-          target_qty: pp.target_qty, unit_wage: pp.unit_wage,
-        })),
-      };
-    });
-
-    res.json({
-      header: parsed.header,
-      code: parsed.code,
-      product: { id: product.id, code: product.code, name: product.name },
-      items: matchedItems,
-      matched: true,
-      unmatched_count: matchedItems.filter(x => x.matched_processes.length === 0).length,
-    });
+    const { status, body } = buildOrderPreview(parsed, req.workshopId);
+    res.status(status).json(body);
   } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+// 图片导入 - 用百炼视觉模型抽订单结构,然后走和 PDF 一样的匹配流程
+router.post('/import-image', upload.single('file'), async (req, res) => {
+  if (!req.file) return res.status(400).json({ error: 'file required' });
+  const fs = require('fs');
+  try {
+    const buf = fs.readFileSync(req.file.path);
+    const mime = req.file.mimetype || 'image/jpeg';
+    const parsed = await parseImageOrder(buf, mime);
+    fs.unlinkSync(req.file.path);
+    const { status, body } = buildOrderPreview(parsed, req.workshopId);
+    res.status(status).json(body);
+  } catch (e) {
+    try { fs.unlinkSync(req.file.path); } catch (_) {}
     res.status(500).json({ error: e.message });
   }
 });
@@ -244,15 +305,16 @@ router.post('/import-pdf/confirm', (req, res) => {
   if (!product_id || !order_name || !start_date || !Array.isArray(items)) {
     return res.status(400).json({ error: 'product_id, order_name, start_date, items required' });
   }
-  // items: [{ product_process_id, qty }, ...] (可来自多 PDF 部位 × 多工序的展开)
-  // 注:total_qty 不再是单一值;我们按 items 里最大 qty 当 total_qty(只是展示用)
+  // items 形态:
+  //   { product_process_id, qty, pdf_part_name?, learn_alias? }  — 用已有工序;learn_alias=true 时把 pdf_part_name → product_process_id 存映射
+  //   { new_process: {part_name,technique,unit_wage,target_qty}, qty, pdf_part_name?, learn_alias? } — 新建工序,也可顺手记 alias
   const totalQty = Math.max(...items.map(i => Number(i.qty) || 0), 0);
   const product = db.prepare('SELECT id FROM products WHERE id=? AND deleted=0 AND workshop_id=?')
     .get(product_id, req.workshopId);
   if (!product) return res.status(404).json({ error: 'product not found' });
 
   try {
-    const oid = db.transaction(() => {
+    const result = db.transaction(() => {
       const { lastInsertRowid: oid } = db.prepare(
         'INSERT INTO production_orders(order_name, product_id, total_qty, start_date, remarks, workshop_id) VALUES (?,?,?,?,?,?)'
       ).run(order_name, product_id, totalQty, start_date, 'PDF 导入', req.workshopId);
@@ -261,15 +323,55 @@ router.post('/import-pdf/confirm', (req, res) => {
         'SELECT line_id FROM technique_line_defaults WHERE workshop_id=? AND technique=?'
       );
       const ppStmt = db.prepare('SELECT * FROM product_processes WHERE id=?');
+      const insertProc = db.prepare(`
+        INSERT INTO product_processes
+        (product_id,part_name,technique,target_qty,worker_count,unit_wage,calc_price,paint_price,total_price,remarks)
+        VALUES (?,?,?,?,?,?,?,?,?,?)
+      `);
       const insertLine = db.prepare(`
         INSERT INTO order_schedule_lines
-        (order_id, product_process_id, line_id, qty, daily_capacity, actual_capacity, est_days, start_date, end_date)
-        VALUES (?,?,?,?,?,?,?,?,?)
+        (order_id, product_process_id, line_id, qty, daily_capacity, actual_capacity, est_days, start_date, end_date, sort_order)
+        VALUES (?,?,?,?,?,?,?,?,?,?)
+      `);
+      let sortOrder = nextSortOrder(db, req.workshopId);
+      const insertAlias = db.prepare(`
+        INSERT OR IGNORE INTO pdf_part_alias
+        (product_id, pdf_part_name, product_process_id, workshop_id)
+        VALUES (?,?,?,?)
       `);
 
+      let createdProcCount = 0;
+      let learnedAliasCount = 0;
       for (const it of items) {
-        const pp = ppStmt.get(it.product_process_id);
+        let pp = null;
+        if (it.new_process && it.new_process.part_name && it.new_process.technique) {
+          const np = it.new_process;
+          const unit_wage = Number(np.unit_wage) || 0;
+          const target_qty = Number(np.target_qty) || 0;
+          const { calc_price, paint_price, total_price } = calcPrices({ unit_wage });
+          const { lastInsertRowid: ppId } = insertProc.run(
+            product_id,
+            String(np.part_name).trim(),
+            String(np.technique).trim(),
+            target_qty,
+            1,
+            unit_wage,
+            calc_price,
+            paint_price,
+            total_price,
+            ''
+          );
+          pp = ppStmt.get(ppId);
+          createdProcCount++;
+        } else if (it.product_process_id) {
+          pp = ppStmt.get(it.product_process_id);
+        }
         if (!pp) continue;
+        // 记 alias:前端传了 learn_alias 才记(避免把自动模糊匹配的也写进去)
+        if (it.learn_alias && it.pdf_part_name) {
+          const info = insertAlias.run(product_id, String(it.pdf_part_name).trim(), pp.id, req.workshopId);
+          if (info.changes) learnedAliasCount++;
+        }
         // 优先工序级记忆,再车间级默认
         let line_id = pp.default_line_id || null;
         if (!line_id) {
@@ -280,14 +382,69 @@ router.post('/import-pdf/confirm', (req, res) => {
         const capacity = pp.target_qty || 1;
         const est_days = ceilDiv(qty, capacity);
         const end_date = addDays(start_date, Math.max(est_days - 1, 0));
-        insertLine.run(oid, pp.id, line_id, qty, capacity, capacity, est_days, start_date, end_date);
+        insertLine.run(oid, pp.id, line_id, qty, capacity, capacity, est_days, start_date, end_date, sortOrder++);
       }
-      return oid;
+      return { oid, createdProcCount, learnedAliasCount };
     })();
-    res.json({ ok: true, order_id: oid });
+    res.json({
+      ok: true,
+      order_id: result.oid,
+      created_processes: result.createdProcCount,
+      learned_aliases: result.learnedAliasCount,
+    });
   } catch (e) {
     res.status(500).json({ error: e.message });
   }
+});
+
+// 平铺所有件:按 sort_order 排,可选月份/关键字过滤,这是新版主页要用的接口
+router.get('/schedule-lines/flat', (req, res) => {
+  const { month, q } = req.query;
+  const params = [req.workshopId];
+  let where = 'po.deleted=0 AND po.workshop_id=?';
+  if (month) { where += " AND strftime('%Y-%m', po.start_date) = ?"; params.push(month); }
+  if (q) {
+    where += ' AND (po.order_name LIKE ? OR p.code LIKE ? OR p.name LIKE ? OR pp.part_name LIKE ?)';
+    params.push(`%${q}%`, `%${q}%`, `%${q}%`, `%${q}%`);
+  }
+  const rows = db.prepare(`
+    SELECT osl.id, osl.order_id, po.order_name, po.start_date AS order_start_date,
+           p.id AS product_id, p.code AS product_code, p.name AS product_name, p.quote_price,
+           osl.product_process_id, pp.part_name, pp.technique, pp.unit_wage,
+           osl.line_id, l.name AS line_name,
+           osl.qty, osl.daily_capacity,
+           COALESCE(osl.actual_capacity, osl.daily_capacity) AS actual_capacity,
+           osl.est_days, osl.start_date, osl.end_date,
+           osl.started_at, osl.completed_at, osl.sort_order,
+           (SELECT COALESCE(SUM(dr.produced_qty), 0)
+             FROM daily_records dr
+             WHERE dr.product_process_id = osl.product_process_id
+               AND dr.record_date >= osl.start_date
+               AND (osl.line_id IS NULL OR dr.line_id = osl.line_id)
+           ) AS produced_total
+    FROM order_schedule_lines osl
+    JOIN production_orders po ON po.id = osl.order_id
+    LEFT JOIN lines l ON l.id = osl.line_id
+    JOIN products p ON p.id = po.product_id
+    JOIN product_processes pp ON pp.id = osl.product_process_id
+    WHERE ${where}
+    ORDER BY osl.sort_order, osl.id
+  `).all(...params);
+  res.json(rows);
+});
+
+// 拖拽重排:前端传 {ids:[id1,id2,...]} 按数组顺序重写 sort_order
+router.put('/schedule-lines/reorder', (req, res) => {
+  const ids = Array.isArray(req.body?.ids) ? req.body.ids.map(Number).filter(Boolean) : [];
+  if (!ids.length) return res.status(400).json({ error: 'ids required' });
+  const upd = db.prepare(`
+    UPDATE order_schedule_lines SET sort_order=?
+    WHERE id=? AND order_id IN (SELECT id FROM production_orders WHERE workshop_id=?)
+  `);
+  db.transaction(() => {
+    ids.forEach((id, i) => upd.run(i + 1, id, req.workshopId));
+  })();
+  res.json({ ok: true });
 });
 
 router.put('/:id/schedule-lines/:slId', (req, res) => {

--- a/apps/生产部/喷油部生产管理系统/server/services/image-order-parser.js
+++ b/apps/生产部/喷油部生产管理系统/server/services/image-order-parser.js
@@ -1,0 +1,95 @@
+// 用百炼(Bailian / DashScope)的 qwen-vl-max 视觉模型,从订单照片/截图里抽出
+//   { header:{order_no,order_date,due_date}, code, items:[{part_name, qty}] }
+// 跟 pdf-order-parser 返回结构对齐,后续可以走同一套匹配/alias 流程。
+
+const ENDPOINT = 'https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions';
+const MODEL = 'qwen-vl-max';
+
+const SYSTEM_PROMPT = `你是工厂订单图片识别助手。用户会发一张工厂订单的照片或截图,
+请抽取以下字段并以严格 JSON 输出(不要 markdown 代码块,不要任何额外文字):
+{
+  "header": {
+    "order_no": "订单号/单号(找不到给空串)",
+    "order_date": "下单日期 YYYY-MM-DD(找不到给空串)",
+    "due_date": "交货日期 YYYY-MM-DD(找不到给空串)"
+  },
+  "code": "产品货号(只取主货号,不带后缀如 -总MA;找不到给空串)",
+  "items": [
+    { "part_name": "部位名(或工序名,按订单上的写法原样输出)", "qty": 数字 }
+  ]
+}
+注意:
+- items 里数量必须是纯数字。
+- 同一部位/工序的不同款/颜色,如果只有一个汇总数,合并成一行。
+- 不要编造没看见的字段,空就给空串或 0。`;
+
+async function parseImageOrder(buffer, mimeType) {
+  const apiKey = process.env.DASHSCOPE_API_KEY;
+  if (!apiKey) throw new Error('DASHSCOPE_API_KEY 未配置(server/.env)');
+
+  const b64 = buffer.toString('base64');
+  const dataUrl = `data:${mimeType || 'image/jpeg'};base64,${b64}`;
+
+  const body = {
+    model: MODEL,
+    messages: [
+      { role: 'system', content: SYSTEM_PROMPT },
+      {
+        role: 'user',
+        content: [
+          { type: 'image_url', image_url: { url: dataUrl } },
+          { type: 'text', text: '请按系统指令把这张订单图里的内容抽成 JSON 输出。' },
+        ],
+      },
+    ],
+    temperature: 0,
+  };
+
+  const resp = await fetch(ENDPOINT, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`Bailian ${resp.status}: ${text.slice(0, 300)}`);
+  }
+  const data = await resp.json();
+  const content = data?.choices?.[0]?.message?.content || '';
+
+  // 模型偶尔会包 ```json ... ```;剥掉
+  const cleaned = String(content)
+    .replace(/^\s*```(?:json)?\s*/i, '')
+    .replace(/\s*```\s*$/i, '')
+    .trim();
+
+  let parsed;
+  try {
+    parsed = JSON.parse(cleaned);
+  } catch (e) {
+    throw new Error(`Bailian 返回的不是合法 JSON: ${cleaned.slice(0, 300)}`);
+  }
+
+  // 规整 items
+  const items = Array.isArray(parsed.items) ? parsed.items.map(it => ({
+    part_name: String(it.part_name || '').trim(),
+    qty: Number(it.qty) || 0,
+  })).filter(it => it.part_name) : [];
+
+  return {
+    header: {
+      order_no: String(parsed?.header?.order_no || '').trim(),
+      order_date: String(parsed?.header?.order_date || '').trim(),
+      due_date: String(parsed?.header?.due_date || '').trim(),
+      technique_label: '',
+    },
+    code: String(parsed.code || '').trim(),
+    items,
+    raw_text: content,
+  };
+}
+
+module.exports = { parseImageOrder };

--- a/apps/生产部/喷油部生产管理系统/server/services/pricing-importer.js
+++ b/apps/生产部/喷油部生产管理系统/server/services/pricing-importer.js
@@ -91,7 +91,12 @@ async function parsePricingSheet(filePath) {
     const fallbackCode = codeFromSheetName(sheet.name);
     const fallbackName = sheet.name.replace(/^[A-Za-z]?\d+[A-Za-z]?\d*\s*/, '').trim();
 
+    // 嵌套结构:同时有 cols.name(货名)+ cols.part_name(位置)+ cols.technique(工序),
+    // 此时「货名」列实为「款」(sub-product),需要拼到 part_name 前
+    const hasSubproduct = cols.name !== undefined && cols.part_name !== undefined && cols.technique !== undefined;
+
     let lastPartName = '';
+    let lastSubproduct = '';
 
     for (let r = headerRowIdx + 1; r <= sheet.rowCount; r++) {
       const row = sheet.getRow(r);
@@ -135,6 +140,19 @@ async function parsePricingSheet(filePath) {
       if (/^(合计|小计|总计)[\s:：]*$/.test(part_name)) continue;
       if (/^(货号|货名|位置|工序|工艺|目标数|人数|工价|核价|油漆价|总核价|报价|备注|图片)$/.test(part_name)) continue;
       lastPartName = part_name;
+
+      // 嵌套结构(货名+位置+工序):读 货名 列作 款,合并单元格则继承
+      if (hasSubproduct) {
+        const nameRaw = rowCellVal(row.getCell(cols.name + 1));
+        let sub = nameRaw ? String(nameRaw).trim() : '';
+        if (sub) lastSubproduct = sub;
+        else sub = lastSubproduct;
+        // 跳过把 货名 当 part_name 的伪行(没有真位置时,partRaw 等于 货名)
+        if (sub && part_name === sub) continue;
+        if (sub && !part_name.startsWith(sub + '·')) {
+          part_name = `${sub}·${part_name}`;
+        }
+      }
 
       const key = idPair.code;
       if (!productsMap.has(key)) {

--- a/docker-compose.cloud.yml
+++ b/docker-compose.cloud.yml
@@ -259,6 +259,8 @@ services:
       - PORT=3100
       - DATA_PATH=/app/data
       - NODE_ENV=production
+      # 阿里云百炼 (DashScope/Qwen-VL) — AI 订单图片识别用；和 paiji 共用同一把 Bailian key
+      - DASHSCOPE_API_KEY=${PENYOU_BAILIAN_API_KEY:-}
     volumes:
       - ./apps/生产部/喷油部生产管理系统/data:/app/data
     healthcheck:


### PR DESCRIPTION
## Summary

从 PR #123 抽出 penyou v2 feature commits 应用到 main 上现有路径 `apps/生产部/喷油部生产管理系统/`。

PR #123 因 stale base regression 不可合（fork point `aecf600`，main 已前进 20 commits，diff 静默 revert 了 PR #104/#105/#106/#107/#111/#113/#115/#117/#119/#121/#122 等 8+ 个已合 infra PR + 含 penyou 文件夹搬迁但缺 Dockerfile）。本 PR 仅取 commit `25677bb` 的功能改动，path-rewrite 应用到现有路径，3-way merge 保留 main 上的 `DATA_PATH` SQLite 硬化。

## v2 新功能

**后端**
- POST `/api/orders/import-image` — 百炼 qwen-vl-max 视觉模型从订单图片抽 `{货号, 部位, 数量}`，走 PDF 同套匹配/alias 流程
- `pdf_part_alias` 表 — 用户绑定一次未匹配部位后，同款下次自动套用
- `order_schedule_lines.sort_order` 列 + GET `/schedule-lines/flat` + PUT `/schedule-lines/reorder` 支持拖拽排序
- GET `/api/daily-records/export` — 导出 Excel（含合计行）
- `/api/orders/active` 改为「started_at 非空且未完成」语义，「点了排单才进每日录入」
- `pricing-importer` 支持嵌套款+位置+工序布局

**前端**
- Orders 页重做：扁平件表 + `@dnd-kit` 行拖拽手排 + 列内编辑（拉/数量/日产能）
- 「开始」→「排单」按钮，点击跳 `/daily-records`
- 导入 Modal 加 DatePicker 自定义起始日
- 未匹配部位下拉多选（从核价表挑），兜底手动新建
- DailyRecords 加「导出 Excel」按钮
- 上传 accept `.pdf,image/*`，按文件类型自动选 endpoint

**基础设施**
- `docker-compose.cloud.yml` penyou 加 `DASHSCOPE_API_KEY=${PENYOU_BAILIAN_API_KEY:-}` env passthrough，跟 paiji/baojia 一致的 Bailian 配置模式

## 部署后 TODO

ECS `.env.cloud.production` 加：
```
PENYOU_BAILIAN_API_KEY=<同 BAOJIA/PAIJI 的 Bailian key 即可>
```
不加也能部署，AI 图片识别功能会抛 `DASHSCOPE_API_KEY 未配置` 友好报错；其他所有功能（拖拽排单、Excel 导出、PDF 导入、排产、收支表）全部不受影响。

## Test plan

- [x] 3-way patch apply 无冲突，`DATA_PATH` SQLite 硬化保留
- [x] `git diff --stat origin/main` 只触碰 penyou + 1 行 compose
- [ ] CI 绿
- [ ] /penyou/api/health 200
- [ ] penyou 容器健康（无 restart loop）
- [ ] portal 首页 penyou 卡片可见且状态绿

---

原 PR: #123（关闭，superseded by this PR）
原作者: @duanlei10

🤖 Generated with [Claude Code](https://claude.com/claude-code)