### PR TITLE
fix(pi-outsource): npm ci → npm install (no lockfile)

### DIFF
--- a/apps/生产部/啤机外发系统/Dockerfile
+++ b/apps/生产部/啤机外发系统/Dockerfile
@@ -17,7 +17,7 @@ RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 WORKDIR /app
 
 COPY server/package.json server/
-RUN cd server && npm ci --omit=dev
+RUN cd server && npm install --omit=dev
 
 COPY server/ /app/server/
 COPY --from=frontend-build /build/client/dist /app/client/dist


### PR DESCRIPTION
## Summary
- Dockerfile used `npm ci` in the production stage, but `server/` has no `package-lock.json`
- Docker build step #16 failed with `EUSAGE`, silently — GHA deploy reported success but pi-outsource container was never created
- Fix: switch to `npm install --omit=dev`

## Root cause
`npm ci` requires an existing lockfile. The original repo didn't commit one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)