### PR TITLE
fix(deploy): add pi-outsource+penyou to PATH_TO_SERVICE; rebuild pi-outsource

### DIFF
--- a/apps/生产部/啤机外发系统/server/server.js
+++ b/apps/生产部/啤机外发系统/server/server.js
@@ -3,6 +3,7 @@ const express = require('express');
 const cors = require('cors');
 const path = require('path');
 const fs = require('fs');
+// v1.0.1
 const { nanoid } = require('nanoid');
 const multer = require('multer');
 const XLSX = require('xlsx');

--- a/deploy/update-server.sh
+++ b/deploy/update-server.sh
@@ -90,6 +90,8 @@ declare -A PATH_TO_SERVICE=(
   # 业务 app：按部门 nested。service 名保持英文（DNS/nginx 依赖）
   ["apps/生产部/注塑啤机排产系统/"]="paiji"
   ["apps/生产部/生产计划管理系统/"]="production-plan"
+  ["apps/生产部/喷油部生产管理系统/"]="penyou"
+  ["apps/生产部/啤机外发系统/"]="pi-outsource"
   ["apps/PMC跟仓管/配色库存管理/"]="peise"
   ["apps/PMC跟仓管/华登包材管理/"]="huadeng"
   ["apps/PMC跟仓管/采购订单管理系统/"]="jiangping"


### PR DESCRIPTION
## Summary
- `update-server.sh` PATH_TO_SERVICE was missing entries for `pi-outsource` and `penyou` (added in PRs #124/#100)
- Unmatched paths → NONRUNTIME_ONLY=1 → deploy silently skipped → pi-outsource container was never created
- Adds missing PATH_TO_SERVICE entries + bumps server.js v1.0.1 to trigger rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)