### PR TITLE
feat(huadeng-maorong): 纳入仓库 + 子货号关联 + deploy 防呆

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,8 @@ RR-Portal/
 │   │   ├── 采购订单管理系统/        — jiangping (Flask + EasyOCR)
 │   │   ├── 成品核对系统/            — liwenjuan (Flask)
 │   │   ├── 配色库存管理/            — peise (Flask)
-│   │   └── 华登包材管理/            — huadeng (Flask)
+│   │   ├── 华登包材管理/            — huadeng (Flask)
+│   │   └── 华登毛绒仓库/            — huadeng-maorong (Flask, 毛绒+戏服库存)
 │   ├── 生产部/
 │   │   ├── 注塑啤机排产系统/        — paiji (Node.js + React)
 │   │   ├── 喷油部生产管理系统/      — penyou (Node.js + React)
@@ -200,6 +201,7 @@ curl http://localhost:<port>/health
 | liwenjuan 成品核对系统 | Flask | 5004 | /liwenjuan/ |
 | peise 配色库存管理 | Flask | 5006 | /peise/ |
 | huadeng 华登包材管理 | Flask | 5007 | /huadeng/ |
+| huadeng-maorong 华登毛绒仓库 | Flask | 5009 | /huadeng-maorong/ |
 | hy-schedule-system ZURU河源排期入单 | Flask | 5008 | /hy-schedule/ |
 | baojia 报价系统 | Node.js | 3007 | /baojia/ |
 
@@ -448,6 +450,7 @@ const data = JSON.parse(fs.readFileSync('data/data.json'));
 | liwenjuan | 成品核对系统 | PMC跟仓管 | Standalone (Python/Flask) | /liwenjuan/ | — |
 | peise | 配色库存管理 | PMC跟仓管 | Standalone (Python/Flask) | /peise/ | https://github.com/fxxaxxx/peisecangku |
 | huadeng | 华登包材管理 | PMC跟仓管 | Standalone (Python/Flask) | /huadeng/ | — |
+| huadeng-maorong | 华登毛绒仓库 | PMC跟仓管 | Standalone (Python/Flask) | /huadeng-maorong/ | — |
 | hy-schedule-system | ZURU河源排期入单 | 业务部 | Standalone (Python/Flask) | /hy-schedule/ | https://github.com/hanson678/hy-schedule-system |
 | baojia | 报价系统 | 业务部 | Standalone (Node.js) | /baojia/ | — |
 

--- a/apps/PMC跟仓管/华登毛绒仓库/.gitignore
+++ b/apps/PMC跟仓管/华登毛绒仓库/.gitignore
@@ -1,0 +1,15 @@
+__pycache__/
+*.pyc
+*.pyo
+flask_session/
+backup/
+*.stackdump
+*.log
+# 运行时上传的排期表
+uploads/
+# 根目录野生 db 文件(正式 db 在 data/inventory.db)
+/inventory.db
+# 动态生成的字母款式图片
+static/schedule_images/*.png
+data/*
+!data/.gitkeep

--- a/apps/PMC跟仓管/华登毛绒仓库/API_DESIGN.md
+++ b/apps/PMC跟仓管/华登毛绒仓库/API_DESIGN.md
@@ -1,0 +1,250 @@
+# API 设计文档
+
+> 前端已经按这个调用,后端必须严格遵守。
+
+## 通用约定
+
+**请求格式**:所有 POST/PUT 请求 body 都是 JSON,`Content-Type: application/json`
+
+**字段命名**:
+- 前端 → 后端:**驼峰**(billNo)
+- 数据库 → 后端 → 前端:**下划线**(bill_no),前端用 `normalizeRecord()` 自动转
+
+**认证**:基于 Session Cookie,登录后 cookie 自动带上
+
+**错误响应**:
+```json
+{ "error": "错误信息" }
+```
+状态码:400(参数错)/ 401(未登录)/ 403(无权限)/ 404(不存在)/ 500(服务器错)
+
+**成功响应**:
+```json
+{ "success": true, ... }
+```
+
+---
+
+## 认证
+
+### POST /api/login
+**权限**:无需登录
+**请求**:`{ "username": "admin", "password": "123456" }`
+**响应**:
+```json
+{
+  "success": true,
+  "user": {"username": "admin", "role": "admin", "display_name": "系统管理员"}
+}
+```
+
+### POST /api/logout
+**权限**:需登录
+
+### GET /api/me
+**权限**:需登录
+**响应**:`{ "id": 1, "username": "admin", "role": "admin", "display_name": "..." }`
+
+---
+
+## 入库(已实现,作为参考)
+
+### GET /api/in
+**权限**:任何登录用户
+**Query 参数**:
+- `category`(可选):'plush' 或 'costume',筛选品类
+
+**响应**:数组,按日期倒序
+```json
+[
+  {
+    "id": 7,
+    "category": "plush",
+    "date": "2026-05-11",
+    "bill_no": "IN-007",
+    "sku": "HD-T003",
+    "name": "恐龙毛绒 20cm 绿色",
+    "style": "rare",
+    "flag": "日本",
+    "qty": 80,
+    "created_by": "admin",
+    "created_at": "2026-05-11 10:23:45"
+  }
+]
+```
+
+### POST /api/in
+**权限**:admin / operator
+**请求**:
+```json
+{
+  "category": "plush",
+  "date": "2026-05-12",
+  "billNo": "IN-008",
+  "sku": "HD-T001",
+  "name": "小熊毛绒 25cm 棕色",
+  "style": "normal",
+  "flag": "美国",
+  "qty": 500
+}
+```
+
+**戏服示例**:
+```json
+{
+  "category": "costume",
+  "date": "2026-05-12",
+  "billNo": "IN-201",
+  "sku": "CS-001",
+  "name": "小熊配套连衣裙",
+  "style": "M码连衣裙",
+  "flag": "美国",
+  "qty": 100
+}
+```
+
+**校验**:
+- category 必须是 'plush' 或 'costume'(默认 plush)
+- 毛绒 style 只能是 'normal' 或 'rare'
+- 戏服 style 是任意非空文本
+- qty 必须是正整数
+
+**响应**:`{ "success": true, "id": 8 }`
+
+### DELETE /api/in/{id}
+**权限**:admin
+**响应**:`{ "success": true }`
+
+---
+
+## 库存查询(已实现)
+
+### GET /api/stock
+**权限**:任何登录用户
+**Query 参数**:
+- `category`(可选):'plush' 或 'costume'
+
+**响应**:库存汇总数组
+```json
+[
+  {
+    "category": "plush",
+    "sku": "HD-T001",
+    "name": "小熊毛绒 25cm 棕色",
+    "style": "normal",
+    "flag": "美国",
+    "in_total": 800,
+    "out_total": 300,
+    "stock": 500
+  }
+]
+```
+
+---
+
+## 出库(待实现,与入库结构一致)
+
+### GET /api/out?category=plush|costume
+**权限**:任何登录用户
+
+### POST /api/out
+**权限**:admin / operator
+**请求**:
+```json
+{
+  "category": "plush",
+  "date": "2026-05-12",
+  "billNo": "OUT-004",
+  "po": "PO-2026-0501",
+  "picker": "王师傅",
+  "sku": "HD-T001",
+  "name": "小熊毛绒 25cm 棕色",
+  "style": "normal",
+  "flag": "美国",
+  "qty": 200
+}
+```
+
+**戏服示例**:
+```json
+{
+  "category": "costume",
+  "date": "2026-05-12",
+  "billNo": "OUT-201",
+  "po": "PO-2026-0501",
+  "picker": "李工",
+  "sku": "CS-001",
+  "name": "小熊配套连衣裙",
+  "style": "M码连衣裙",
+  "flag": "美国",
+  "qty": 50
+}
+```
+
+**校验**:同入库,但 po 和 picker 是可选字段(允许空字符串)
+
+### DELETE /api/out/{id}
+**权限**:admin
+
+---
+
+## 布标(待实现)
+
+### GET /api/flags
+**权限**:任何登录用户
+**响应**:字符串数组 `["中国", "美国", ...]`
+
+### POST /api/flags
+**权限**:admin
+**请求**:`{ "name": "荷兰" }`
+
+### DELETE /api/flags/{name}
+**权限**:admin
+**URL**:name 是中文,Flask 自动 URL-decode
+
+---
+
+## 用户管理(待实现)
+
+### GET /api/users
+**权限**:admin
+**响应**:用户数组(不含 password_hash)
+
+### POST /api/users
+**权限**:admin
+**请求**:
+```json
+{
+  "username": "newuser",
+  "password": "abc123",
+  "role": "operator",
+  "display_name": "张三"
+}
+```
+
+### DELETE /api/users/{id}
+**权限**:admin
+**约束**:不能删除自己
+
+### PUT /api/users/{id}/password
+**权限**:任何登录用户改自己 / admin 改任何人
+**请求**:`{ "old_password": "123456", "new_password": "abc123" }`
+**约束**:
+- 非 admin:user_id 必须等于自己的 id,且需要验证 old_password
+- admin:user_id 可以是任何人,old_password 字段可以省略
+
+---
+
+## 导出 CSV(待实现,可选)
+
+### GET /api/export/in?category=plush&from=2026-01-01&to=2026-12-31
+**权限**:任何登录用户
+**响应**:`Content-Type: text/csv; charset=utf-8`
+**响应头**:`Content-Disposition: attachment; filename=in_records_20260512.csv`
+**重要**:文件第一字节必须是 BOM (`\ufeff`),不然 Excel 会乱码
+
+### GET /api/export/out?category=plush&from=...&to=...
+同上
+
+### GET /api/export/stock?category=plush
+导出当前库存(按 货号+款式+布标 聚合)

--- a/apps/PMC跟仓管/华登毛绒仓库/DEPLOYMENT.md
+++ b/apps/PMC跟仓管/华登毛绒仓库/DEPLOYMENT.md
@@ -1,0 +1,109 @@
+# 部署指南
+
+> 给最终部署的人(可以是非程序员)
+
+## 第一次安装(在服务器电脑上做)
+
+### 1. 安装 Python
+
+下载 Python 3.10 或更高版本:https://www.python.org/downloads/
+
+**Windows 安装时务必勾选 "Add Python to PATH"**
+
+验证:CMD 输入 `python --version`,看到 `Python 3.10.x` 之类即可。
+
+### 2. 拷贝项目到服务器电脑
+
+随便找位置,如 `C:\huadeng_inventory\`,把整个项目文件夹复制过去。
+
+### 3. 安装依赖
+
+打开 CMD,进入项目目录:
+```
+cd C:\huadeng_inventory
+pip install -r requirements.txt
+```
+
+如果下载慢,用国内镜像:
+```
+pip install -r requirements.txt -i https://pypi.tuna.tsinghua.edu.cn/simple
+```
+
+### 4. 初始化数据库 + 跑测试
+
+```
+python init_db.py
+python test_logic.py
+```
+
+测试应该全绿(23/23 通过)。如果有红色,说明环境有问题。
+
+### 5. 启动服务
+
+双击 `start.bat`(Windows)。
+
+会看到:
+```
+访问地址:
+  本机:        http://localhost:5000
+  局域网其他人: http://<本机IP>:5000
+```
+
+### 6. 测试访问
+
+- 服务器本机:浏览器打开 http://localhost:5000
+- 其他电脑:打开 http://服务器IP:5000(IP 用 `ipconfig` 查)
+
+用 `admin / 123456` 登录,**首次登录后立即修改密码**!
+
+---
+
+## 找到服务器电脑的 IP
+
+CMD 输入 `ipconfig`,找 "IPv4 地址",一般是 `192.168.1.xxx` 这种。
+
+---
+
+## 防火墙(Windows)
+
+如果同事打不开,可能是防火墙拦了 5000 端口。
+
+打开 控制面板 → Windows Defender 防火墙 → 高级设置 → 入站规则 → 新建规则 → 端口 → TCP / 5000 → 允许。
+
+---
+
+## 开机自启(可选)
+
+Win+R 输入 `shell:startup` → 把 `start.bat` 的快捷方式拖进去。下次电脑开机自动启动服务。
+
+---
+
+## 数据备份(强烈建议)
+
+数据**只在 `data/inventory.db` 这一个文件里**。
+
+**最简单**:每周手动把 `data/inventory.db` 复制到 U 盘 / 网盘。
+
+**进阶**:让 Claude Code 帮你实现 P7 的备份脚本,设置 Windows 任务计划每天自动备份。
+
+---
+
+## 数据库文件可以直接看吗?
+
+可以!免费工具 [DB Browser for SQLite](https://sqlitebrowser.org/) 打开 `data/inventory.db` 就能直接看所有数据,做 SQL 查询。
+
+---
+
+## 换服务器电脑
+
+把整个项目目录复制过去,重新装 Python 依赖,运行 `python app.py` 即可。数据完全保留。
+
+---
+
+## 安全建议
+
+1. **改默认密码**!特别是 admin
+2. 每天备份 `data/inventory.db`
+3. 定期(3 个月)换密码
+4. 服务器电脑装杀毒软件
+5. **不要把这个服务暴露到公网**,只在公司内网用

--- a/apps/PMC跟仓管/华登毛绒仓库/Dockerfile
+++ b/apps/PMC跟仓管/华登毛绒仓库/Dockerfile
@@ -1,0 +1,30 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PIP_INDEX_URL=https://mirrors.aliyun.com/pypi/simple/
+ENV PIP_TRUSTED_HOST=mirrors.aliyun.com
+
+# gunicorn 用于生产（替代 waitress，跟 sibling Flask app 一致）
+RUN pip install --no-cache-dir gunicorn==21.2.0
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+# data/ 用 bind mount 覆盖，但镜像里需要存在目录占位以防裸跑
+RUN mkdir -p /app/data
+
+RUN addgroup --system appgroup && adduser --system --ingroup appgroup appuser && \
+    chown -R appuser:appgroup /app
+
+EXPOSE 5009
+
+USER appuser
+
+CMD ["gunicorn", "--bind", "0.0.0.0:5009", "--workers", "2", "--threads", "4", "--timeout", "120", "app:app"]

--- a/apps/PMC跟仓管/华登毛绒仓库/IMPLEMENTATION_PLAN.md
+++ b/apps/PMC跟仓管/华登毛绒仓库/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,592 @@
+# 实现计划(Claude Code 必读)
+
+> 这份文档是你的工作手册。**严格按顺序、按步骤完成每个任务。**
+>
+> 每个任务都有「完成标准」,不达标不能进入下一个任务。
+
+---
+
+## 总览:你要完成 8 个任务
+
+```
+[基础准备]
+□ 任务 0:环境验证(确认能跑起来)
+
+[核心功能]
+□ 任务 1:出库 API(P1,最重要)
+□ 任务 2:布标 API(P2)
+□ 任务 3:用户管理 API(P3)
+
+[前端完善]
+□ 任务 4:前端权限 UI(P5)
+□ 任务 5:用户管理页面(P6)
+
+[导出 & 部署]
+□ 任务 6:导出 CSV API(P4)
+□ 任务 7:数据备份脚本(P7)
+□ 任务 8:生产服务器配置(P8)
+```
+
+**估计总时长**:每个任务 15-40 分钟,全部完成 3-5 小时。
+
+---
+
+## ⚠️ 开始前的铁律(每个任务都适用)
+
+1. **每写完一段代码,先想:这会不会破坏已有功能?** 如果不确定,跑 `python test_logic.py` 验证
+2. **完成每个任务后,必须跑 `python test_logic.py`,全绿才能进入下一个任务**
+3. **不要修改 `database.py` 中的 `calculate_stock()` 函数**
+4. **不要修改 `test_logic.py` 中已有的测试用例**(你可以新增测试,但不能改已有的)
+5. **不要为了让测试通过而修改测试**,测试失败说明你的实现有问题
+6. **每个任务完成后,告诉用户「✓ 任务 X 完成」并简单说明做了什么**
+
+---
+
+## 📋 任务 0:环境验证
+
+### 目标
+确认你接手的项目能正常启动。
+
+### 步骤
+
+1. 进入项目目录
+2. 运行 `pip install -r requirements.txt`
+3. 运行 `python init_db.py` — 应该看到"初始化完成"
+4. 运行 `python test_logic.py` — 应该看到 **29 个测试全部通过**
+5. 运行 `python app.py` — 应该看到"http://localhost:5000"
+6. (可选)用浏览器访问,用 admin/123456 登录,确认登录页和主页能打开
+
+### 完成标准
+
+- [x] `python test_logic.py` 输出 `✓ 通过 29 个 / ✗ 失败 0 个`
+- [x] `python app.py` 能启动,无报错
+
+### 出问题怎么办
+
+- 测试失败 → **不要往下做**,先告诉用户,贴出报错信息
+- 安装依赖失败 → 让用户改用 `pip install -r requirements.txt -i https://pypi.tuna.tsinghua.edu.cn/simple`
+
+### 完成后说什么
+
+> ✓ 任务 0 完成。环境验证通过,29/29 测试绿,服务能启动。准备开始任务 1。
+
+---
+
+## 📋 任务 1:出库 API(最重要)
+
+### 为什么必须最先做
+
+前端的"录入出库"、"出库流水"、"货号细表显示出库"全部依赖这个 API。
+
+### 你要做的事
+
+**1. 在 `database.py` 中添加 3 个函数**(仿照入库的写法):
+
+- `query_all_out_records(category=None)` — 查询所有出库记录
+- `insert_out_record(data, username)` — 新增出库记录
+- `delete_out_record(record_id)` — 删除出库记录
+
+**关键点**:出库表比入库表多 `po`(PO 号)和 `picker`(领货人)两个字段。
+
+参考代码已经在 `REQUIREMENTS.md` 的 P1 部分给出,直接复制粘贴即可。
+
+**2. 在 `app.py` 中添加 3 个路由**:
+
+- `GET /api/out` — 任何登录用户,可带 `?category=plush|costume` 筛选
+- `POST /api/out` — admin/operator,新增
+- `DELETE /api/out/<id>` — admin,删除
+
+参考代码同样在 `REQUIREMENTS.md` 的 P1 部分。
+
+### 完成标准
+
+- [x] `python test_logic.py` 全 29 个测试通过(其中很多测试都用到了出库)
+- [x] 启动服务后,用 curl 或浏览器开发者工具能调通:
+  - `GET /api/out` 返回出库列表
+  - `POST /api/out` 能新增一条记录(后续 GET 能看到)
+  - `DELETE /api/out/<id>` 能删除
+
+### 验证脚本(任务完成后跑一遍)
+
+```bash
+# 登录(替换 cookie 文件路径)
+curl -c cookies.txt -X POST http://localhost:5000/api/login \
+  -H "Content-Type: application/json" \
+  -d '{"username":"admin","password":"123456"}'
+
+# 查询出库列表
+curl -b cookies.txt http://localhost:5000/api/out
+
+# 按品类筛选
+curl -b cookies.txt "http://localhost:5000/api/out?category=costume"
+
+# 新增一条出库
+curl -b cookies.txt -X POST http://localhost:5000/api/out \
+  -H "Content-Type: application/json" \
+  -d '{"category":"plush","date":"2026-05-13","billNo":"OUT-TEST","sku":"HD-T001","style":"normal","flag":"美国","qty":50}'
+```
+
+### 出问题怎么办
+
+- 测试失败 → 看错误信息,大多是字段名错了(注意:前端 camelCase → 后端 snake_case)
+- POST 返回 400 → 看错误信息,通常是缺字段或字段值不对
+
+### 完成后说什么
+
+> ✓ 任务 1 完成。出库 API(GET/POST/DELETE)已实现,29/29 测试通过。可以前往任务 2:布标 API。
+
+---
+
+## 📋 任务 2:布标 API
+
+### 你要做的事
+
+**1. 在 `database.py` 添加 3 个函数**(参考 `REQUIREMENTS.md` P2):
+
+- `query_all_flags()` — 返回字符串列表
+- `add_flag(name)` — 新增
+- `delete_flag(name)` — 删除
+
+**2. 在 `app.py` 添加 3 个路由**:
+
+- `GET /api/flags` — 任何登录用户,返回 `["中国","美国",...]`
+- `POST /api/flags` — admin
+- `DELETE /api/flags/<name>` — admin
+
+### 完成标准
+
+- [x] `python test_logic.py` 全 29 个测试通过
+- [x] 前端"布标维护"页面能正常显示布标列表
+- [x] 能在该页面新增 / 删除布标
+
+### 验证脚本
+
+```bash
+# 查询所有布标
+curl -b cookies.txt http://localhost:5000/api/flags
+# 应该看到: ["中国","美国","德国",...]
+
+# 新增布标(admin)
+curl -b cookies.txt -X POST http://localhost:5000/api/flags \
+  -H "Content-Type: application/json" \
+  -d '{"name":"荷兰"}'
+
+# 删除布标(admin,注意中文要 URL 编码)
+curl -b cookies.txt -X DELETE "http://localhost:5000/api/flags/%E8%8D%B7%E5%85%B0"
+```
+
+### 完成后说什么
+
+> ✓ 任务 2 完成。布标 API 已实现,29/29 测试通过。可以前往任务 3:用户管理 API。
+
+---
+
+## 📋 任务 3:用户管理 API
+
+### 你要做的事
+
+**1. 在 `database.py` 添加 5 个函数**:
+
+- `query_all_users()` — 返回所有用户(不含 password_hash)
+- `get_user_by_id(user_id)` — 按 ID 查询
+- `insert_user(username, password_hash, role, display_name)`
+- `delete_user(user_id)`
+- `update_user_password(user_id, new_password_hash)`
+
+参考代码在 `REQUIREMENTS.md` P3。
+
+**2. 在 `app.py` 添加 4 个路由**:
+
+- `GET /api/users` — admin
+- `POST /api/users` — admin,新增用户
+- `DELETE /api/users/<id>` — admin,**禁止删自己**
+- `PUT /api/users/<id>/password` — 任何登录用户改自己 / admin 改任何人
+
+**关键校验**:
+- username 4-20 字符
+- password 至少 4 位
+- role ∈ ('admin', 'operator', 'viewer')
+- 非 admin 改自己密码时必须验证 old_password
+
+### 完成标准
+
+- [x] `python test_logic.py` 全 29 个测试通过
+- [x] curl 测试通过(见下方验证脚本)
+- [x] 不能删除自己(返回 400)
+- [x] 普通用户改密码必须验证旧密码
+
+### 验证脚本
+
+```bash
+# 列出所有用户(admin)
+curl -b cookies.txt http://localhost:5000/api/users
+
+# 新增用户(admin)
+curl -b cookies.txt -X POST http://localhost:5000/api/users \
+  -H "Content-Type: application/json" \
+  -d '{"username":"tester","password":"abcd","role":"operator","display_name":"测试员"}'
+
+# 尝试删除自己(应该返回 400)
+curl -b cookies.txt -X DELETE http://localhost:5000/api/users/1
+
+# 改密码
+curl -b cookies.txt -X PUT http://localhost:5000/api/users/1/password \
+  -H "Content-Type: application/json" \
+  -d '{"old_password":"123456","new_password":"newpass"}'
+```
+
+### 完成后说什么
+
+> ✓ 任务 3 完成。用户管理 API 已实现,29/29 测试通过。后端 API 三大模块全部完成,准备开始前端任务。
+
+---
+
+## 📋 任务 4:前端权限 UI
+
+### 你要做的事
+
+打开 `templates/app.html`,找到 `<style>` 区域,在合适位置添加 CSS:
+
+```css
+/* 游客隐藏录入和删除按钮 */
+body[data-role="viewer"] .btn-in,
+body[data-role="viewer"] .btn-out,
+body[data-role="viewer"] .btn-danger { display: none !important; }
+
+/* 仓管员看不到删除 */
+body[data-role="operator"] .btn-danger { display: none !important; }
+
+/* admin-only 元素只 admin 可见 */
+body:not([data-role="admin"]) .admin-only { display: none !important; }
+```
+
+然后在 HTML 里:
+- 给"布标维护"导航项的 `<div class="nav-item">` 加上 `admin-only` class
+
+### 完成标准
+
+- [x] 用 viewer 登录,看不到任何"录入"和"删除"按钮
+- [x] 用 operator 登录,能录入但看不到"删除"按钮
+- [x] 用 admin 登录,所有功能正常
+
+### 验证方法
+
+依次用三个账号登录,检查页面:
+- viewer/123456 → 全只读
+- warehouse/123456 → 能录入,不能删
+- admin/123456 → 全部权限
+
+### 完成后说什么
+
+> ✓ 任务 4 完成。前端按角色自动隐藏对应按钮,三个角色权限正确。准备开始任务 5。
+
+---
+
+## 📋 任务 5:用户管理页面
+
+### 你要做的事
+
+在 `templates/app.html` 添加一个新页面 `users`(管理员可见)。
+
+**1. 在侧边栏导航加入口**(放在"基础数据"那一组,在"布标维护"下面):
+
+```html
+<div class="nav-item admin-only" data-page="users" onclick="navigate('users')">
+  <span class="nav-icon">👤</span><span>用户管理</span>
+</div>
+```
+
+**2. 在 JS 里加 `navigate('users')` 的处理**和 `renderUsers()` 函数。
+
+参考布标维护页面(`renderFlags()`)的写法,做一个用户列表:
+
+- 表格列:用户名 / 显示名 / 角色 / 创建时间 / 操作(改密码 / 删除)
+- 上方一个"+ 新增用户"按钮 → 弹窗(用户名 / 密码 / 角色 / 显示名)
+- 改密码按钮 → 弹窗(新密码)
+- 删除按钮 → 确认后调 DELETE
+- **不能删除自己**(前端隐藏当前用户的删除按钮)
+
+### 完成标准
+
+- [x] admin 登录后能看到"用户管理"导航项
+- [x] 能列出所有用户
+- [x] 能新增用户
+- [x] 能改任意用户的密码
+- [x] 能删除其他用户,但不能删自己
+- [x] viewer 和 operator 登录时看不到"用户管理"入口(因为有 admin-only class)
+
+### 完成后说什么
+
+> ✓ 任务 5 完成。用户管理页面已实现,所有 CRUD 操作正常,自身保护生效。准备开始任务 6:导出 CSV。
+
+---
+
+## 📋 任务 6:导出 CSV API
+
+### 你要做的事
+
+在 `app.py` 添加 3 个导出路由:
+
+- `GET /api/export/in?from=...&to=...&category=...` — 导出入库
+- `GET /api/export/out?from=...&to=...&category=...` — 导出出库
+- `GET /api/export/stock?category=...` — 导出当前库存
+
+**关键技术点**:
+
+1. CSV 文件**第一字节必须是 BOM** (`\ufeff`),否则 Excel 打开中文会乱码
+2. 响应头:
+   - `Content-Type: text/csv; charset=utf-8`
+   - `Content-Disposition: attachment; filename=xxx.csv`(filename 要 URL 编码,因为可能含中文)
+
+参考代码:
+
+```python
+from flask import Response
+from urllib.parse import quote
+import csv
+import io
+
+@app.route('/api/export/in', methods=['GET'])
+@login_required
+def api_export_in():
+    category = request.args.get('category')
+    date_from = request.args.get('from')
+    date_to = request.args.get('to')
+
+    records = db.query_all_in_records(category=category)
+    if date_from:
+        records = [r for r in records if r['date'] >= date_from]
+    if date_to:
+        records = [r for r in records if r['date'] <= date_to]
+
+    # 生成 CSV
+    output = io.StringIO()
+    output.write('\ufeff')  # BOM
+    writer = csv.writer(output)
+    writer.writerow(['品类','日期','单号','货号','物料名称','款式','布标','数量'])
+    for r in records:
+        writer.writerow([
+            '毛绒' if r['category']=='plush' else '戏服',
+            r['date'], r['bill_no'], r['sku'], r.get('name',''),
+            '普通款' if r['style']=='normal' else '稀有款' if r['style']=='rare' else r['style'],
+            r['flag'], r['qty']
+        ])
+
+    filename = f'入库流水_{datetime.now().strftime("%Y%m%d")}.csv'
+    return Response(
+        output.getvalue(),
+        mimetype='text/csv; charset=utf-8',
+        headers={'Content-Disposition': f"attachment; filename*=UTF-8''{quote(filename)}"}
+    )
+```
+
+### 完成标准
+
+- [x] 访问 `/api/export/in` 能下载 CSV
+- [x] Excel 打开 CSV 中文不乱码
+- [x] `?category=plush` 能筛选品类
+- [x] `?from=2026-05-01&to=2026-05-10` 能筛选日期
+
+### 完成后说什么
+
+> ✓ 任务 6 完成。后端 CSV 导出(入库/出库/库存)已实现,中文无乱码。准备开始任务 7。
+
+---
+
+## 📋 任务 7:数据备份脚本
+
+### 你要做的事
+
+在项目根目录创建 `backup.py`:
+
+```python
+"""
+数据库备份脚本
+使用:python backup.py
+建议设置为定时任务每天凌晨 2 点跑
+"""
+import shutil
+from datetime import datetime, timedelta
+import os
+import glob
+
+BACKUP_DIR = 'backup'
+KEEP_DAYS = 30
+DB_PATH = 'data/inventory.db'
+
+
+def backup():
+    os.makedirs(BACKUP_DIR, exist_ok=True)
+
+    if not os.path.exists(DB_PATH):
+        print(f'✗ 数据库文件不存在: {DB_PATH}')
+        return False
+
+    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+    dst = f'{BACKUP_DIR}/inventory_{timestamp}.db'
+    shutil.copy2(DB_PATH, dst)
+    size_kb = os.path.getsize(dst) / 1024
+    print(f'✓ 备份完成: {dst} ({size_kb:.1f} KB)')
+
+    # 删除 30 天前的备份
+    cutoff = datetime.now() - timedelta(days=KEEP_DAYS)
+    cleaned = 0
+    for f in glob.glob(f'{BACKUP_DIR}/inventory_*.db'):
+        if datetime.fromtimestamp(os.path.getmtime(f)) < cutoff:
+            os.remove(f)
+            cleaned += 1
+    if cleaned:
+        print(f'✓ 清理了 {cleaned} 个 {KEEP_DAYS} 天前的旧备份')
+
+    return True
+
+
+if __name__ == '__main__':
+    backup()
+```
+
+### 完成标准
+
+- [x] `python backup.py` 能成功备份
+- [x] `backup/` 目录会出现一个 `inventory_YYYYMMDD_HHMMSS.db` 文件
+
+### 完成后说什么
+
+> ✓ 任务 7 完成。备份脚本已就位,可手动 `python backup.py` 或设置定时任务。准备开始最后一个任务。
+
+---
+
+## 📋 任务 8:生产服务器(waitress)
+
+### 你要做的事
+
+**1. 创建 `serve.py`**:
+
+```python
+"""
+生产服务器(waitress)
+比 Flask 自带的开发服务器更稳定,适合多人并发访问
+"""
+from waitress import serve
+from app import app
+
+if __name__ == '__main__':
+    print('=' * 50)
+    print('华登库存管理系统 - 生产服务器')
+    print('=' * 50)
+    print()
+    print('访问地址:')
+    print('  本机:        http://localhost:5000')
+    print('  局域网其他人: http://<本机IP>:5000')
+    print()
+    print('按 Ctrl+C 停止服务')
+    print('=' * 50)
+
+    serve(app, host='0.0.0.0', port=5000, threads=8)
+```
+
+**2. 更新 `start.bat`**:把 `python app.py` 改为 `python serve.py`
+
+**3. 更新 `start.sh`**:同上
+
+### 完成标准
+
+- [x] `python serve.py` 能正常启动
+- [x] 浏览器访问能正常使用
+- [x] 双击 `start.bat` 启动正常
+
+### 完成后说什么
+
+> ✓ 任务 8 完成。生产服务器已配置,启动脚本已更新。
+>
+> 🎉 全部 8 个任务完成!整个系统已经可以投入使用。
+>
+> **建议用户接下来做的事**:
+> 1. 用 admin 登录,在用户管理里修改默认密码
+> 2. 把项目部署到公司专用电脑
+> 3. 设置 Windows 任务计划每天自动跑 `python backup.py`
+> 4. 开放防火墙 5000 端口,让局域网其他电脑能访问
+
+---
+
+## 🛡 整个过程要遵守的原则
+
+### ✅ 该做的
+
+- 每个任务完成后跑 `python test_logic.py`,**全 29 个测试通过才能算完成**
+- 保持代码风格和已有代码一致(中文注释、简单清晰)
+- 遇到不确定的设计,**先问用户,不要擅自决定**
+- 每个任务完成后给用户一个简短的总结
+
+### ❌ 绝对不做的
+
+- 不要修改 `calculate_stock()` 函数
+- 不要修改 `test_logic.py` 已有的测试
+- 不要在数据库添加 "库存数量" 字段(永远是计算出来的)
+- 不要引入新的 Python 库(只用 Flask + SQLite + waitress)
+- 不要引入前端框架(React/Vue 等)
+- 不要做单号自动生成(用户要求手动填)
+- 不要加 BOM / 配比 / 多仓联动这些复杂业务概念
+
+---
+
+## 🐛 出问题怎么办
+
+| 现象 | 排查方向 |
+|---|---|
+| 测试失败 | 看测试报错信息,**绝大多数是字段名错了**(camelCase vs snake_case) |
+| API 返回 500 | 看后端 console 错误堆栈,通常是 SQL 语法或字段名问题 |
+| API 返回 401 | 没登录,先 POST `/api/login` |
+| API 返回 403 | 权限不够,换 admin 账号 |
+| 前端调用 API 失败 | 看浏览器开发者工具 Network,查看返回内容 |
+| 中文乱码 | CSV 要加 BOM,数据库要 UTF-8 |
+
+**遇到任何无法解决的问题,立即停下来问用户,不要瞎改。**
+
+---
+
+## 📞 沟通规范
+
+每个任务完成后,用类似格式向用户汇报:
+
+```
+✓ 任务 X 完成
+
+做了什么:
+- 在 database.py 添加 3 个函数(query_all_out_records / insert_out_record / delete_out_record)
+- 在 app.py 添加 3 个路由(GET/POST/DELETE /api/out)
+
+验证结果:
+- python test_logic.py:✓ 29/29 通过
+- curl 测试:✓ 通过
+
+下一步:任务 Y(布标 API)
+```
+
+如果遇到问题:
+
+```
+⚠ 任务 X 遇到问题
+
+现象:[具体描述]
+我尝试了:[已经尝试的方案]
+请问:[需要用户决定的事]
+```
+
+---
+
+## 🏁 全部完成的标志
+
+当 8 个任务都打 ✓ 后,系统就完整了。这时候应该:
+
+1. 跑完整测试 `python test_logic.py`,29/29 通过
+2. 启动服务 `python serve.py`,能正常访问
+3. 用三个角色(admin/operator/viewer)分别登录测试,功能符合权限
+4. 录入几条数据,看库存计算正确
+5. 删除一条记录,看库存自动重算
+6. 导出 CSV,Excel 打开正常
+7. 跑一次备份 `python backup.py`,文件正确生成
+
+全部通过后,告诉用户:
+
+> 🎉 系统已经完整可用,可以部署到生产环境了!

--- a/apps/PMC跟仓管/华登毛绒仓库/PROJECT_NOTES.md
+++ b/apps/PMC跟仓管/华登毛绒仓库/PROJECT_NOTES.md
@@ -1,0 +1,135 @@
+# 项目笔记 - 后续迭代记录
+
+> 记录骨架 8 个任务完成之后,在原系统上做的所有功能扩展、设计决定、字段约定。
+> 每次对话补充新内容时,按时间倒序追加到文件顶部。
+
+---
+
+## 当前架构概览
+
+**端口**:5002(`serve.py` 和 `app.py` 里写死,如需改一并改两处)
+
+**已有页面**(导航顺序):
+- 库存总览 / 入库流水 / 出库流水
+- 货号细表(点 SKU 进入)
+- 布标维护(admin only)
+- 用户管理(admin only)
+- **排期对比**(所有人可见)
+- **字母绑定**(所有人可见,改/删 viewer 隐藏)
+- **布标映射**(所有人可见,改/删 viewer 隐藏)
+- 导出 Excel
+
+---
+
+## 关键数据模型
+
+### `po_schedules`(排期表)
+来自 `xlsx` 上传,**整库替换**式入库。
+
+| 字段 | 说明 |
+|---|---|
+| series | sheet 名(如 `15758二代`) |
+| po_no | D 列 PO 号 |
+| item_code | G 列 ITEM#(`15758-S001`、`15758A-S001` 等) |
+| customer_sku | F 列 SKU(客户内部,如 `4500159232-190`) |
+| variant_letter | 单款字母(拼盘行为空,看 letters_json) |
+| qty | I 列 PO 数量 |
+| customer | B 列 |
+| country | C 列(走货国家) |
+| **flag_type** | 排期布标类型(`MA布标 / 客版布标`),按 AM/AN 列哪列有数判定,fallback 到 AL 标签列 |
+| **flag** | `{flag_type}-{country}` 拼接,如 `MA布标-美国` |
+| **ratio_normal_text** | AU 列(`每款的23/24` 等) |
+| **ratio_rare_text** | AV 列(`每款的1/24` 等) |
+| **letters_json** | 字母分布 JSON:`[{letter:"A",qty:30,image_url:"/static/.../A.png"}]`,**不拆开存** |
+| name_cn | H 列中文名 |
+| plan_ship_date | M 列计划出货期 |
+| image_url | 单款行的图(SKU 视图用) |
+
+### `letter_bindings`(字母绑定主数据)
+用户手动维护,UNIQUE(sku, letter)。
+
+| 字段 | 说明 |
+|---|---|
+| sku | **纯数字货号**(如 `15758`),不是带后缀的 ITEM# |
+| letter | A / B / D / E / G / H / J / K / L 等 |
+| material_name | 入库时填的物料名(如 `小杏怪`) |
+
+**匹配规则**:排期 ITEM# 用正则 `^(\d+)` 提取数字前缀 → 跟 `letter_bindings.sku` 匹配 → 查到 `material_name` → 用 `(sku, name, style, flag)` 4 维查库存。
+
+### `flag_mappings`(布标映射)
+UNIQUE(flag_type, country)。
+
+| 字段 | 说明 |
+|---|---|
+| flag_type | 排期里布标类型(`MA布标` / `客版布标` ...) |
+| country | 排期里国家(`美国` / `英国` ...) |
+| inventory_flag | 库存里实际录入的布标(`MA标美国版` / `客标美国` ...) |
+
+排期对比时,把排期 `(flag_type, country)` 翻译成 `inventory_flag` 后再查库存。没配映射就 fallback 用 `{flag_type}-{country}` 拼接。
+
+---
+
+## 排期 xlsx 解析规则
+
+- **sheet 筛选**:首字符是数字的 sheet 才解析(自动过滤 `半成品MA / 包装MA / 布料MA / 取消订单`)
+- **表头**:跨 R3+R4 合并扫描(`每款普通款数量` 在 R3,`PO号` 等在 R4)
+- **蓝色字体跳过**:R<80 G<80 B>150 RGB 判定 = 已完货
+- **不拆开**:每行 1 条 DB 记录,字母分布塞 letters_json
+- **同货号配比回退**:AU/AV 空时,用同数字前缀 sku 上一行的比例
+- **比例字符串**:支持 `N/M` 分数、`减去稀有款`、纯数字 3 种
+- **兜底**:AU/AV 都失败时,全部归普通款,标 `ratio_assumed=true`
+- **图片**:从每张 sheet 的 `_images`(产品缩略图)抽取,SHA1 hash 去重存到 `static/schedule_images/`
+
+---
+
+## 视图视图
+
+### 排期对比页(`renderSchedule`)
+- 上传按钮(admin+operator 见,viewer 不见)
+- PO 号 / ITEM# / 客户 SKU 三种值都能搜
+- 返回 `type`:`po` / `sku` / `none`
+  - **PO 视图**:每个 ITEM# 一行,按比例拆成 **普通款需求 / 稀有款需求 两个表**
+  - **SKU 视图**:每个 PO 行展开为字母 chips,同样**普通/稀有两表**
+- 每行展示:货号 / 字母(带产品图) / 物料 / 库存布标(翻译后,如不同显示排期原文) / 比例文本 / 计划 / 库存 / 缺口 / 够否
+
+### 字母绑定页(`renderBindings`)
+- 主数据风格:列表 + 新增/改/删按钮
+- 弹窗里物料名建议来自该 sku 已入库的 distinct name(`materials_by_sku`)
+- 字母只允许 A-Z 单字母大写
+
+### 布标映射页(`renderFlagMappings`)
+- 已映射 + 待映射(从已上传排期里抽 `(flag_type, country)` 组合)
+- 弹窗里"库存布标"输入框 datalist 从 `布标维护` 拉建议
+
+---
+
+## 入库 / 出库
+
+- 录入弹窗去掉了 placeholder("如: IN-008" 等)
+- 加了"清空"按钮
+- 编辑功能:每行 [编辑][删除],PUT `/api/in/<id>` 和 `/api/out/<id>`,admin+operator 可编辑
+- 录入时 SKU 字段填**纯数字货号**(15758),物料名填具体款(小杏怪)
+- 布标字段填**库存约定的拼接名**(如 `MA标美国版`)
+
+---
+
+## 其他功能扩展
+
+- **货号细表导出**:每个货号一个 xlsx,入库/出库 各一个 sheet,矩阵布局(行 = 单据,列 = 款式×布标)
+- **数据库备份**:`python backup.py`(保留 30 天)
+- **生产服务器**:`python serve.py`(waitress,8 线程,端口 5002)
+
+---
+
+## 测试
+
+- `python test_logic.py` → 29/29 应当全过(每次改动都验证)
+- 不要改 `calculate_stock` 和已有 29 个测试
+
+---
+
+## 仍可改进的方向
+
+- 排期对比里,多 PO 排队时按出货期累计扣库存(目前每个 PO 独立看库存,不互相扣减)
+- 字母绑定页可加批量导入(CSV)避免一条条填
+- 布标映射页可加批量配置("MA布标 + 所有国家 → MA标XX版" 模板生成)

--- a/apps/PMC跟仓管/华登毛绒仓库/README.md
+++ b/apps/PMC跟仓管/华登毛绒仓库/README.md
@@ -1,0 +1,231 @@
+# 华登塑胶 · 库存管理系统(毛绒 + 戏服)
+
+> 给 Claude Code:请按这个顺序阅读
+> 1. **`IMPLEMENTATION_PLAN.md`** ⭐ — 你的工作手册,有 8 个明确任务和验证标准,按它走
+> 2. 本文档(README.md)— 全局认知
+> 3. REQUIREMENTS.md — 每个任务的代码参考
+> 4. API_DESIGN.md — 接口约定
+> 5. 先跑一次 `python test_logic.py` 确认基础环境无误,再开始改
+
+## 项目背景
+
+东莞华登塑胶制品有限公司(清溪镇)的库存管理系统,管理两类产品:
+
+- **毛绒玩具**(主要业务):接收毛绒厂送来的成品玩具,按订单出货
+- **戏服**(配套产品):跟毛绒配套的衣服(连衣裙、T恤、外套等),按尺码 / 类型管理
+
+**核心痛点**:之前用 Excel 管理,容易出错、对账难、多人协作冲突。
+
+**最终用户**:5 人以内,角色分主管 / 仓管员 / 游客。
+
+## 技术栈
+
+- **后端**:Python 3.10+ / Flask 3.0
+- **数据库**:SQLite(单文件,零配置)
+- **前端**:原生 HTML + JavaScript(无框架)
+- **部署**:公司局域网内一台专用电脑,内网 IP 访问
+
+**技术选型理由**:**简单可维护**。这是给一个小厂用的内部工具,过度工程是大忌。
+
+## 数据模型(必须严格遵守)
+
+### 双品类设计
+
+出入库流水共用一套表,通过 `category` 字段区分品类:
+
+| category 值 | 含义 | 货号示例 | 款式/类型字段 | 布标字段 |
+|---|---|---|---|---|
+| `plush` | 毛绒 | HD-T001、HD-T002... | 只能是 `normal`(普通款) 或 `rare`(稀有款) | **必填**(按国家命名) |
+| `costume` | 戏服 | CS-001、CS-002... | 自由文本,如 "M码连衣裙"、"L码外套" | **没有此字段**(后端存空字符串 `''`,前端隐藏) |
+
+**⚠ 重要规则**:
+- 录入戏服时,前端不显示布标字段,后端自动把 `flag` 设为 `''`
+- 戏服的库存维度是「品类 + 货号 + 类型」(三级);毛绒是「品类 + 货号 + 款式 + 布标」(四级)
+- 数据库 schema 上 `flag` 字段对两类都保留(`NOT NULL DEFAULT ''`),只是戏服永远存空字符串
+
+### 四级唯一性
+
+**一个库存单元由四个维度唯一确定**:
+
+```
+category + sku + style + flag
+```
+
+例如:
+- 毛绒 / HD-T001 / 普通款 / 美国 → 库存 X
+- 毛绒 / HD-T001 / 普通款 / 德国 → 库存 Y(独立)
+- 毛绒 / HD-T001 / 稀有款 / 日本 → 库存 Z(独立)
+- 戏服 / CS-001 / M码连衣裙 / 美国 → 库存 W(完全独立)
+
+### 库存计算公式(必须严格按这个实现)
+
+```
+库存数量 = SUM(入库.qty) - SUM(出库.qty)
+WHERE category=? AND sku=? AND style=? AND flag=?
+```
+
+**注意**:库存数量不单独存字段,每次查询时从流水实时计算!这样不会出现"库存数据"和"流水数据"对不上的问题。
+
+## 字段定义(客户已确认,不要随便改)
+
+### 入库表 in_records
+
+| 字段 | 类型 | 必填 | 说明 |
+|---|---|---|---|
+| id | INTEGER | 自动 | 主键自增 |
+| category | TEXT | 是 | 'plush' 或 'costume',默认 plush |
+| date | TEXT | 是 | 'YYYY-MM-DD' |
+| bill_no | TEXT | 是 | 单号(手动填) |
+| sku | TEXT | 是 | 货号 |
+| name | TEXT | 否 | 物料名称 |
+| style | TEXT | 是 | 毛绒:normal/rare;戏服:自由文本 |
+| flag | TEXT | 是 | 布标(国家) |
+| qty | INTEGER | 是 | 数量,必须 > 0 |
+| created_by | TEXT | 自动 | 创建人 |
+| created_at | TEXT | 自动 | 创建时间 |
+
+### 出库表 out_records
+
+入库表所有字段 + 以下两个:
+
+| 字段 | 类型 | 必填 | 说明 |
+|---|---|---|---|
+| po | TEXT | 否 | PO 号(手动填,可空) |
+| picker | TEXT | 否 | 领货人(可空) |
+
+## 三种角色权限
+
+| 角色 | 英文标识 | 权限范围 |
+|---|---|---|
+| 主管 | `admin` | 所有功能 + 用户管理 + 布标管理 + 删除记录 |
+| 仓管员 | `operator` | 录入出入库 + 查看所有数据 + 导出 |
+| 游客 | `viewer` | 只读所有数据 + 导出 |
+
+**默认账号**(`init_db.py` 自动创建,首次启动后必须改密码):
+
+| 用户名 | 密码 | 角色 |
+|---|---|---|
+| admin | 123456 | 主管 |
+| warehouse | 123456 | 仓管员 |
+| viewer | 123456 | 游客 |
+
+## 防错指引(重要!给 Claude Code 看)
+
+### 1. 写代码前先读 test_logic.py
+
+`test_logic.py` 包含 29 个测试用例,覆盖核心计算逻辑。你写的任何代码不能让这些测试失败。
+
+```bash
+python test_logic.py
+```
+
+**通过标志**:看到 `✓ 全部测试通过!`
+
+### 2. 不要存"库存数量"字段
+
+库存永远是计算出来的,不能存。否则会出现入库流水和库存数据对不上的问题。
+
+✅ 正确:`SELECT SUM(qty) FROM in_records WHERE ... - SELECT SUM(qty) FROM out_records WHERE ...`
+
+❌ 错误:维护一个 `stock` 表/字段,出入库时手动加减
+
+### 3. 严格区分品类的款式校验
+
+毛绒款式必须严格校验为 `normal` 或 `rare`,戏服则不限。
+
+```python
+# 正确示例
+if category == 'plush' and style not in ('normal', 'rare'):
+    return error('毛绒款式必须是 normal 或 rare')
+# 戏服 style 任意文本都接受
+```
+
+### 4. 删除流水后库存自动重算
+
+不需要写额外代码,库存是实时计算的。删除一笔流水后,下一次查询自动得到新值。
+
+### 5. 不要做的事
+
+❌ 不要加 BOM / 配比 / 多仓联动这些复杂逻辑,华登业务不需要
+❌ 不要自动生成单号(用户明确要求手动)
+❌ 不要引入 React / Vue 等前端框架
+❌ 不要把 SQLite 换成 MySQL,5 个人用 SQLite 完全够
+❌ 不要做软删除,直接物理删除
+❌ 不要把毛绒和戏服分成两套表,共用一套表 + category 字段是正确做法
+
+## 项目结构
+
+```
+huadeng_inventory/
+├── app.py              # Flask 主程序(骨架,含登录 + 入库 + 库存查询)
+├── database.py         # 数据库操作模块(已完成核心计算函数)
+├── auth.py             # 认证 / 权限装饰器(已完成)
+├── init_db.py          # 数据库初始化脚本
+├── test_logic.py       # ⭐ 自动化测试脚本(29 个用例,必须通过)
+├── requirements.txt    # Python 依赖
+├── start.bat            # Windows 启动脚本
+├── start.sh             # Mac/Linux 启动
+├── templates/
+│   ├── login.html      # 登录页(已完成)
+│   └── app.html        # 主应用(已完成,从 V3 改造,支持双品类切换)
+├── data/
+│   └── inventory.db    # SQLite 数据库(首次运行自动创建)
+├── README.md                   # 本文档
+├── IMPLEMENTATION_PLAN.md      # ⭐ Claude Code 工作手册(8 个任务,按顺序做)
+├── REQUIREMENTS.md             # 详细需求 + 代码参考
+├── API_DESIGN.md               # API 接口约定
+└── DEPLOYMENT.md               # 部署文档
+```
+
+## 开发状态
+
+### ✅ 已完成
+
+- 数据库设计(双品类、四维度库存模型)
+- 核心库存计算函数(`calculate_stock`, `get_stock_summary`)
+- 用户认证(登录 / 登出 / 权限装饰器)
+- 入库 API 完整实现(增 / 删 / 查,支持品类筛选)
+- 库存查询 API
+- 自动化测试脚本(29 个用例)
+- 前端 UI(品类切换、货号细表、表单)
+
+### ⏳ 待开发(按优先级)
+
+详见 `REQUIREMENTS.md`,优先级:
+
+1. **出库 API**(`/api/out` 的 GET / POST / DELETE)— 仿照 `/api/in`
+2. **布标 API**(`/api/flags` 的 GET / POST / DELETE)
+3. **用户管理 API**(列表 / 新增 / 删除 / 改密码)
+4. **导出 CSV API**(可选,前端已有 JS 版本)
+5. **数据备份脚本**(自动每天备份 SQLite)
+6. **生产部署优化**(用 waitress 替代开发服务器)
+
+## 启动方式
+
+**首次启动**:
+```bash
+# 安装依赖
+pip install -r requirements.txt
+
+# 初始化数据库(创建表 + 默认账号 + 示例数据)
+python init_db.py
+
+# 运行测试(确认代码无误)
+python test_logic.py
+
+# 启动服务
+python app.py
+```
+
+**之后启动**:双击 `start.bat`(Windows)或 `./start.sh`(Mac/Linux)
+
+访问:`http://localhost:5000`
+
+## 给 Claude Code 的协作建议
+
+1. **每写完一个功能,都跑一遍 `python test_logic.py`**,确保没有破坏现有逻辑
+2. **写新功能前,先查看 `API_DESIGN.md`** 看接口约定
+3. **遇到不确定的设计,先查 `REQUIREMENTS.md` 和本 README,实在不清楚再问用户**
+4. **保持代码风格和现有代码一致**(中文注释、简单清晰、不要过度抽象)
+5. **不要引入新的 Python 库**(除非用户同意)
+6. **每次提交前**:确保 `python test_logic.py` 全部通过 + `python app.py` 能正常启动

--- a/apps/PMC跟仓管/华登毛绒仓库/REQUIREMENTS.md
+++ b/apps/PMC跟仓管/华登毛绒仓库/REQUIREMENTS.md
@@ -1,0 +1,272 @@
+# 需求清单(给 Claude Code)
+
+> 按本清单的优先级顺序实现,每完成一个任务后**必须**跑 `python test_logic.py` 确认没破坏现有逻辑。
+
+## 测试为先!
+
+**在动手写任何代码之前**,先跑一次:
+```bash
+python test_logic.py
+```
+应该看到 `✓ 全部测试通过!`(29 个用例全绿)
+
+**每次写完一个 API**,再跑一次 `test_logic.py`,确认没有破坏现有逻辑。
+
+如果加了新功能,**主动给 test_logic.py 加测试用例**(参考现有写法)。
+
+---
+
+## 优先级 1:出库 API(必做)
+
+### database.py 加三个函数
+
+```python
+def query_all_out_records(category=None):
+    """查询出库记录,按日期倒序。category 可选筛选品类"""
+    # 仿照 query_all_in_records,但查 out_records 表
+
+def insert_out_record(data, username):
+    """新增出库记录,字段比入库多 po(可空) 和 picker(可空)"""
+    # 仿照 insert_in_record,SQL 多 po 和 picker 两个字段
+
+def delete_out_record(record_id):
+    """删除出库记录"""
+    # 仿照 delete_in_record
+```
+
+### app.py 加三个 API
+
+- `GET /api/out?category=plush|costume` — `@login_required`,所有角色可看
+- `POST /api/out` — `@role_required('admin', 'operator')`
+- `DELETE /api/out/<int:record_id>` — `@role_required('admin')`
+
+### 字段校验规则(必须严格按这个写)
+
+```python
+# 1. 必填:date, billNo, sku, style, flag, qty
+# 2. 可选:po, picker, name
+# 3. category 默认 'plush',只能是 'plush' 或 'costume'
+# 4. 如果是毛绒,style 必须是 'normal' 或 'rare'
+# 5. 如果是戏服,style 是自由文本(非空即可)
+# 6. qty 必须是正整数
+```
+
+### 测试
+
+完成后跑 `test_logic.py`,然后手动测试:
+
+```bash
+# 启动服务
+python app.py
+
+# 浏览器打开 http://localhost:5000
+# 用 admin/123456 登录
+# 进入"出库流水",尝试录入一笔
+# 切换"戏服"品类,再录一笔(注意 style 字段是自由文本)
+```
+
+**新增测试用例**(可选但推荐):在 `test_logic.py` 加测试,验证:
+- 出库 API 能正常插入毛绒和戏服记录
+- 出库后库存数量正确减少
+- 删除出库记录后库存恢复
+
+---
+
+## 优先级 2:布标 API
+
+### database.py
+
+```python
+def query_all_flags():
+    """返回布标名称数组(按 sort_order 排序)"""
+    # SELECT name FROM flags ORDER BY sort_order, id
+
+def add_flag(name):
+    """新增布标,sort_order 自动取当前最大值+1"""
+    # 先 SELECT MAX(sort_order),再 INSERT
+
+def delete_flag(name):
+    """按名称删除布标"""
+    # DELETE FROM flags WHERE name = ?
+```
+
+### app.py
+
+- `GET /api/flags` — 任何角色,返回 `["中国","美国",...]`
+- `POST /api/flags` — admin,body: `{"name": "荷兰"}`
+- `DELETE /api/flags/<name>` — admin
+
+**注意**:URL 中的 name 是中文,要 url-decode。Flask 默认会处理。
+
+---
+
+## 优先级 3:用户管理 API
+
+### database.py
+
+```python
+def query_all_users():
+    """返回所有用户(不含 password_hash)"""
+
+def insert_user(username, password_hash, role, display_name):
+    """新增用户"""
+
+def delete_user(user_id):
+    """删除用户"""
+
+def update_user_password(user_id, new_password_hash):
+    """更新密码"""
+```
+
+### app.py
+
+- `GET /api/users` — admin
+- `POST /api/users` — admin,body: `{"username","password","role","display_name"}`
+- `DELETE /api/users/<int:user_id>` — admin,**不能删自己**
+- `PUT /api/users/<int:user_id>/password`:
+  - admin 可以改任何人,可以不带 old_password
+  - 非 admin 只能改自己 + 必须验证 old_password
+
+### 校验
+
+- username 非空,4-20 字符
+- password 至少 4 位
+- role ∈ ('admin', 'operator', 'viewer')
+
+---
+
+## 优先级 4:导出 CSV API(可选)
+
+前端目前已经有 JS 版本的 CSV 导出,所以这个优先级低。但后端导出有优势:可以按权限和时间范围控制。
+
+如果做,实现:
+- `GET /api/export/in?category=plush&from=2026-01-01&to=2026-12-31` — 返回 CSV
+- `GET /api/export/out?category=plush&from=...&to=...`
+- `GET /api/export/stock?category=plush` — 库存总览
+
+**重要**:CSV 第一字节必须是 BOM(`\ufeff`),不然 Excel 打开会乱码。
+
+---
+
+## 优先级 5:数据备份脚本
+
+创建 `backup.py`:
+
+```python
+"""
+数据备份脚本
+功能:复制 data/inventory.db 到 backup/inventory_YYYYMMDD_HHMMSS.db
+保留最近 30 天的备份,自动删除老的
+
+用法:
+  python backup.py          # 手动备份
+  设 cron / 任务计划        # 自动每天凌晨 2 点跑
+"""
+import shutil
+import os
+from datetime import datetime, timedelta
+
+BACKUP_DIR = 'backup'
+DB_PATH = 'data/inventory.db'
+
+# 1. 创建备份
+timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+target = f'{BACKUP_DIR}/inventory_{timestamp}.db'
+os.makedirs(BACKUP_DIR, exist_ok=True)
+shutil.copy2(DB_PATH, target)
+print(f'✓ 已备份到 {target}')
+
+# 2. 删除 30 天前的备份
+cutoff = datetime.now() - timedelta(days=30)
+# ... 遍历 backup/ 目录,删除创建时间早于 cutoff 的文件
+```
+
+---
+
+## 优先级 6:生产部署优化
+
+`app.py` 当前用 Flask 开发服务器,生产环境应该用 waitress(已经在 requirements.txt):
+
+创建 `serve.py`:
+```python
+from waitress import serve
+from app import app
+print('生产服务器启动: http://0.0.0.0:5000')
+serve(app, host='0.0.0.0', port=5000, threads=8)
+```
+
+更新 `start.bat` 和 `start.sh` 用 `python serve.py`。
+
+---
+
+## 优先级 7:前端权限 UI 优化
+
+当前前端通过 `document.body.dataset.role` 知道角色,但还没根据角色隐藏 UI。
+
+在 app.html 的 `<style>` 里加:
+
+```css
+/* 游客隐藏所有"录入"和"删除"按钮 */
+body[data-role="viewer"] .btn-in,
+body[data-role="viewer"] .btn-out,
+body[data-role="viewer"] .btn-danger {
+  display: none;
+}
+
+/* 仓管员看得到录入,看不到删除 */
+body[data-role="operator"] .btn-danger {
+  display: none;
+}
+
+/* 仅 admin 能看用户管理入口 */
+body:not([data-role="admin"]) .admin-only {
+  display: none;
+}
+```
+
+把"布标维护"导航项加 `admin-only` class。
+
+---
+
+## 优先级 8:用户管理页面
+
+加一个 `users` 页面到导航(admin-only),展示用户列表 + 新增 + 改密码 + 删除。
+
+参考布标维护页面的写法。
+
+---
+
+## 优先级 9:细节优化(锦上添花)
+
+- **库存预警阈值可配置**:当前硬编码 `SAFE_STOCK = 100`,可以做成数据库配置
+- **PO 号下拉联想**:出库时,基于历史 PO 号联想
+- **统计图表**:近 30 天出入库趋势,毛绒 vs 戏服占比饼图
+- **打印细表**:加一个"打印此页"按钮(window.print())
+- **快捷搜索**:Ctrl+K 全局搜索货号
+
+---
+
+## 不要做的事
+
+❌ 不要存"库存数量"字段,库存永远实时计算
+❌ 不要加 BOM / 配比 / 多仓联动逻辑
+❌ 不要自动生成单号(用户明确要求手动填)
+❌ 不要引入 React/Vue/jQuery 等前端框架
+❌ 不要把 SQLite 换成 MySQL/PostgreSQL
+❌ 不要做软删除,直接物理删除
+❌ 不要把毛绒和戏服分成两套表
+❌ 不要破坏 test_logic.py 现有测试用例
+
+---
+
+## 完成标准
+
+每个任务完成的标志:
+
+1. ✅ `python test_logic.py` 全部通过
+2. ✅ `python app.py` 能启动,无报错
+3. ✅ 浏览器手动测试功能正常
+4. ✅ 代码风格和现有代码一致
+5. ✅ 中文注释清晰
+
+如果加了新功能,推荐**主动给 test_logic.py 加测试用例**(参考现有写法)。

--- a/apps/PMC跟仓管/华登毛绒仓库/app.py
+++ b/apps/PMC跟仓管/华登毛绒仓库/app.py
@@ -1,0 +1,1594 @@
+"""
+华登塑胶 · 库存管理系统(毛绒 + 戏服)
+Flask 主程序
+
+【骨架版】已实现:
+- 登录 / 登出 / 当前用户查询
+- 入库 API(查询 / 新增 / 删除)— 支持 category 筛选,作为示例
+- 库存汇总 API(实时计算)
+
+【待实现】给 Claude Code:
+- 出库 API(仿照入库写,字段多 po 和 picker)
+- 布标 API
+- 用户管理 API
+- 导出 CSV API
+"""
+import os
+import re
+import json
+import shutil
+import sqlite3
+import csv
+import io
+import hashlib
+from datetime import datetime
+from urllib.parse import quote
+from flask import Flask, render_template, request, jsonify, session, redirect, url_for, Response
+import openpyxl
+from openpyxl.styles import Alignment, Font, Border, Side
+from openpyxl.utils import get_column_letter
+
+import database as db
+
+
+SCHEDULE_IMG_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                'static', 'schedule_images')
+from auth import (
+    hash_password, check_password,
+    login_required, role_required,
+    current_user
+)
+
+
+app = Flask(__name__)
+
+# Session 密钥从环境变量注入；本地开发可不设，云端 compose 强制传入
+app.secret_key = os.environ.get('HUADENG_MAORONG_SECRET_KEY') or 'dev-only-CHANGE-IN-PROD'
+
+# Session 7 天有效
+app.permanent_session_lifetime = 60 * 60 * 24 * 7
+
+# 模块加载时确保表结构存在(CREATE IF NOT EXISTS,幂等)
+db.init_database()
+
+
+@app.route('/health')
+def health():
+    return {'status': 'ok'}, 200
+
+
+# ==================== 工具函数 ====================
+
+def validate_category(category):
+    """验证品类参数,返回标准化后的值或 None"""
+    if category in ('plush', 'costume'):
+        return category
+    return None
+
+
+def validate_record_payload(data, allow_optional=()):
+    """
+    校验出入库 payload,返回 (data, None) 或 (None, (error_msg, status))
+    新增 / 编辑 共用,出库可通过 allow_optional=('po','picker') 传入可空字段
+    """
+    category = data.get('category', 'plush')
+    if category not in ('plush', 'costume'):
+        return None, ({'error': '品类只能是 plush(毛绒) 或 costume(戏服)'}, 400)
+    data['category'] = category
+    # 戏服自动 flag = ''
+    if category == 'costume':
+        data['flag'] = ''
+    required = ['date', 'billNo', 'sku', 'qty']
+    if category == 'plush':
+        # 毛绒:style(normal/rare)和 flag 都必填
+        required.extend(['style', 'flag'])
+    for field in required:
+        if not data.get(field):
+            return None, ({'error': f'缺少必填字段: {field}'}, 400)
+    if category == 'plush' and data['style'] not in ('normal', 'rare'):
+        return None, ({'error': '毛绒款式必须是 normal 或 rare'}, 400)
+    # 戏服 style 可选,空时归一为空字符串(避免下游 NPE)
+    if category == 'costume' and not data.get('style'):
+        data['style'] = ''
+    try:
+        qty = int(data['qty'])
+        if qty <= 0:
+            return None, ({'error': '数量必须大于 0'}, 400)
+        data['qty'] = qty
+    except (ValueError, TypeError):
+        return None, ({'error': '数量必须是数字'}, 400)
+    if 'flag' not in data:
+        data['flag'] = ''
+    return data, None
+
+
+# ==================== 页面路由 ====================
+
+@app.route('/')
+def index():
+    """首页:已登录跳主程序,未登录跳登录页"""
+    if 'user_id' not in session:
+        return redirect(url_for('login_page'))
+    return render_template('app.html', user=current_user())
+
+
+@app.route('/login')
+def login_page():
+    """登录页面"""
+    if 'user_id' in session:
+        return redirect(url_for('index'))
+    return render_template('login.html')
+
+
+# ==================== 认证 API ====================
+
+@app.route('/api/login', methods=['POST'])
+def api_login():
+    """登录"""
+    data = request.get_json() or {}
+    username = (data.get('username') or '').strip()
+    password = data.get('password') or ''
+
+    if not username or not password:
+        return jsonify({'error': '请输入用户名和密码'}), 400
+
+    user = db.get_user_by_username(username)
+    if not user or not check_password(password, user['password_hash']):
+        return jsonify({'error': '用户名或密码错误'}), 401
+
+    # 写入 session
+    session.permanent = True
+    session['user_id'] = user['id']
+    session['username'] = user['username']
+    session['role'] = user['role']
+    session['display_name'] = user['display_name'] or user['username']
+
+    return jsonify({
+        'success': True,
+        'user': {
+            'username': user['username'],
+            'role': user['role'],
+            'display_name': user['display_name']
+        }
+    })
+
+
+@app.route('/api/logout', methods=['POST'])
+def api_logout():
+    """登出"""
+    session.clear()
+    return jsonify({'success': True})
+
+
+@app.route('/api/me', methods=['GET'])
+@login_required
+def api_me():
+    """获取当前登录用户"""
+    return jsonify(current_user())
+
+
+# ==================== 入库 API(示例完整实现) ====================
+
+@app.route('/api/in', methods=['GET'])
+@login_required
+def api_in_list():
+    """
+    查询入库记录(所有角色都能看)
+    Query 参数:
+        category: 可选,'plush' 或 'costume',筛选品类
+    """
+    category = validate_category(request.args.get('category'))
+    records = db.query_all_in_records(category=category)
+    return jsonify(records)
+
+
+@app.route('/api/in', methods=['POST'])
+@role_required('admin', 'operator')
+def api_in_create():
+    """新增入库记录(主管 / 仓管员)"""
+    data, err = validate_record_payload(request.get_json() or {})
+    if err:
+        body, status = err
+        return jsonify(body), status
+    record_id = db.insert_in_record(data, session.get('username'))
+    return jsonify({'success': True, 'id': record_id})
+
+
+@app.route('/api/in/<int:record_id>', methods=['PUT'])
+@role_required('admin', 'operator')
+def api_in_update(record_id):
+    """编辑入库记录(主管 / 仓管员)"""
+    data, err = validate_record_payload(request.get_json() or {})
+    if err:
+        body, status = err
+        return jsonify(body), status
+    affected = db.update_in_record(record_id, data)
+    if affected == 0:
+        return jsonify({'error': '记录不存在'}), 404
+    return jsonify({'success': True})
+
+
+@app.route('/api/in/<int:record_id>', methods=['DELETE'])
+@role_required('admin')
+def api_in_delete(record_id):
+    """删除入库记录(仅主管)"""
+    db.delete_in_record(record_id)
+    return jsonify({'success': True})
+
+
+@app.route('/api/in/batch-delete', methods=['POST'])
+@role_required('admin')
+def api_in_batch_delete():
+    """批量删除入库记录(仅主管)。body: {ids: [int, ...]}"""
+    ids = (request.get_json() or {}).get('ids') or []
+    ids = [int(i) for i in ids]
+    if not ids:
+        return jsonify({'error': '没有要删除的记录'}), 400
+    count = db.delete_in_records_batch(ids)
+    return jsonify({'success': True, 'count': count})
+
+
+# ==================== 出库 API ====================
+
+@app.route('/api/out', methods=['GET'])
+@login_required
+def api_out_list():
+    """
+    查询出库记录(所有角色都能看)
+    Query 参数:
+        category: 可选,'plush' 或 'costume',筛选品类
+    """
+    category = validate_category(request.args.get('category'))
+    records = db.query_all_out_records(category=category)
+    return jsonify(records)
+
+
+@app.route('/api/out', methods=['POST'])
+@role_required('admin', 'operator')
+def api_out_create():
+    """新增出库记录(主管 / 仓管员)。出库多 po(可空)/ picker(可空)两个字段"""
+    data, err = validate_record_payload(request.get_json() or {})
+    if err:
+        body, status = err
+        return jsonify(body), status
+    record_id = db.insert_out_record(data, session.get('username'))
+    return jsonify({'success': True, 'id': record_id})
+
+
+@app.route('/api/out/batch', methods=['POST'])
+@role_required('admin', 'operator')
+def api_out_batch_create():
+    """批量出库(排期对比页一键出库用)。单事务,任一条失败全部回滚。"""
+    payload = request.get_json() or {}
+    records = payload.get('records') or []
+    if not records:
+        return jsonify({'error': '没有要出库的记录'}), 400
+    cleaned = []
+    for i, r in enumerate(records):
+        d, err = validate_record_payload(r)
+        if err:
+            body, status = err
+            return jsonify({'error': f'第 {i+1} 条: {body["error"]}'}), status
+        cleaned.append(d)
+    ids = db.insert_out_records_batch(cleaned, session.get('username'))
+    return jsonify({'success': True, 'ids': ids, 'count': len(ids)})
+
+
+@app.route('/api/out/<int:record_id>', methods=['PUT'])
+@role_required('admin', 'operator')
+def api_out_update(record_id):
+    """编辑出库记录(主管 / 仓管员)"""
+    data, err = validate_record_payload(request.get_json() or {})
+    if err:
+        body, status = err
+        return jsonify(body), status
+    affected = db.update_out_record(record_id, data)
+    if affected == 0:
+        return jsonify({'error': '记录不存在'}), 404
+    return jsonify({'success': True})
+
+
+@app.route('/api/out/<int:record_id>', methods=['DELETE'])
+@role_required('admin')
+def api_out_delete(record_id):
+    """删除出库记录(仅主管)"""
+    db.delete_out_record(record_id)
+    return jsonify({'success': True})
+
+
+@app.route('/api/out/batch-delete', methods=['POST'])
+@role_required('admin')
+def api_out_batch_delete():
+    """批量删除出库记录(仅主管)。body: {ids: [int, ...]}"""
+    ids = (request.get_json() or {}).get('ids') or []
+    ids = [int(i) for i in ids]
+    if not ids:
+        return jsonify({'error': '没有要删除的记录'}), 400
+    count = db.delete_out_records_batch(ids)
+    return jsonify({'success': True, 'count': count})
+
+
+# ==================== 库存查询 API ====================
+
+@app.route('/api/stock', methods=['GET'])
+@login_required
+def api_stock_summary():
+    """
+    查询库存汇总(实时计算)
+    Query 参数:
+        category: 可选,筛选品类
+
+    返回:list[dict],每条字段:
+        category, sku, name, style, flag, in_total, out_total, stock
+    """
+    category = validate_category(request.args.get('category'))
+    summary = db.get_stock_summary(category=category)
+    return jsonify(summary)
+
+
+# ==================== 布标 API ====================
+
+@app.route('/api/flags', methods=['GET'])
+@login_required
+def api_flags_list():
+    """查询所有布标(任何登录用户)"""
+    return jsonify(db.query_all_flags())
+
+
+@app.route('/api/flags', methods=['POST'])
+@role_required('admin')
+def api_flags_create():
+    """新增布标(仅 admin),body: {"name": "荷兰"}"""
+    data = request.get_json() or {}
+    name = (data.get('name') or '').strip()
+    if not name:
+        return jsonify({'error': '布标名称不能为空'}), 400
+
+    try:
+        db.add_flag(name)
+    except sqlite3.IntegrityError:
+        return jsonify({'error': f'布标 "{name}" 已存在'}), 400
+
+    return jsonify({'success': True})
+
+
+@app.route('/api/flags/<path:name>', methods=['DELETE'])
+@role_required('admin')
+def api_flags_delete(name):
+    """删除布标(仅 admin),URL 中的中文名 Flask 自动解码"""
+    affected = db.delete_flag(name)
+    if affected == 0:
+        return jsonify({'error': f'布标 "{name}" 不存在'}), 404
+    return jsonify({'success': True})
+
+
+# ==================== 用户管理 API ====================
+
+VALID_ROLES = ('admin', 'operator', 'viewer')
+
+
+@app.route('/api/users', methods=['GET'])
+@role_required('admin')
+def api_users_list():
+    """列出所有用户(仅 admin)"""
+    return jsonify(db.query_all_users())
+
+
+@app.route('/api/users', methods=['POST'])
+@role_required('admin')
+def api_users_create():
+    """
+    新增用户(仅 admin)
+    Body: username(4-20), password(>=4), role, display_name(可空)
+    """
+    data = request.get_json() or {}
+    username = (data.get('username') or '').strip()
+    password = data.get('password') or ''
+    role = data.get('role') or ''
+    display_name = (data.get('display_name') or '').strip()
+
+    if not (4 <= len(username) <= 20):
+        return jsonify({'error': '用户名长度必须为 4-20 个字符'}), 400
+    if len(password) < 4:
+        return jsonify({'error': '密码至少 4 位'}), 400
+    if role not in VALID_ROLES:
+        return jsonify({'error': f'角色必须是 {VALID_ROLES} 之一'}), 400
+
+    try:
+        new_id = db.insert_user(username, hash_password(password), role, display_name)
+    except sqlite3.IntegrityError:
+        return jsonify({'error': f'用户名 "{username}" 已存在'}), 400
+
+    return jsonify({'success': True, 'id': new_id})
+
+
+@app.route('/api/users/<int:user_id>', methods=['DELETE'])
+@role_required('admin')
+def api_users_delete(user_id):
+    """删除用户(仅 admin,禁止删自己)"""
+    if user_id == session.get('user_id'):
+        return jsonify({'error': '不能删除当前登录的自己'}), 400
+
+    affected = db.delete_user(user_id)
+    if affected == 0:
+        return jsonify({'error': '用户不存在'}), 404
+    return jsonify({'success': True})
+
+
+@app.route('/api/users/<int:user_id>/password', methods=['PUT'])
+@login_required
+def api_users_change_password(user_id):
+    """
+    改密码:
+      - admin 可改任何人,old_password 可省略
+      - 非 admin 只能改自己,必须验证 old_password
+    Body: { "old_password": "...", "new_password": "..." }
+    """
+    data = request.get_json() or {}
+    new_password = data.get('new_password') or ''
+    old_password = data.get('old_password') or ''
+
+    if len(new_password) < 4:
+        return jsonify({'error': '新密码至少 4 位'}), 400
+
+    current = current_user()
+    target = db.get_user_by_id(user_id)
+    if not target:
+        return jsonify({'error': '用户不存在'}), 404
+
+    # 非 admin:只能改自己 + 必须验证旧密码
+    if current['role'] != 'admin':
+        if user_id != current['id']:
+            return jsonify({'error': '只能修改自己的密码'}), 403
+        if not check_password(old_password, target['password_hash']):
+            return jsonify({'error': '旧密码错误'}), 400
+
+    db.update_user_password(user_id, hash_password(new_password))
+    return jsonify({'success': True})
+
+
+# ==================== 导出 CSV API ====================
+
+def _category_label(c):
+    return '毛绒' if c == 'plush' else '戏服' if c == 'costume' else (c or '')
+
+
+def _style_label(s):
+    """毛绒款式中文化,戏服直接返回原文本"""
+    if s == 'normal': return '普通款'
+    if s == 'rare': return '稀有款'
+    return s or ''
+
+
+def _csv_response(rows, header, filename):
+    """
+    生成 CSV 响应
+    - 文件首字节写 BOM,Excel 打开中文不乱码
+    - filename URL 编码,支持中文文件名
+    """
+    output = io.StringIO()
+    output.write('﻿')
+    writer = csv.writer(output)
+    writer.writerow(header)
+    for row in rows:
+        writer.writerow(row)
+    return Response(
+        output.getvalue(),
+        mimetype='text/csv',
+        headers={'Content-Disposition': f"attachment; filename*=UTF-8''{quote(filename)}"}
+    )
+
+
+def _filter_by_date(records, date_from, date_to):
+    if date_from:
+        records = [r for r in records if r['date'] >= date_from]
+    if date_to:
+        records = [r for r in records if r['date'] <= date_to]
+    return records
+
+
+@app.route('/api/export/in', methods=['GET'])
+@login_required
+def api_export_in():
+    """导出入库流水。Query: category / from / to"""
+    category = validate_category(request.args.get('category'))
+    records = _filter_by_date(
+        db.query_all_in_records(category=category),
+        request.args.get('from'), request.args.get('to')
+    )
+    rows = [[
+        _category_label(r['category']), r['date'], r['bill_no'], r['sku'],
+        r.get('name', ''), _style_label(r['style']), r['flag'], r['qty']
+    ] for r in records]
+    header = ['品类', '日期', '单号', '货号', '物料名称', '款式', '布标', '数量']
+    filename = f'入库流水_{datetime.now().strftime("%Y%m%d")}.csv'
+    return _csv_response(rows, header, filename)
+
+
+@app.route('/api/export/out', methods=['GET'])
+@login_required
+def api_export_out():
+    """导出出库流水。Query: category / from / to"""
+    category = validate_category(request.args.get('category'))
+    records = _filter_by_date(
+        db.query_all_out_records(category=category),
+        request.args.get('from'), request.args.get('to')
+    )
+    rows = [[
+        _category_label(r['category']), r['date'], r['bill_no'],
+        r.get('po', '') or '', r.get('picker', '') or '',
+        r['sku'], r.get('name', ''), _style_label(r['style']), r['flag'], r['qty']
+    ] for r in records]
+    header = ['品类', '日期', '单号', 'PO号', '领货人', '货号', '物料名称', '款式', '布标', '数量']
+    filename = f'出库流水_{datetime.now().strftime("%Y%m%d")}.csv'
+    return _csv_response(rows, header, filename)
+
+
+@app.route('/api/export/stock', methods=['GET'])
+@login_required
+def api_export_stock():
+    """导出当前库存。Query: category"""
+    category = validate_category(request.args.get('category'))
+    summary = db.get_stock_summary(category=category)
+    rows = [[
+        _category_label(s['category']), s['sku'], s.get('name', ''),
+        _style_label(s['style']), s['flag'],
+        s['in_total'], s['out_total'], s['stock']
+    ] for s in summary]
+    header = ['品类', '货号', '物料名称', '款式', '布标', '入库累计', '出库累计', '当前库存']
+    filename = f'库存总览_{datetime.now().strftime("%Y%m%d")}.csv'
+    return _csv_response(rows, header, filename)
+
+
+# ==================== 排期表导入与查询 ====================
+
+def _is_blue_font(font):
+    """字体颜色是否属于"已完货蓝":R<80 && G<80 && B>150"""
+    if not font or not font.color or font.color.type != 'rgb':
+        return False
+    rgb = (font.color.rgb or '').upper()
+    if len(rgb) != 8:
+        return False
+    try:
+        r = int(rgb[2:4], 16)
+        g = int(rgb[4:6], 16)
+        b = int(rgb[6:8], 16)
+    except ValueError:
+        return False
+    return b > 150 and r < 80 and g < 80
+
+
+def _find_schedule_header(ws, max_scan=12):
+    """
+    扫前 max_scan 行,跨行合并识别各种表头列(因为 AU/AV "每款普通/稀有" 表头
+    在 R3,而 PO号 等核心列在 R4——必须合扫才能拿到完整字段)
+    返回 (primary_row, cols) —— primary_row 是 PO号 所在的行(数据起始行 = primary_row + 1)
+    """
+    upper = min(ws.max_column + 1, 80)
+    cols = {}
+    primary_row = None
+    for r in range(1, max_scan + 1):
+        for c in range(1, upper):
+            v = ws.cell(row=r, column=c).value
+            if v is None:
+                continue
+            s = str(v).strip()
+            if s == 'PO号' and 'po' not in cols:
+                cols['po'] = c
+                primary_row = r
+            elif 'ITEM#' in s and 'item' not in cols:
+                cols['item'] = c
+            elif s == 'SKU' and 'csku' not in cols:
+                cols['csku'] = c
+            elif 'PO数量' in s and 'qty' not in cols:
+                cols['qty'] = c
+            elif s == '第三方客户名称' and 'customer' not in cols:
+                cols['customer'] = c
+            elif s == '走货国家' and 'country' not in cols:
+                cols['country'] = c
+            elif s == '中文名' and 'name' not in cols:
+                cols['name'] = c
+            elif s == '计划出货期' and 'ship' not in cols:
+                cols['ship'] = c
+            elif s == '布标' and 'flag_type' not in cols:
+                cols['flag_type'] = c
+            elif s == 'MA布标' and 'ma_qty' not in cols:
+                cols['ma_qty'] = c
+            elif s == '客版布标' and 'kb_qty' not in cols:
+                cols['kb_qty'] = c
+            elif '每款普通' in s and 'ratio_normal' not in cols:
+                cols['ratio_normal'] = c
+            elif ('每款公仔稀有' in s or '每款稀有' in s) and 'ratio_rare' not in cols:
+                cols['ratio_rare'] = c
+    if primary_row and {'po', 'item', 'qty'} <= cols.keys():
+        return primary_row, cols
+    return None, None
+
+
+def _parse_ratio(text, letter_qty):
+    """
+    根据排期字符串解析"普通款 / 稀有款"实际数量
+    返回 (qty, mode):
+      - mode='absolute': 字符串是纯数字,直接取 qty 不再 round
+      - mode='fraction': 字符串含 N/M 分数,按 letter_qty * N/M round
+      - mode='subtract_rare': 字符串带"减去稀有",由调用方算
+      - mode=None: 读不出
+    """
+    if text is None:
+        return None, None
+    s = str(text).strip()
+    if not s:
+        return None, None
+    # 1. 分数 N/M
+    m = re.search(r'(\d+)\s*/\s*(\d+)', s)
+    if m:
+        num, den = int(m.group(1)), int(m.group(2))
+        if den > 0:
+            return int(round(letter_qty * num / den)), 'fraction'
+    # 2. "减去稀有"
+    if '减去稀有' in s:
+        return None, 'subtract_rare'
+    # 3. 纯数字
+    try:
+        return int(round(float(s))), 'absolute'
+    except (ValueError, TypeError):
+        return None, None
+
+
+def _collect_letter_columns(ws, header_row):
+    """
+    收集字母款式列:R{header_row} 是单个大写字母的列
+    返回 [(column_index, letter), ...]
+    """
+    out = []
+    upper = min(ws.max_column + 1, 100)
+    for c in range(20, upper):
+        v = ws.cell(row=header_row, column=c).value
+        if v is None:
+            continue
+        s = str(v).strip()
+        if len(s) == 1 and s.isalpha() and s.isupper():
+            out.append((c, s))
+    return out
+
+
+def _clean_material_from_column(s):
+    """从列头如 '5"锁扣粉色无毛猫 Wrinkle McStinkles' 提取物料名 '粉色无毛猫'"""
+    s = re.sub(r'^\d+["″“”]', '', s).strip()
+    s = re.sub(r'^锁扣', '', s).strip()
+    m = re.match(r'^([一-鿿]+)', s)
+    return m.group(1) if m else (s.split()[0] if s else '')
+
+
+def _collect_no_letter_style_columns(ws, name_row=3, marker_row=4, start_col=20):
+    """
+    无字母款式列(15789 模式):R{name_row} 列头是中文+英文(如 '5"锁扣粉色无毛猫 ...'),
+    R{marker_row} 可能标 '稀有款'。每列对应一个独立款式。
+    返回 [(col_index, material_name, style), ...]  style: 'normal'/'rare'
+    """
+    out = []
+    upper = min(ws.max_column + 1, 100)
+    for c in range(start_col, upper):
+        v = ws.cell(row=name_row, column=c).value
+        if v is None:
+            continue
+        s = str(v).strip()
+        # 必须 <数字>"... 开头 + 含中文(15789 这种"5"锁扣XX猫"格式)
+        if not re.match(r'^\d+["″“”]', s):
+            continue
+        if not re.search(r'[一-鿿]', s):
+            continue
+        name = _clean_material_from_column(s)
+        if not name:
+            continue
+        marker = ws.cell(row=marker_row, column=c).value
+        marker_s = str(marker).strip() if marker else ''
+        style = 'rare' if '稀有' in marker_s else 'normal'
+        out.append((c, name, style))
+    return out
+
+
+def _extract_letter_images(wb_fmt, sheet_letter_cols):
+    """
+    从 xlsx 中提取每个字母列上方的产品图,根据 anchor 的列号匹配字母
+    sheet_letter_cols: {sheet_name: [(col_index_1based, letter), ...]}
+    返回 {(sheet_name, letter): bytes}
+    """
+    out = {}
+    for sheet_name, letter_cols in sheet_letter_cols.items():
+        col_to_letter = {c: l for c, l in letter_cols}
+        ws = wb_fmt[sheet_name]
+        for img in getattr(ws, '_images', []) or []:
+            anc = getattr(img, 'anchor', None)
+            anchor_from = getattr(anc, '_from', None) if anc else None
+            if anchor_from is None:
+                continue
+            col_1based = anchor_from.col + 1
+            if col_1based in col_to_letter:
+                try:
+                    data = img._data() if callable(img._data) else img._data
+                    out[(sheet_name, col_to_letter[col_1based])] = data
+                except Exception:
+                    continue
+    return out
+
+
+def _save_schedule_images(images):
+    """
+    清空 SCHEDULE_IMG_DIR 后保存图片,返回 {(sheet, letter): /static/... URL}
+    用图片内容 hash 做文件名前缀,避免重复存
+    """
+    if os.path.exists(SCHEDULE_IMG_DIR):
+        for f in os.listdir(SCHEDULE_IMG_DIR):
+            try:
+                os.remove(os.path.join(SCHEDULE_IMG_DIR, f))
+            except OSError:
+                pass
+    os.makedirs(SCHEDULE_IMG_DIR, exist_ok=True)
+    out = {}
+    for (sheet, letter), data in images.items():
+        h = hashlib.sha1(data).hexdigest()[:12]
+        # 文件扩展名从 PNG 头判断
+        ext = '.png' if data[:4] == b'\x89PNG' else '.jpg'
+        fname = f'{h}_{letter}{ext}'
+        path = os.path.join(SCHEDULE_IMG_DIR, fname)
+        if not os.path.exists(path):
+            with open(path, 'wb') as f:
+                f.write(data)
+        out[(sheet, letter)] = '/static/schedule_images/' + fname
+    return out
+
+
+def parse_schedule_workbook(file_bytes):
+    """
+    解析排期 xlsx,返回 (rows, stats)
+    每一行:
+      - 单款行(字母列 ≤ 1 个有值)→ 1 条记录,variant_letter='' 用 I 列数量
+      - 拼盘行(字母列 ≥ 2 个有值)→ N 条记录,每条 variant_letter=该字母,qty=该字母列的数量
+    蓝色字体的字母列也单独跳过(只完了部分款式的情况)
+    """
+    # data_only=True 拿公式计算结果(字母列大多是 =I/N 或 =I)
+    # 但 data_only 拿不到字体颜色 / 图片,所以分两次加载:一份取值,一份取颜色和图片
+    wb_vals = openpyxl.load_workbook(io.BytesIO(file_bytes), data_only=True)
+    wb_fmt = openpyxl.load_workbook(io.BytesIO(file_bytes))
+    aggregated = {}
+    sheets_processed = []
+    sheets_skipped = []
+    sheet_letter_cols = {}  # 收集每个 sheet 的字母列(用于图片提取)
+    rows_skipped_blue = 0
+    rows_skipped_invalid = 0
+    letter_rows_split = 0
+    # 同货号配比回退缓存:数字前缀 sku → (normal_text, rare_text)
+    sku_ratio_cache = {}
+
+    for name in wb_vals.sheetnames:
+        n = name.strip()
+        if not n or not n[0].isdigit():
+            sheets_skipped.append(name)
+            continue
+        ws_v = wb_vals[name]
+        ws_f = wb_fmt[name]
+        header_row, cols = _find_schedule_header(ws_v)
+        if not header_row:
+            sheets_skipped.append(name + '(无表头)')
+            continue
+        sheets_processed.append(name)
+
+        letter_cols = _collect_letter_columns(ws_v, header_row)
+        # letter_cols 空时,尝试用 R3 中文款式列(15789 这种 5"锁扣XX猫 模式)
+        no_letter_style_cols = []
+        if not letter_cols:
+            no_letter_style_cols = _collect_no_letter_style_columns(ws_v, name_row=3, marker_row=4)
+        sheet_letter_cols[name] = letter_cols
+
+        for r in range(header_row + 1, ws_v.max_row + 1):
+            po_cell_f = ws_f.cell(row=r, column=cols['po'])
+            po_val = ws_v.cell(row=r, column=cols['po']).value
+            if po_val is None or _is_blue_font(po_cell_f.font):
+                if po_val is not None:
+                    rows_skipped_blue += 1
+                continue
+            item_val = ws_v.cell(row=r, column=cols['item']).value
+            qty_val = ws_v.cell(row=r, column=cols['qty']).value
+            if item_val is None or qty_val is None:
+                rows_skipped_invalid += 1
+                continue
+            if _is_blue_font(ws_f.cell(row=r, column=cols['item']).font) or \
+               _is_blue_font(ws_f.cell(row=r, column=cols['qty']).font):
+                rows_skipped_blue += 1
+                continue
+            try:
+                qty_total = int(qty_val)
+            except (ValueError, TypeError):
+                rows_skipped_invalid += 1
+                continue
+            if qty_total <= 0:
+                rows_skipped_invalid += 1
+                continue
+
+            po_no = str(po_val).strip()
+            item_code = str(item_val).strip()
+
+            def _cell_text(col_key):
+                if col_key not in cols:
+                    return ''
+                v = ws_v.cell(row=r, column=cols[col_key]).value
+                if v is None:
+                    return ''
+                if hasattr(v, 'strftime'):
+                    return v.strftime('%Y-%m-%d')
+                return str(v).strip()
+
+            csku = _cell_text('csku')
+            country = _cell_text('country')
+            flag_type = _cell_text('flag_type')
+
+            # 用户规则:布标类型按 MA布标列(AM)/ 客版布标列(AN)哪个有数判定,
+            # 覆盖 AL 标签列(AL 可能空,或与 AM/AN 实际不一致)
+            def _num_or_none(col_key):
+                if col_key not in cols:
+                    return None
+                v = ws_v.cell(row=r, column=cols[col_key]).value
+                try:
+                    return int(round(float(v))) if v is not None and float(v) > 0 else None
+                except (ValueError, TypeError):
+                    return None
+            ma_q = _num_or_none('ma_qty')
+            kb_q = _num_or_none('kb_qty')
+            if ma_q and not kb_q:
+                flag_type = 'MA布标'
+            elif kb_q and not ma_q:
+                flag_type = '客版布标'
+            # 都有数 / 都空 → 保持 AL 列原值
+
+            # 库存布标 = 布标类型 + "-" + 国家(用户填库存时按此约定录)
+            row_flag = f'{flag_type}-{country}' if (flag_type and country) else (flag_type or country or '')
+
+            # 普通/稀有 比例 文本,空时回退同货号(数字前缀)上次的
+            ratio_n_text = _cell_text('ratio_normal')
+            ratio_r_text = _cell_text('ratio_rare')
+            sku_prefix = _extract_sku_prefix(item_code)
+            cached = sku_ratio_cache.get(sku_prefix, ('', ''))
+            if not ratio_n_text:
+                ratio_n_text = cached[0]
+            if not ratio_r_text:
+                ratio_r_text = cached[1]
+            # 把这次解析到的更新进缓存(只在非空时更新)
+            if ratio_n_text or ratio_r_text:
+                sku_ratio_cache[sku_prefix] = (
+                    ratio_n_text or cached[0],
+                    ratio_r_text or cached[1],
+                )
+
+            common = {
+                'series': name, 'po_no': po_no, 'item_code': item_code,
+                'customer_sku': csku,
+                'customer': _cell_text('customer'),
+                'country': country,
+                'flag_type': flag_type,
+                'flag': row_flag,
+                'ratio_normal_text': ratio_n_text,
+                'ratio_rare_text': ratio_r_text,
+                'name_cn': _cell_text('name'),
+                'plan_ship_date': _cell_text('ship'),
+            }
+
+            # 收集字母列里的有效数量(非空、非零、非蓝色)
+            # 字母列大多是公式 =I/N,data_only 拿到浮点;按 round 取整,
+            # 不再做余数补差(避免出现文件里不存在的数字,如 19200/9 → 8×2133 + 1×2136)
+            # 字母数量之和可能 ≠ I 列(行总数仍用 I 列存)
+            letter_distrib = []
+            for col_idx, letter in letter_cols:
+                v = ws_v.cell(row=r, column=col_idx).value
+                if v in (None, 0, '0'):
+                    continue
+                if _is_blue_font(ws_f.cell(row=r, column=col_idx).font):
+                    continue
+                try:
+                    q = int(round(float(v)))
+                except (ValueError, TypeError):
+                    continue
+                if q > 0:
+                    letter_distrib.append((letter, q))
+
+            # 不拆开:每条 xlsx 行 → 1 条 DB 记录,字母分布序列化进 letters_json
+            if len(letter_distrib) >= 2:
+                letter_rows_split += 1
+                only_letter = ''
+            else:
+                only_letter = letter_distrib[0][0] if len(letter_distrib) == 1 else ''
+
+            # 无字母款式列模式(15789):每列一个物料,直接读列数字,不算 ratio
+            # xlsx 公式可能给小数(如 287.5),先 round,再把 sum vs PO 总数 的差额加到第一款
+            letters_list = []
+            if no_letter_style_cols and not letter_distrib:
+                raw = []  # [[q_int, name, style], ...]
+                for col_idx, mat_name, mat_style in no_letter_style_cols:
+                    v = ws_v.cell(row=r, column=col_idx).value
+                    if v in (None, 0, '0'):
+                        continue
+                    if _is_blue_font(ws_f.cell(row=r, column=col_idx).font):
+                        continue
+                    try:
+                        q = int(round(float(v)))
+                    except (ValueError, TypeError):
+                        continue
+                    if q <= 0:
+                        continue
+                    raw.append([q, mat_name, mat_style])
+                if raw:
+                    diff = qty_total - sum(x[0] for x in raw)
+                    if diff != 0:
+                        raw[0][0] += diff
+                    letters_list = [{
+                        'letter': '', 'qty': q, 'image_url': '',
+                        'name': name, 'style': style,
+                        'normal_qty': q if style == 'normal' else 0,
+                        'rare_qty': q if style == 'rare' else 0,
+                        'ratio_assumed': False,
+                    } for q, name, style in raw]
+
+            # 对每个字母按比例算 普通款 / 稀有款 数量(字母列模式)
+            for l, q in letter_distrib:
+                n_qty, n_mode = _parse_ratio(ratio_n_text, q)
+                r_qty, r_mode = _parse_ratio(ratio_r_text, q)
+                # "减去稀有款" 模式:先算另一项,再用 q 减
+                if n_mode == 'subtract_rare' and r_qty is not None:
+                    n_qty = q - r_qty
+                if r_mode == 'subtract_rare' and n_qty is not None:
+                    r_qty = q - n_qty
+                # 兜底:N 或 R 一个有值另一个空 → 用 q 减
+                if n_qty is not None and r_qty is None:
+                    r_qty = q - n_qty
+                elif r_qty is not None and n_qty is None:
+                    n_qty = q - r_qty
+                # 双兜底:两者都读不出,默认全部归普通款,加一个 ratio_assumed 标记
+                ratio_assumed = False
+                if n_qty is None and r_qty is None:
+                    n_qty = q
+                    r_qty = 0
+                    ratio_assumed = True
+                letters_list.append({
+                    'letter': l, 'qty': q, 'image_url': '',
+                    'normal_qty': n_qty, 'rare_qty': r_qty,
+                    'ratio_assumed': ratio_assumed,
+                })
+
+            key = (name, po_no, item_code, csku)
+            entry = aggregated.get(key)
+            if entry:
+                entry['qty'] += qty_total
+                entry['letters_list'].extend(letters_list)
+            else:
+                aggregated[key] = {
+                    **common,
+                    'variant_letter': only_letter,
+                    'qty': qty_total,
+                    'letters_list': letters_list,
+                }
+
+    # 提取图片并保存,然后按 (series, letter) 回填到每条 letters_list 里
+    images = _extract_letter_images(wb_fmt, sheet_letter_cols)
+    img_urls = _save_schedule_images(images)
+    for row in aggregated.values():
+        for l in row.get('letters_list', []):
+            url = img_urls.get((row['series'], l['letter']), '')
+            if url:
+                l['image_url'] = url
+        # 单款行的 image_url(便于 SKU 视图直接显示)
+        single_letter = row.get('variant_letter') or ''
+        if single_letter:
+            url = img_urls.get((row['series'], single_letter), '')
+            if url:
+                row['image_url'] = url
+        # 序列化字母分布到 JSON,DB 存这个
+        row['letters_json'] = json.dumps(row.get('letters_list', []), ensure_ascii=False)
+        row.pop('letters_list', None)
+
+    rows = list(aggregated.values())
+    stats = {
+        'sheets_processed': sheets_processed,
+        'sheets_skipped': sheets_skipped,
+        'rows_inserted': len(rows),
+        'rows_skipped_blue': rows_skipped_blue,
+        'rows_skipped_invalid': rows_skipped_invalid,
+        'letter_rows_split': letter_rows_split,
+        'images_extracted': len(img_urls),
+    }
+    return rows, stats
+
+
+@app.route('/api/schedule/upload', methods=['POST'])
+@role_required('admin', 'operator')
+def api_schedule_upload():
+    """上传排期 xlsx,整库替换"""
+    f = request.files.get('file')
+    if not f or not f.filename:
+        return jsonify({'error': '请上传 xlsx 文件'}), 400
+    if not f.filename.lower().endswith('.xlsx'):
+        return jsonify({'error': '只支持 .xlsx 格式'}), 400
+    try:
+        rows, stats = parse_schedule_workbook(f.read())
+    except Exception as e:
+        return jsonify({'error': f'解析失败: {e}'}), 400
+    db.replace_po_schedules(rows, session.get('username'))
+    return jsonify({'success': True, 'stats': stats})
+
+
+@app.route('/api/schedule/info', methods=['GET'])
+@login_required
+def api_schedule_info():
+    return jsonify(db.get_schedule_info())
+
+
+def _parse_letters(letters_json):
+    if not letters_json:
+        return []
+    try:
+        return json.loads(letters_json)
+    except (json.JSONDecodeError, TypeError):
+        return []
+
+
+def _extract_sku_prefix(item_code):
+    """
+    从 ITEM# 提取最前面的连续数字段作为入库货号
+    例:'15758-S001' → '15758',  '15758A-S001-PKC1' → '15758',  '15704UQ1-S001' → '15704'
+    """
+    m = re.match(r'^(\d+)', str(item_code or '').strip())
+    return m.group(1) if m else ''
+
+
+# 货号别名缓存:子货号 → 父货号。CUD 后置空触发重载。
+_alias_cache = None
+
+def _invalidate_alias_cache():
+    global _alias_cache
+    _alias_cache = None
+
+def _resolve_sku_prefix(prefix):
+    """如果 prefix 是别名,返回 primary;否则返回原值。"""
+    global _alias_cache
+    if not prefix:
+        return prefix
+    if _alias_cache is None:
+        _alias_cache = db.get_sku_alias_map()
+    return _alias_cache.get(prefix, prefix)
+
+
+def _match_sku_prefix(item_code):
+    """提取 + 别名解析,业务匹配字母绑定/库存时用这个。"""
+    return _resolve_sku_prefix(_extract_sku_prefix(item_code))
+
+
+def _resolve_inventory_flag(flag_type, country, fallback):
+    """
+    把排期里的 (布标类型, 国家) 用 flag_mappings 翻译成入库布标
+    没配置映射 → 返回 fallback(默认拼接 flag_type-country)
+    """
+    if flag_type and country:
+        mp = db.get_flag_mapping(flag_type, country)
+        if mp:
+            return mp['inventory_flag']
+    return fallback
+
+
+def _clean_name_cn(name_cn):
+    """name_cn 取开头的连续中文字符作为物料名(如 '猫系列盲盒锁扣怪 3FACING6PCS/PDQ' → '猫系列盲盒锁扣怪')"""
+    if not name_cn:
+        return ''
+    m = re.match(r'^[一-鿿]+', name_cn.strip())
+    return m.group(0) if m else name_cn.strip().split()[0]
+
+
+def _enrich_letters_with_binding(item_code, letters, row_flag='', row_flag_type='', row_country=''):
+    """
+    给每个字母补充:
+      - 绑定物料 (bound_name)
+      - 该物料的总库存 (letter_stock,只按 sku+name 汇总)
+      - 普通/稀有 分款库存 (normal_stock / rare_stock,按 sku+name+style+flag 精确查)
+        库存布标先通过 flag_mappings 把 (flag_type, country) → 实际入库布标
+      - 配套的缺口/是否够做 (针对 normal_qty / rare_qty)
+
+    特殊情况:letter['letter'] == '' 表示"无字母款"(如 15789),不查 letter_bindings,
+    直接用 letter['_name_cn'] 清洗后的中文当物料名,整 qty 当普通款。
+    """
+    sku_prefix = _match_sku_prefix(item_code)
+    # 翻译入库布标
+    inventory_flag = _resolve_inventory_flag(row_flag_type, row_country, row_flag)
+    out = []
+    for l in letters:
+        is_no_letter = not l.get('letter')  # 空字母 = 无字母款
+        info = {**l, 'bound_sku': sku_prefix,
+                'flag': row_flag,           # 原始拼接(给用户看排期写的什么)
+                'inventory_flag': inventory_flag,  # 翻译后实际查库存用的
+                'no_letter': is_no_letter,
+                }
+        info.pop('_name_cn', None)  # 内部传递字段,不外泄
+
+        if is_no_letter:
+            # 优先用 parser 填入的 name(15789 这种新数据);旧合成行走 _name_cn 清洗
+            name = l.get('name') or _clean_name_cn(l.get('_name_cn') or '')
+            binding = None
+        else:
+            binding = db.get_letter_binding(sku_prefix, l['letter']) if sku_prefix else None
+            name = binding['material_name'] if binding else ''
+
+        if name:
+            info['bound_name'] = name
+            # 总库存(sku+name)
+            total_stock = db.get_stock_by_sku_name(sku_prefix, name)
+            shortage = max(0, l['qty'] - total_stock)
+            info['letter_stock'] = total_stock
+            info['letter_shortage'] = shortage
+            info['letter_sufficient'] = shortage == 0
+            # 按 style+flag 精确查 normal/rare 库存
+            n_qty = l.get('normal_qty')
+            r_qty = l.get('rare_qty')
+            if n_qty is not None:
+                n_stock = db.get_stock_by_full_dim(sku_prefix, name, 'normal', inventory_flag) if inventory_flag else None
+                info['normal_stock'] = n_stock
+                if n_stock is not None:
+                    info['normal_shortage'] = max(0, n_qty - n_stock)
+                    info['normal_sufficient'] = n_stock >= n_qty
+            if r_qty is not None:
+                r_stock = db.get_stock_by_full_dim(sku_prefix, name, 'rare', inventory_flag) if inventory_flag else None
+                info['rare_stock'] = r_stock
+                if r_stock is not None:
+                    info['rare_shortage'] = max(0, r_qty - r_stock)
+                    info['rare_sufficient'] = r_stock >= r_qty
+        else:
+            info['bound_name'] = ''
+            info['letter_stock'] = None
+            info['letter_shortage'] = None
+            info['letter_sufficient'] = None
+        out.append(info)
+    return out
+
+
+def _build_po_view(po, rows):
+    """PO 视角:每条排期行 = 一个 ITEM# + 客户 SKU,字母分布从 letters_json 拿"""
+    items = []
+    for r in rows:
+        letters = _parse_letters(r.get('letters_json'))
+        if not letters and r.get('variant_letter'):
+            letters = [{'letter': r['variant_letter'], 'qty': r['qty'],
+                        'image_url': r.get('image_url') or ''}]
+        elif not letters and r.get('qty', 0) > 0:
+            # 无字母款(如 15789):整 qty 当普通款,不拆配比,物料名取 name_cn 的中文部分
+            letters = [{
+                'letter': '', 'qty': r['qty'], 'image_url': r.get('image_url') or '',
+                'normal_qty': r['qty'], 'rare_qty': 0, 'ratio_assumed': False,
+                '_name_cn': r.get('name_cn') or '',
+            }]
+        row_flag = r.get('flag') or ''
+        letters = _enrich_letters_with_binding(
+            r['item_code'], letters,
+            row_flag=row_flag,
+            row_flag_type=r.get('flag_type') or '',
+            row_country=r.get('country') or '',
+        )
+        sku_prefix = _match_sku_prefix(r['item_code'])
+        stock = db.get_sku_total_stock(sku_prefix) if sku_prefix else 0
+        # 行级"是否够做":有绑定的字母都 sufficient;无绑定的字母按 total 模式判断
+        bound_letters = [l for l in letters if l['bound_name']]
+        unbound_letters = [l for l in letters if not l['bound_name']]
+        if letters and not unbound_letters:
+            # 全部字母都绑定 → 看每个字母是否各自够
+            sufficient = all(l['letter_sufficient'] for l in bound_letters)
+            shortage = sum(l['letter_shortage'] for l in bound_letters)
+        else:
+            # 有未绑定字母 → 沿用 SKU 总库存对比
+            shortage = max(0, r['qty'] - stock)
+            sufficient = shortage == 0
+        items.append({
+            'item_code': r['item_code'], 'series': r['series'],
+            'customer_sku': r.get('customer_sku') or '',
+            'customer': r['customer'] or '', 'country': r['country'] or '',
+            'flag_type': r.get('flag_type') or '', 'flag': r.get('flag') or '',
+            'ratio_normal_text': r.get('ratio_normal_text') or '',
+            'ratio_rare_text': r.get('ratio_rare_text') or '',
+            'name_cn': r['name_cn'] or '', 'plan_ship_date': r['plan_ship_date'] or '',
+            'scheduled_qty': r['qty'],
+            'letters': letters,
+            'current_stock': stock,
+            'shortage': shortage,
+            'sufficient': sufficient,
+            'has_unbound': bool(unbound_letters),
+        })
+    items.sort(key=lambda x: (x['item_code'], x['customer_sku']))
+    return {
+        'type': 'po', 'po_no': po, 'items': items,
+        'all_sufficient': all(it['sufficient'] for it in items),
+        'total_scheduled': sum(it['scheduled_qty'] for it in items),
+        'total_stock': sum(it['current_stock'] for it in items),
+        'total_shortage': sum(it['shortage'] for it in items),
+    }
+
+
+def _build_sku_view(query, rows, matched_by='item'):
+    """
+    货号视角:该货号涉及哪些 PO、各多少,库存够不够覆盖全部
+    matched_by='item' 表示用户输的就是 ITEM#,直接用 query 当 SKU 去查库存;
+    matched_by='customer_sku' 表示用户输的是客户 SKU(F 列),
+        库存按 rows 里的 item_code 汇总
+    """
+    pos = []
+    total_scheduled = 0
+    for r in rows:
+        letters = _parse_letters(r.get('letters_json'))
+        if not letters and r.get('variant_letter'):
+            letters = [{'letter': r['variant_letter'], 'qty': r['qty'],
+                        'image_url': r.get('image_url') or ''}]
+        elif not letters and r.get('qty', 0) > 0:
+            # 无字母款(如 15789):整 qty 当普通款,不拆配比
+            letters = [{
+                'letter': '', 'qty': r['qty'], 'image_url': r.get('image_url') or '',
+                'normal_qty': r['qty'], 'rare_qty': 0, 'ratio_assumed': False,
+                '_name_cn': r.get('name_cn') or '',
+            }]
+        row_flag = r.get('flag') or ''
+        letters = _enrich_letters_with_binding(
+            r['item_code'], letters,
+            row_flag=row_flag,
+            row_flag_type=r.get('flag_type') or '',
+            row_country=r.get('country') or '',
+        )
+        pos.append({
+            'po_no': r['po_no'], 'series': r['series'],
+            'item_code': r['item_code'], 'customer_sku': r.get('customer_sku') or '',
+            'variant_letter': r.get('variant_letter') or '',
+            'image_url': r.get('image_url') or '',
+            'letters': letters,
+            'customer': r['customer'] or '', 'country': r['country'] or '',
+            'flag_type': r.get('flag_type') or '', 'flag': r.get('flag') or '',
+            'ratio_normal_text': r.get('ratio_normal_text') or '',
+            'ratio_rare_text': r.get('ratio_rare_text') or '',
+            'name_cn': r['name_cn'] or '', 'plan_ship_date': r['plan_ship_date'] or '',
+            'scheduled_qty': r['qty'],
+        })
+        total_scheduled += r['qty']
+    pos.sort(key=lambda x: (x['plan_ship_date'] or '', x['po_no']))
+
+    # 库存汇总 + 缺口汇总:都按 letter 行逐行累加,跟下面表格逐行判断口径一致。
+    # 不能用 query 直接查库存表 —— query 是客户 SKU/带后缀 ITEM#,不在纯数字 sku 库存表里。
+    # shortage 也必须逐行 sum:某品类不够 + 某品类过剩,不能互相抵消。
+    display_code = query
+    seen_keys = set()
+    stock = 0
+    shortage = 0
+    all_letter_sufficient = True
+    has_any_letter = False
+    for p in pos:
+        for l in p['letters']:
+            if not l.get('bound_sku') or not l.get('bound_name'):
+                all_letter_sufficient = False
+                has_any_letter = True
+                continue
+            inv_flag = l.get('inventory_flag') or l.get('flag') or ''
+            for style_key, stock_key, suf_key, short_key in (
+                ('normal', 'normal_stock', 'normal_sufficient', 'normal_shortage'),
+                ('rare', 'rare_stock', 'rare_sufficient', 'rare_shortage'),
+            ):
+                qty_field = 'normal_qty' if style_key == 'normal' else 'rare_qty'
+                if not l.get(qty_field):
+                    continue
+                has_any_letter = True
+                key = (l['bound_sku'], l['bound_name'], style_key, inv_flag)
+                if key not in seen_keys:
+                    seen_keys.add(key)
+                    s = l.get(stock_key)
+                    if s is not None:
+                        stock += s
+                shortage += l.get(short_key) or 0
+                if not l.get(suf_key):
+                    all_letter_sufficient = False
+
+    sufficient = all_letter_sufficient if has_any_letter else (shortage == 0)
+    return {
+        'type': 'sku', 'item_code': display_code, 'matched_by': matched_by,
+        'pos': pos,
+        'current_stock': stock, 'total_scheduled': total_scheduled,
+        'shortage': shortage, 'sufficient': sufficient,
+    }
+
+
+# ---- 字母绑定 ----
+
+@app.route('/api/letter-bindings', methods=['GET'])
+@login_required
+def api_letter_bindings_list():
+    """
+    返回:
+      bindings: 已配置的绑定列表 [{id, sku, letter, material_name, created_by, created_at}]
+      materials_by_sku: {sku: [该 sku 在入库 / 出库出现过的物料名]} —— 新增弹窗里物料名下拉建议用
+    """
+    bindings = db.query_all_letter_bindings()
+    skus = {b['sku'] for b in bindings}
+    materials_by_sku = {sku: db.get_material_names_for_sku(sku) for sku in skus}
+    return jsonify({'bindings': bindings, 'materials_by_sku': materials_by_sku})
+
+
+@app.route('/api/letter-bindings', methods=['POST'])
+@role_required('admin', 'operator')
+def api_letter_bindings_create():
+    """新增 / 更新字母绑定"""
+    data = request.get_json() or {}
+    sku = (data.get('sku') or '').strip()
+    letter = (data.get('letter') or '').strip()
+    name = (data.get('material_name') or '').strip()
+    if not sku or not letter:
+        return jsonify({'error': '缺少 sku 或 letter'}), 400
+    if not name:
+        return jsonify({'error': '请选择物料名称'}), 400
+    bid = db.upsert_letter_binding(sku, letter, name, session.get('username'))
+    return jsonify({'success': True, 'id': bid})
+
+
+@app.route('/api/letter-bindings/<int:binding_id>', methods=['DELETE'])
+@role_required('admin', 'operator')
+def api_letter_bindings_delete(binding_id):
+    affected = db.delete_letter_binding(binding_id)
+    if affected == 0:
+        return jsonify({'error': '绑定不存在'}), 404
+    return jsonify({'success': True})
+
+
+# ---- 货号别名 (子货号 → 父货号) ----
+
+@app.route('/api/sku-aliases', methods=['GET'])
+@login_required
+def api_sku_aliases_list():
+    return jsonify(db.query_all_sku_aliases())
+
+
+@app.route('/api/sku-aliases', methods=['POST'])
+@role_required('admin', 'operator')
+def api_sku_aliases_create():
+    """新增子货号→父货号映射。body: {alias_prefix, primary_prefix}"""
+    data = request.get_json() or {}
+    alias = (data.get('alias_prefix') or '').strip()
+    primary = (data.get('primary_prefix') or '').strip()
+    if not alias or not primary:
+        return jsonify({'error': '缺少 alias_prefix 或 primary_prefix'}), 400
+    if alias == primary:
+        return jsonify({'error': '子货号不能跟父货号相同'}), 400
+    # 防止链式别名(alias→primary→primary2)
+    existing_map = db.get_sku_alias_map()
+    if primary in existing_map:
+        return jsonify({'error': f'父货号 {primary} 自己已经是子货号(映射到 {existing_map[primary]}),不能再当父货号'}), 400
+    if alias in existing_map:
+        return jsonify({'error': f'子货号 {alias} 已经映射到 {existing_map[alias]},先删除再加'}), 400
+    try:
+        aid = db.insert_sku_alias(alias, primary, session.get('username'))
+    except Exception as e:
+        return jsonify({'error': f'新增失败: {e}'}), 400
+    _invalidate_alias_cache()
+    return jsonify({'success': True, 'id': aid})
+
+
+@app.route('/api/sku-aliases/<int:alias_id>', methods=['DELETE'])
+@role_required('admin', 'operator')
+def api_sku_aliases_delete(alias_id):
+    affected = db.delete_sku_alias(alias_id)
+    if affected == 0:
+        return jsonify({'error': '别名不存在'}), 404
+    _invalidate_alias_cache()
+    return jsonify({'success': True})
+
+
+# ---- 布标映射 ----
+
+@app.route('/api/flag-mappings', methods=['GET'])
+@login_required
+def api_flag_mappings_list():
+    """
+    返回:
+      mappings: 已配置的映射 [{id, flag_type, country, inventory_flag, ...}]
+      unmapped: 排期里有但还没配映射的 (flag_type, country) 组合
+      inventory_flags: 当前库存里所有可选的布标(来自 flags 表)
+    """
+    mappings = db.query_all_flag_mappings()
+    sched_pairs = db.get_schedule_flag_country_pairs()
+    mapped_keys = {(m['flag_type'], m['country']) for m in mappings}
+    unmapped = [p for p in sched_pairs if (p['flag_type'], p['country']) not in mapped_keys]
+    inventory_flags = db.query_all_flags()  # 复用现有"布标维护"里的
+    return jsonify({'mappings': mappings, 'unmapped': unmapped,
+                    'inventory_flags': inventory_flags})
+
+
+@app.route('/api/flag-mappings', methods=['POST'])
+@role_required('admin', 'operator')
+def api_flag_mappings_create():
+    data = request.get_json() or {}
+    ft = (data.get('flag_type') or '').strip()
+    cy = (data.get('country') or '').strip()
+    inv = (data.get('inventory_flag') or '').strip()
+    if not ft or not cy:
+        return jsonify({'error': '缺少 flag_type 或 country'}), 400
+    if not inv:
+        return jsonify({'error': '请填写库存布标'}), 400
+    mid = db.upsert_flag_mapping(ft, cy, inv, session.get('username'))
+    return jsonify({'success': True, 'id': mid})
+
+
+@app.route('/api/flag-mappings/<int:mapping_id>', methods=['DELETE'])
+@role_required('admin', 'operator')
+def api_flag_mappings_delete(mapping_id):
+    affected = db.delete_flag_mapping(mapping_id)
+    if affected == 0:
+        return jsonify({'error': '映射不存在'}), 404
+    return jsonify({'success': True})
+
+
+@app.route('/api/schedule/query', methods=['GET'])
+@login_required
+def api_schedule_query():
+    """
+    搜索排期:q 依次按 PO号 → ITEM#(G) → 客户 SKU(F)三个字段尝试匹配,自动识别
+    """
+    q = (request.args.get('q') or request.args.get('po') or '').strip()
+    if not q:
+        return jsonify({'error': '请输入 PO 号或货号'}), 400
+    po_rows = db.query_po_schedules_by_po(q)
+    if po_rows:
+        return jsonify(_build_po_view(q, po_rows))
+    item_rows = db.query_po_schedules_by_item(q)
+    if item_rows:
+        return jsonify(_build_sku_view(q, item_rows, matched_by='item'))
+    csku_rows = db.query_po_schedules_by_customer_sku(q)
+    if csku_rows:
+        return jsonify(_build_sku_view(q, csku_rows, matched_by='customer_sku'))
+    return jsonify({'type': 'none', 'query': q, 'not_found': True})
+
+
+# ---- 货号细表(xlsx,双 sheet,矩阵布局)----
+
+_THIN = Side(border_style='thin', color='999999')
+_BORDER = Border(left=_THIN, right=_THIN, top=_THIN, bottom=_THIN)
+
+
+def _detect_costume(records, fallback):
+    rs = records or fallback
+    return bool(rs) and rs[0]['category'] == 'costume'
+
+
+def _build_sku_sheet(wb, sheet_name, records, sku, kind, is_costume):
+    """
+    构建一个 sheet:
+      第 1 行:货号(合并居中)
+      第 2 行:空
+      第 3 行:左侧标签列空 + 各变体列的"物料名称 + 款式"
+      第 4 行:左侧标签(入库日期/单号 或 出库日期/单号/PO号/领货人) + 各变体列的布标(戏服空)
+      第 5 行起:每条记录一行,左侧字段 + 在匹配变体列填 qty
+    """
+    ws = wb.create_sheet(sheet_name)
+    left_labels = ['入库日期', '单号'] if kind == 'in' else ['出库日期', '单号', 'PO号', '领货人']
+    left_count = len(left_labels)
+
+    # 变体列:毛绒 = (style, flag) 去重排序,戏服 = style 去重排序
+    if is_costume:
+        styles = sorted({r['style'] for r in records})
+        variants = [(s, '') for s in styles]
+    else:
+        variants = sorted({(r['style'], r['flag']) for r in records})
+    total_cols = left_count + len(variants)
+    if total_cols == 0:
+        total_cols = left_count or 1
+
+    # 物料名称(取记录中第一个非空)
+    name = next((r.get('name') for r in records if r.get('name')), '') or ''
+
+    # 第 1 行:货号
+    c1 = ws.cell(row=1, column=1, value=sku)
+    if total_cols > 1:
+        ws.merge_cells(start_row=1, start_column=1, end_row=1, end_column=total_cols)
+    c1.alignment = Alignment(horizontal='center', vertical='center')
+    c1.font = Font(bold=True, size=14)
+
+    # 第 3 行:变体列的 "物料名称 + 款式"
+    for i, (style, _flag) in enumerate(variants):
+        col = left_count + 1 + i
+        head = f'{name} {_style_label(style)}'.strip() if name else _style_label(style)
+        cell = ws.cell(row=3, column=col, value=head)
+        cell.alignment = Alignment(horizontal='center', vertical='center', wrap_text=True)
+        cell.font = Font(bold=True)
+        cell.border = _BORDER
+
+    # 第 4 行:左侧标签 + 布标
+    for i, lab in enumerate(left_labels):
+        cell = ws.cell(row=4, column=i + 1, value=lab)
+        cell.alignment = Alignment(horizontal='center', vertical='center')
+        cell.font = Font(bold=True)
+        cell.border = _BORDER
+    if not is_costume:
+        for i, (_style, flag) in enumerate(variants):
+            col = left_count + 1 + i
+            cell = ws.cell(row=4, column=col, value=flag)
+            cell.alignment = Alignment(horizontal='center', vertical='center')
+            cell.font = Font(bold=True)
+            cell.border = _BORDER
+
+    # 数据行
+    variant_index = {v: i for i, v in enumerate(variants)}
+    sorted_records = sorted(records, key=lambda r: (r['date'], r['id']))
+    for row_i, r in enumerate(sorted_records):
+        excel_row = 5 + row_i
+        ws.cell(row=excel_row, column=1, value=r['date']).border = _BORDER
+        ws.cell(row=excel_row, column=2, value=r['bill_no']).border = _BORDER
+        if kind == 'out':
+            ws.cell(row=excel_row, column=3, value=r.get('po', '') or '').border = _BORDER
+            ws.cell(row=excel_row, column=4, value=r.get('picker', '') or '').border = _BORDER
+        key = (r['style'], '') if is_costume else (r['style'], r['flag'])
+        if key in variant_index:
+            col = left_count + 1 + variant_index[key]
+            cell = ws.cell(row=excel_row, column=col, value=r['qty'])
+            cell.alignment = Alignment(horizontal='center')
+            cell.border = _BORDER
+        # 给空变体列也加边框,保持矩阵感
+        for i, v in enumerate(variants):
+            if v != key:
+                ws.cell(row=excel_row, column=left_count + 1 + i).border = _BORDER
+
+    # 列宽:左侧标签 12,变体列按表头长度 max 14
+    for i in range(1, left_count + 1):
+        ws.column_dimensions[get_column_letter(i)].width = 12
+    for i in range(len(variants)):
+        col_letter = get_column_letter(left_count + 1 + i)
+        ws.column_dimensions[col_letter].width = 16
+
+
+@app.route('/api/export/sku/<path:sku>', methods=['GET'])
+@login_required
+def api_export_sku_detail(sku):
+    """
+    导出单个货号的出入库细表(xlsx 双 sheet 矩阵布局)
+    - 一个货号一个文件,入库 / 出库 各一个 sheet
+    - 列 = (款式, 布标) 唯一组合;戏服没有布标,列 = 款式;戏服 sheet 跳过布标表头
+    """
+    in_records = [r for r in db.query_all_in_records() if r['sku'] == sku]
+    out_records = [r for r in db.query_all_out_records() if r['sku'] == sku]
+
+    if not in_records and not out_records:
+        return jsonify({'error': f'货号 "{sku}" 没有任何出入库记录'}), 404
+
+    wb = openpyxl.Workbook()
+    wb.remove(wb.active)
+    _build_sku_sheet(wb, '入库', in_records, sku,
+                     kind='in', is_costume=_detect_costume(in_records, out_records))
+    _build_sku_sheet(wb, '出库', out_records, sku,
+                     kind='out', is_costume=_detect_costume(out_records, in_records))
+
+    buf = io.BytesIO()
+    wb.save(buf)
+    buf.seek(0)
+
+    filename = f'{sku}_出入库明细_{datetime.now().strftime("%Y%m%d")}.xlsx'
+    return Response(
+        buf.getvalue(),
+        mimetype='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        headers={'Content-Disposition': f"attachment; filename*=UTF-8''{quote(filename)}"}
+    )
+
+
+# ==================== 启动 ====================
+
+if __name__ == '__main__':
+    # 开发模式:Flask 自带服务器
+    print('=' * 50)
+    print('华登库存管理系统(毛绒 + 戏服)')
+    print('=' * 50)
+    print()
+    print('访问地址:')
+    print('  本机:        http://localhost:5002')
+    print('  局域网其他人: http://<本机IP>:5002')
+    print()
+    print('默认账号(请尽快改密码):')
+    print('  admin / 123456 (主管)')
+    print('  cg / 123456    (仓管员)')
+    print('  yk / 123456    (游客)')
+    print()
+    print('按 Ctrl+C 停止服务')
+    print('=' * 50)
+
+    app.run(host='0.0.0.0', port=5002, debug=True)

--- a/apps/PMC跟仓管/华登毛绒仓库/auth.py
+++ b/apps/PMC跟仓管/华登毛绒仓库/auth.py
@@ -1,0 +1,60 @@
+"""
+认证和权限模块
+- 密码哈希
+- 登录验证装饰器
+- 角色权限装饰器
+"""
+import hashlib
+from functools import wraps
+from flask import session, jsonify, request, redirect, url_for
+
+
+PASSWORD_SALT = 'huadeng_plush_2026_salt'
+
+
+def hash_password(password):
+    """密码哈希(加盐 SHA-256)"""
+    return hashlib.sha256((password + PASSWORD_SALT).encode('utf-8')).hexdigest()
+
+
+def check_password(password, password_hash):
+    """验证密码"""
+    return hash_password(password) == password_hash
+
+
+def login_required(f):
+    """装饰器:必须登录"""
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        if 'user_id' not in session:
+            if request.path.startswith('/api/'):
+                return jsonify({'error': '未登录'}), 401
+            return redirect(url_for('login_page'))
+        return f(*args, **kwargs)
+    return decorated
+
+
+def role_required(*allowed_roles):
+    """装饰器:指定角色才能访问"""
+    def decorator(f):
+        @wraps(f)
+        def decorated(*args, **kwargs):
+            if 'user_id' not in session:
+                return jsonify({'error': '未登录'}), 401
+            if session.get('role') not in allowed_roles:
+                return jsonify({'error': '权限不足'}), 403
+            return f(*args, **kwargs)
+        return decorated
+    return decorator
+
+
+def current_user():
+    """获取当前用户信息"""
+    if 'user_id' not in session:
+        return None
+    return {
+        'id': session.get('user_id'),
+        'username': session.get('username'),
+        'role': session.get('role'),
+        'display_name': session.get('display_name')
+    }

--- a/apps/PMC跟仓管/华登毛绒仓库/backup.py
+++ b/apps/PMC跟仓管/华登毛绒仓库/backup.py
@@ -1,0 +1,43 @@
+"""
+数据库备份脚本
+使用:python backup.py
+建议设置为定时任务每天凌晨 2 点跑(Windows 任务计划 / Linux cron)
+"""
+import shutil
+import os
+import glob
+from datetime import datetime, timedelta
+
+BACKUP_DIR = 'backup'
+KEEP_DAYS = 30
+DB_PATH = 'data/inventory.db'
+
+
+def backup():
+    os.makedirs(BACKUP_DIR, exist_ok=True)
+
+    if not os.path.exists(DB_PATH):
+        print(f'✗ 数据库文件不存在: {DB_PATH}')
+        return False
+
+    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+    dst = f'{BACKUP_DIR}/inventory_{timestamp}.db'
+    shutil.copy2(DB_PATH, dst)
+    size_kb = os.path.getsize(dst) / 1024
+    print(f'✓ 备份完成: {dst} ({size_kb:.1f} KB)')
+
+    # 删除 30 天前的备份
+    cutoff = datetime.now() - timedelta(days=KEEP_DAYS)
+    cleaned = 0
+    for f in glob.glob(f'{BACKUP_DIR}/inventory_*.db'):
+        if datetime.fromtimestamp(os.path.getmtime(f)) < cutoff:
+            os.remove(f)
+            cleaned += 1
+    if cleaned:
+        print(f'✓ 清理了 {cleaned} 个 {KEEP_DAYS} 天前的旧备份')
+
+    return True
+
+
+if __name__ == '__main__':
+    backup()

--- a/apps/PMC跟仓管/华登毛绒仓库/database.py
+++ b/apps/PMC跟仓管/华登毛绒仓库/database.py
@@ -1,0 +1,825 @@
+"""
+数据库模块
+负责 SQLite 连接、初始化和增删改查操作
+
+【关键设计】
+- 出入库共用一套表,通过 category 字段区分品类:
+    - 'plush'   = 毛绒(主要业务)
+    - 'costume' = 戏服
+- 毛绒的"款式"和戏服的"类型"都存在 style 列里:
+    - 毛绒只有 'normal' / 'rare' 两个值
+    - 戏服是自由文本(如 "M码连衣裙"、"L码上衣")
+
+【库存计算公式】
+库存数量不单独存储,每次查询时实时计算:
+    库存 = SUM(入库数量) - SUM(出库数量)
+    WHERE category=? AND sku=? AND style=? AND flag=?
+
+四个维度组合才唯一确定一个库存单元。
+"""
+import sqlite3
+import os
+from contextlib import contextmanager
+
+# 数据库路径：优先环境变量 DATA_PATH（容器 bind mount），否则源码同目录 data/
+_DEFAULT_DATA_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
+DATA_DIR = os.environ.get('DATA_PATH') or _DEFAULT_DATA_DIR
+DB_PATH = os.path.join(DATA_DIR, 'inventory.db')
+
+
+def get_db():
+    """获取数据库连接,行结果会自动转成字典格式"""
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    conn.execute('PRAGMA foreign_keys = ON')
+    return conn
+
+
+@contextmanager
+def db_cursor():
+    """
+    上下文管理器,自动提交事务和关闭连接
+    用法:
+        with db_cursor() as cur:
+            cur.execute('SELECT * FROM users')
+    """
+    conn = get_db()
+    try:
+        cursor = conn.cursor()
+        yield cursor
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def init_database():
+    """初始化数据库表结构(幂等,可以重复运行)"""
+    os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
+
+    with db_cursor() as cur:
+        # 用户表
+        cur.execute('''
+            CREATE TABLE IF NOT EXISTS users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                username TEXT UNIQUE NOT NULL,
+                password_hash TEXT NOT NULL,
+                role TEXT NOT NULL CHECK(role IN ('admin', 'operator', 'viewer')),
+                display_name TEXT,
+                created_at TEXT DEFAULT CURRENT_TIMESTAMP
+            )
+        ''')
+
+        # 布标表
+        cur.execute('''
+            CREATE TABLE IF NOT EXISTS flags (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT UNIQUE NOT NULL,
+                sort_order INTEGER DEFAULT 0
+            )
+        ''')
+
+        # 入库流水表
+        # category: 'plush'(毛绒) | 'costume'(戏服)
+        # style:
+        #   - 毛绒: 'normal' | 'rare'
+        #   - 戏服: 自由文本(如 'M码连衣裙')
+        # flag:
+        #   - 毛绒: 必填(按国家命名的布标)
+        #   - 戏服: 始终为空字符串''(戏服没有布标这个字段)
+        cur.execute('''
+            CREATE TABLE IF NOT EXISTS in_records (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                category TEXT NOT NULL DEFAULT 'plush' CHECK(category IN ('plush', 'costume')),
+                date TEXT NOT NULL,
+                bill_no TEXT NOT NULL,
+                sku TEXT NOT NULL,
+                name TEXT,
+                style TEXT NOT NULL,
+                flag TEXT NOT NULL DEFAULT '',
+                qty INTEGER NOT NULL CHECK(qty > 0),
+                created_by TEXT,
+                created_at TEXT DEFAULT CURRENT_TIMESTAMP
+            )
+        ''')
+
+        # 出库流水表
+        cur.execute('''
+            CREATE TABLE IF NOT EXISTS out_records (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                category TEXT NOT NULL DEFAULT 'plush' CHECK(category IN ('plush', 'costume')),
+                date TEXT NOT NULL,
+                bill_no TEXT NOT NULL,
+                po TEXT,
+                picker TEXT,
+                sku TEXT NOT NULL,
+                name TEXT,
+                style TEXT NOT NULL,
+                flag TEXT NOT NULL DEFAULT '',
+                qty INTEGER NOT NULL CHECK(qty > 0),
+                created_by TEXT,
+                created_at TEXT DEFAULT CURRENT_TIMESTAMP
+            )
+        ''')
+
+        # 索引(加快按品类 / 货号 / 日期查询)
+        cur.execute('CREATE INDEX IF NOT EXISTS idx_in_category ON in_records(category)')
+        cur.execute('CREATE INDEX IF NOT EXISTS idx_in_sku ON in_records(sku)')
+        cur.execute('CREATE INDEX IF NOT EXISTS idx_in_date ON in_records(date)')
+        cur.execute('CREATE INDEX IF NOT EXISTS idx_out_category ON out_records(category)')
+        cur.execute('CREATE INDEX IF NOT EXISTS idx_out_sku ON out_records(sku)')
+        cur.execute('CREATE INDEX IF NOT EXISTS idx_out_date ON out_records(date)')
+        cur.execute('CREATE INDEX IF NOT EXISTS idx_out_po ON out_records(po)')
+
+        # 排期表(整库替换式,每次上传清空重建)
+        cur.execute('''
+            CREATE TABLE IF NOT EXISTS po_schedules (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                series TEXT NOT NULL,
+                po_no TEXT NOT NULL,
+                item_code TEXT NOT NULL,
+                customer_sku TEXT,
+                qty INTEGER NOT NULL,
+                customer TEXT,
+                country TEXT,
+                name_cn TEXT,
+                plan_ship_date TEXT,
+                uploaded_by TEXT,
+                uploaded_at TEXT DEFAULT CURRENT_TIMESTAMP
+            )
+        ''')
+        # 旧库迁移(必须在建索引前做)
+        for col, ddl in (
+            ('customer_sku', 'ALTER TABLE po_schedules ADD COLUMN customer_sku TEXT'),
+            ('variant_letter', 'ALTER TABLE po_schedules ADD COLUMN variant_letter TEXT'),
+            ('image_url', 'ALTER TABLE po_schedules ADD COLUMN image_url TEXT'),
+            ('letters_json', 'ALTER TABLE po_schedules ADD COLUMN letters_json TEXT'),
+            ('flag_type', 'ALTER TABLE po_schedules ADD COLUMN flag_type TEXT'),
+            ('flag', 'ALTER TABLE po_schedules ADD COLUMN flag TEXT'),
+            ('ratio_normal_text', 'ALTER TABLE po_schedules ADD COLUMN ratio_normal_text TEXT'),
+            ('ratio_rare_text', 'ALTER TABLE po_schedules ADD COLUMN ratio_rare_text TEXT'),
+        ):
+            try:
+                cur.execute(ddl)
+            except sqlite3.OperationalError:
+                pass  # 已存在
+        cur.execute('CREATE INDEX IF NOT EXISTS idx_po_schedules_po ON po_schedules(po_no)')
+        cur.execute('CREATE INDEX IF NOT EXISTS idx_po_schedules_item ON po_schedules(item_code)')
+        cur.execute('CREATE INDEX IF NOT EXISTS idx_po_schedules_csku ON po_schedules(customer_sku)')
+
+        # 字母绑定:(sku, letter) → material_name
+        cur.execute('''
+            CREATE TABLE IF NOT EXISTS letter_bindings (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                sku TEXT NOT NULL,
+                letter TEXT NOT NULL,
+                material_name TEXT NOT NULL,
+                created_by TEXT,
+                created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE(sku, letter)
+            )
+        ''')
+        cur.execute('CREATE INDEX IF NOT EXISTS idx_lb_sku_letter ON letter_bindings(sku, letter)')
+
+        # 货号别名:子货号 → 父货号(自动复用父货号的字母绑定 + 库存)
+        cur.execute('''
+            CREATE TABLE IF NOT EXISTS sku_aliases (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                alias_prefix   TEXT NOT NULL UNIQUE,
+                primary_prefix TEXT NOT NULL,
+                created_by TEXT,
+                created_at TEXT DEFAULT CURRENT_TIMESTAMP
+            )
+        ''')
+        cur.execute('CREATE INDEX IF NOT EXISTS idx_sa_primary ON sku_aliases(primary_prefix)')
+
+        # 布标映射:(排期布标, 国家) → 入库实际布标
+        cur.execute('''
+            CREATE TABLE IF NOT EXISTS flag_mappings (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                flag_type TEXT NOT NULL,
+                country TEXT NOT NULL,
+                inventory_flag TEXT NOT NULL,
+                created_by TEXT,
+                created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE(flag_type, country)
+            )
+        ''')
+        cur.execute('CREATE INDEX IF NOT EXISTS idx_fm_type_country ON flag_mappings(flag_type, country)')
+
+
+# ==================== 入库记录操作 ====================
+
+def query_all_in_records(category=None):
+    """
+    查询入库记录,按日期倒序
+    :param category: 可选,'plush' 或 'costume',传 None 表示查询全部
+    """
+    with db_cursor() as cur:
+        if category:
+            cur.execute(
+                'SELECT * FROM in_records WHERE category = ? ORDER BY date DESC, id DESC',
+                (category,)
+            )
+        else:
+            cur.execute('SELECT * FROM in_records ORDER BY date DESC, id DESC')
+        return [dict(row) for row in cur.fetchall()]
+
+
+def insert_in_record(data, username):
+    """
+    新增入库记录
+    :param data: dict,必须包含 category, date, billNo, sku, style, flag, qty
+                 可选 name
+    :param username: 创建人
+    :return: 新记录的 id
+    """
+    with db_cursor() as cur:
+        cur.execute(
+            '''INSERT INTO in_records
+               (category, date, bill_no, sku, name, style, flag, qty, created_by)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)''',
+            (data.get('category', 'plush'), data['date'], data['billNo'],
+             data['sku'], data.get('name', ''),
+             data['style'], data['flag'], data['qty'], username)
+        )
+        return cur.lastrowid
+
+
+def delete_in_record(record_id):
+    """删除入库记录"""
+    with db_cursor() as cur:
+        cur.execute('DELETE FROM in_records WHERE id = ?', (record_id,))
+
+
+def delete_in_records_batch(ids):
+    """批量删除入库记录(单事务),返回删除条数"""
+    if not ids:
+        return 0
+    with db_cursor() as cur:
+        placeholders = ','.join('?' * len(ids))
+        cur.execute(f'DELETE FROM in_records WHERE id IN ({placeholders})', list(ids))
+        return cur.rowcount
+
+
+def update_in_record(record_id, data):
+    """更新入库记录,返回受影响的行数"""
+    with db_cursor() as cur:
+        cur.execute(
+            '''UPDATE in_records
+               SET category=?, date=?, bill_no=?, sku=?, name=?, style=?, flag=?, qty=?
+               WHERE id=?''',
+            (data.get('category', 'plush'), data['date'], data['billNo'],
+             data['sku'], data.get('name', ''),
+             data['style'], data['flag'], data['qty'], record_id)
+        )
+        return cur.rowcount
+
+
+# ==================== 出库记录操作 ====================
+
+def query_all_out_records(category=None):
+    """
+    查询出库记录,按日期倒序
+    :param category: 可选,'plush' 或 'costume',传 None 表示查询全部
+    """
+    with db_cursor() as cur:
+        if category:
+            cur.execute(
+                'SELECT * FROM out_records WHERE category = ? ORDER BY date DESC, id DESC',
+                (category,)
+            )
+        else:
+            cur.execute('SELECT * FROM out_records ORDER BY date DESC, id DESC')
+        return [dict(row) for row in cur.fetchall()]
+
+
+def insert_out_record(data, username):
+    """
+    新增出库记录
+    :param data: dict,必须包含 category, date, billNo, sku, style, flag, qty
+                 可选 name, po, picker
+    :param username: 创建人
+    :return: 新记录的 id
+    """
+    with db_cursor() as cur:
+        cur.execute(
+            '''INSERT INTO out_records
+               (category, date, bill_no, po, picker, sku, name, style, flag, qty, created_by)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)''',
+            (data.get('category', 'plush'), data['date'], data['billNo'],
+             data.get('po', ''), data.get('picker', ''),
+             data['sku'], data.get('name', ''),
+             data['style'], data['flag'], data['qty'], username)
+        )
+        return cur.lastrowid
+
+
+def insert_out_records_batch(records, username):
+    """
+    批量新增出库记录(单事务,任一条失败全部回滚)
+    :param records: list[dict],每条同 insert_out_record 的 data
+    :param username: 创建人
+    :return: list[int] 新记录 id
+    """
+    ids = []
+    with db_cursor() as cur:
+        for data in records:
+            cur.execute(
+                '''INSERT INTO out_records
+                   (category, date, bill_no, po, picker, sku, name, style, flag, qty, created_by)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)''',
+                (data.get('category', 'plush'), data['date'], data['billNo'],
+                 data.get('po', ''), data.get('picker', ''),
+                 data['sku'], data.get('name', ''),
+                 data['style'], data['flag'], data['qty'], username)
+            )
+            ids.append(cur.lastrowid)
+    return ids
+
+
+def delete_out_record(record_id):
+    """删除出库记录"""
+    with db_cursor() as cur:
+        cur.execute('DELETE FROM out_records WHERE id = ?', (record_id,))
+
+
+def delete_out_records_batch(ids):
+    """批量删除出库记录(单事务),返回删除条数"""
+    if not ids:
+        return 0
+    with db_cursor() as cur:
+        placeholders = ','.join('?' * len(ids))
+        cur.execute(f'DELETE FROM out_records WHERE id IN ({placeholders})', list(ids))
+        return cur.rowcount
+
+
+def update_out_record(record_id, data):
+    """更新出库记录,返回受影响的行数"""
+    with db_cursor() as cur:
+        cur.execute(
+            '''UPDATE out_records
+               SET category=?, date=?, bill_no=?, po=?, picker=?,
+                   sku=?, name=?, style=?, flag=?, qty=?
+               WHERE id=?''',
+            (data.get('category', 'plush'), data['date'], data['billNo'],
+             data.get('po', ''), data.get('picker', ''),
+             data['sku'], data.get('name', ''),
+             data['style'], data['flag'], data['qty'], record_id)
+        )
+        return cur.rowcount
+
+
+# ==================== 库存计算(核心,Claude Code 必须严格按公式实现) ====================
+
+def calculate_stock(category, sku, style, flag):
+    """
+    计算指定规格的当前库存
+
+    公式: 库存 = SUM(入库数量) - SUM(出库数量)
+    维度: category + sku + style + flag 四者组合唯一定位一个库存单元
+
+    :return: int 库存数量(可能为负数,代表超额出库)
+    """
+    with db_cursor() as cur:
+        cur.execute(
+            '''SELECT COALESCE(SUM(qty), 0) AS total FROM in_records
+               WHERE category=? AND sku=? AND style=? AND flag=?''',
+            (category, sku, style, flag)
+        )
+        in_total = cur.fetchone()['total']
+
+        cur.execute(
+            '''SELECT COALESCE(SUM(qty), 0) AS total FROM out_records
+               WHERE category=? AND sku=? AND style=? AND flag=?''',
+            (category, sku, style, flag)
+        )
+        out_total = cur.fetchone()['total']
+
+        return in_total - out_total
+
+
+def get_stock_summary(category=None):
+    """
+    获取库存汇总,按 (category, sku, style, flag) 分组
+
+    实现思路:用 UNION ALL 把入库和出库流水合并成统一格式,然后 GROUP BY 聚合
+    入库行 qty 计入 in_qty,出库行 qty 计入 out_qty,最后 SUM 求和
+
+    :param category: 可选,筛选品类
+    :return: list[dict],每条字段:
+             category, sku, name, style, flag, in_total, out_total, stock
+    """
+    if category:
+        sql = '''
+            SELECT category, sku, MAX(name) AS name, style, flag,
+                   SUM(in_qty) AS in_total,
+                   SUM(out_qty) AS out_total,
+                   SUM(in_qty) - SUM(out_qty) AS stock
+            FROM (
+                SELECT category, sku, name, style, flag, qty AS in_qty, 0 AS out_qty
+                FROM in_records WHERE category = ?
+                UNION ALL
+                SELECT category, sku, name, style, flag, 0 AS in_qty, qty AS out_qty
+                FROM out_records WHERE category = ?
+            )
+            GROUP BY category, sku, style, flag
+            ORDER BY sku, style, flag
+        '''
+        params = (category, category)
+    else:
+        sql = '''
+            SELECT category, sku, MAX(name) AS name, style, flag,
+                   SUM(in_qty) AS in_total,
+                   SUM(out_qty) AS out_total,
+                   SUM(in_qty) - SUM(out_qty) AS stock
+            FROM (
+                SELECT category, sku, name, style, flag, qty AS in_qty, 0 AS out_qty
+                FROM in_records
+                UNION ALL
+                SELECT category, sku, name, style, flag, 0 AS in_qty, qty AS out_qty
+                FROM out_records
+            )
+            GROUP BY category, sku, style, flag
+            ORDER BY category, sku, style, flag
+        '''
+        params = ()
+
+    with db_cursor() as cur:
+        cur.execute(sql, params)
+        return [dict(row) for row in cur.fetchall()]
+
+
+# ==================== 布标操作 ====================
+
+def query_all_flags():
+    """返回布标名称数组(按 sort_order, id 排序)"""
+    with db_cursor() as cur:
+        cur.execute('SELECT name FROM flags ORDER BY sort_order, id')
+        return [row['name'] for row in cur.fetchall()]
+
+
+def add_flag(name):
+    """
+    新增布标,sort_order 自动取当前最大值 + 1
+    name 已在 schema 上设 UNIQUE,重复插入会抛 sqlite3.IntegrityError
+    """
+    with db_cursor() as cur:
+        cur.execute('SELECT COALESCE(MAX(sort_order), 0) AS m FROM flags')
+        next_order = cur.fetchone()['m'] + 1
+        cur.execute(
+            'INSERT INTO flags (name, sort_order) VALUES (?, ?)',
+            (name, next_order)
+        )
+        return cur.lastrowid
+
+
+def delete_flag(name):
+    """按名称删除布标,返回受影响的行数"""
+    with db_cursor() as cur:
+        cur.execute('DELETE FROM flags WHERE name = ?', (name,))
+        return cur.rowcount
+
+
+# ==================== 用户操作 ====================
+
+def get_user_by_username(username):
+    """按用户名查询用户(登录用)"""
+    with db_cursor() as cur:
+        cur.execute('SELECT * FROM users WHERE username = ?', (username,))
+        row = cur.fetchone()
+        return dict(row) if row else None
+
+
+def query_all_users():
+    """查询所有用户(不含 password_hash),按 id 升序"""
+    with db_cursor() as cur:
+        cur.execute(
+            '''SELECT id, username, role, display_name, created_at
+               FROM users ORDER BY id'''
+        )
+        return [dict(row) for row in cur.fetchall()]
+
+
+def get_user_by_id(user_id):
+    """按 ID 查询用户(含 password_hash,内部校验用)"""
+    with db_cursor() as cur:
+        cur.execute('SELECT * FROM users WHERE id = ?', (user_id,))
+        row = cur.fetchone()
+        return dict(row) if row else None
+
+
+def insert_user(username, password_hash, role, display_name):
+    """
+    新增用户
+    username 已在 schema 上设 UNIQUE,重复插入会抛 sqlite3.IntegrityError
+    """
+    with db_cursor() as cur:
+        cur.execute(
+            '''INSERT INTO users (username, password_hash, role, display_name)
+               VALUES (?, ?, ?, ?)''',
+            (username, password_hash, role, display_name)
+        )
+        return cur.lastrowid
+
+
+def delete_user(user_id):
+    """删除用户,返回受影响的行数"""
+    with db_cursor() as cur:
+        cur.execute('DELETE FROM users WHERE id = ?', (user_id,))
+        return cur.rowcount
+
+
+def update_user_password(user_id, new_password_hash):
+    """更新密码,返回受影响的行数"""
+    with db_cursor() as cur:
+        cur.execute(
+            'UPDATE users SET password_hash = ? WHERE id = ?',
+            (new_password_hash, user_id)
+        )
+        return cur.rowcount
+
+
+# ==================== 排期表操作 ====================
+
+def replace_po_schedules(rows, username):
+    """整库替换:清空 po_schedules 后批量插入 rows(list[dict])"""
+    with db_cursor() as cur:
+        cur.execute('DELETE FROM po_schedules')
+        cur.execute('DELETE FROM sqlite_sequence WHERE name="po_schedules"')
+        cur.executemany(
+            '''INSERT INTO po_schedules
+               (series, po_no, item_code, customer_sku, variant_letter, qty,
+                customer, country, flag_type, flag, ratio_normal_text, ratio_rare_text,
+                name_cn, plan_ship_date, image_url, letters_json, uploaded_by)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)''',
+            [(r['series'], r['po_no'], r['item_code'], r.get('customer_sku', ''),
+              r.get('variant_letter', ''), r['qty'],
+              r.get('customer', ''), r.get('country', ''),
+              r.get('flag_type', ''), r.get('flag', ''),
+              r.get('ratio_normal_text', ''), r.get('ratio_rare_text', ''),
+              r.get('name_cn', ''), r.get('plan_ship_date', ''),
+              r.get('image_url', ''), r.get('letters_json', ''), username)
+             for r in rows]
+        )
+
+
+def query_po_schedules_by_po(po_no):
+    """按 PO 号精确查询(去前后空白后小写不敏感)"""
+    with db_cursor() as cur:
+        cur.execute(
+            '''SELECT * FROM po_schedules
+               WHERE TRIM(LOWER(po_no)) = TRIM(LOWER(?))
+               ORDER BY item_code, id''',
+            (po_no,)
+        )
+        return [dict(row) for row in cur.fetchall()]
+
+
+def query_po_schedules_by_item(item_code):
+    """按 ITEM#(货号)查询所有涉及的 PO 行"""
+    with db_cursor() as cur:
+        cur.execute(
+            '''SELECT * FROM po_schedules
+               WHERE TRIM(LOWER(item_code)) = TRIM(LOWER(?))
+               ORDER BY po_no, id''',
+            (item_code,)
+        )
+        return [dict(row) for row in cur.fetchall()]
+
+
+def query_po_schedules_by_customer_sku(customer_sku):
+    """按客户 SKU(F 列)查询所有涉及的 PO 行"""
+    with db_cursor() as cur:
+        cur.execute(
+            '''SELECT * FROM po_schedules
+               WHERE TRIM(LOWER(customer_sku)) = TRIM(LOWER(?))
+               ORDER BY po_no, id''',
+            (customer_sku,)
+        )
+        return [dict(row) for row in cur.fetchall()]
+
+
+def get_schedule_info():
+    """返回当前排期表数据状态:总行数 / 涉及 PO 数 / 涉及 ITEM 数 / 最后上传时间和人"""
+    with db_cursor() as cur:
+        cur.execute('SELECT COUNT(*) AS c FROM po_schedules')
+        count = cur.fetchone()['c']
+        if count == 0:
+            return {'count': 0, 'po_count': 0, 'item_count': 0,
+                    'last_uploaded_at': '', 'last_uploaded_by': ''}
+        cur.execute('SELECT COUNT(DISTINCT po_no) AS c FROM po_schedules')
+        po_count = cur.fetchone()['c']
+        cur.execute('SELECT COUNT(DISTINCT item_code) AS c FROM po_schedules')
+        item_count = cur.fetchone()['c']
+        cur.execute('SELECT uploaded_at, uploaded_by FROM po_schedules ORDER BY id DESC LIMIT 1')
+        last = cur.fetchone()
+        return {
+            'count': count, 'po_count': po_count, 'item_count': item_count,
+            'last_uploaded_at': last['uploaded_at'] or '',
+            'last_uploaded_by': last['uploaded_by'] or '',
+        }
+
+
+def get_sku_total_stock(sku):
+    """按货号汇总当前总库存(所有 style+flag 之和),用于排期对比"""
+    with db_cursor() as cur:
+        cur.execute(
+            'SELECT COALESCE(SUM(qty), 0) AS total FROM in_records WHERE sku=?',
+            (sku,)
+        )
+        in_total = cur.fetchone()['total']
+        cur.execute(
+            'SELECT COALESCE(SUM(qty), 0) AS total FROM out_records WHERE sku=?',
+            (sku,)
+        )
+        out_total = cur.fetchone()['total']
+        return in_total - out_total
+
+
+def get_stock_by_sku_name(sku, material_name):
+    """按 sku + 物料名汇总库存(用于字母绑定后的精确对比)"""
+    with db_cursor() as cur:
+        cur.execute(
+            'SELECT COALESCE(SUM(qty), 0) AS t FROM in_records WHERE sku=? AND name=?',
+            (sku, material_name)
+        )
+        in_total = cur.fetchone()['t']
+        cur.execute(
+            'SELECT COALESCE(SUM(qty), 0) AS t FROM out_records WHERE sku=? AND name=?',
+            (sku, material_name)
+        )
+        out_total = cur.fetchone()['t']
+        return in_total - out_total
+
+
+def get_stock_by_full_dim(sku, material_name, style, flag):
+    """按 sku + 物料名 + style(normal/rare) + flag(布标-国家) 四维精确查库存"""
+    with db_cursor() as cur:
+        cur.execute(
+            'SELECT COALESCE(SUM(qty), 0) AS t FROM in_records WHERE sku=? AND name=? AND style=? AND flag=?',
+            (sku, material_name, style, flag)
+        )
+        in_total = cur.fetchone()['t']
+        cur.execute(
+            'SELECT COALESCE(SUM(qty), 0) AS t FROM out_records WHERE sku=? AND name=? AND style=? AND flag=?',
+            (sku, material_name, style, flag)
+        )
+        out_total = cur.fetchone()['t']
+        return in_total - out_total
+
+
+def get_material_names_for_sku(sku):
+    """该 sku 下入库 / 出库记录里出现过的所有非空物料名(去重)"""
+    with db_cursor() as cur:
+        cur.execute('''
+            SELECT DISTINCT name FROM (
+                SELECT name FROM in_records WHERE sku=? AND name != ''
+                UNION
+                SELECT name FROM out_records WHERE sku=? AND name != ''
+            ) ORDER BY name
+        ''', (sku, sku))
+        return [row['name'] for row in cur.fetchall()]
+
+
+# ==================== 字母绑定 ====================
+
+def query_all_letter_bindings():
+    """列出所有 (sku, letter, material_name) 绑定"""
+    with db_cursor() as cur:
+        cur.execute('SELECT * FROM letter_bindings ORDER BY sku, letter')
+        return [dict(r) for r in cur.fetchall()]
+
+
+def get_letter_binding(sku, letter):
+    """按 (sku, letter) 取 material_name"""
+    with db_cursor() as cur:
+        cur.execute('SELECT * FROM letter_bindings WHERE sku=? AND letter=?', (sku, letter))
+        row = cur.fetchone()
+        return dict(row) if row else None
+
+
+def upsert_letter_binding(sku, letter, material_name, username):
+    """新增或更新 (sku, letter) → material_name"""
+    with db_cursor() as cur:
+        cur.execute('''
+            INSERT INTO letter_bindings (sku, letter, material_name, created_by)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(sku, letter) DO UPDATE SET material_name=excluded.material_name
+        ''', (sku, letter, material_name, username))
+        return cur.lastrowid
+
+
+def delete_letter_binding(binding_id):
+    """删除绑定"""
+    with db_cursor() as cur:
+        cur.execute('DELETE FROM letter_bindings WHERE id=?', (binding_id,))
+        return cur.rowcount
+
+
+# ==================== 货号别名 ====================
+
+def query_all_sku_aliases():
+    """列出所有 (子货号 → 父货号) 别名"""
+    with db_cursor() as cur:
+        cur.execute('SELECT * FROM sku_aliases ORDER BY primary_prefix, alias_prefix')
+        return [dict(r) for r in cur.fetchall()]
+
+
+def get_sku_alias_map():
+    """返回 {alias_prefix: primary_prefix} 全表字典"""
+    with db_cursor() as cur:
+        cur.execute('SELECT alias_prefix, primary_prefix FROM sku_aliases')
+        return {r['alias_prefix']: r['primary_prefix'] for r in cur.fetchall()}
+
+
+def insert_sku_alias(alias_prefix, primary_prefix, username):
+    """新增别名,UNIQUE(alias_prefix) 冲突会抛 IntegrityError"""
+    with db_cursor() as cur:
+        cur.execute('''
+            INSERT INTO sku_aliases (alias_prefix, primary_prefix, created_by)
+            VALUES (?, ?, ?)
+        ''', (alias_prefix, primary_prefix, username))
+        return cur.lastrowid
+
+
+def delete_sku_alias(alias_id):
+    with db_cursor() as cur:
+        cur.execute('DELETE FROM sku_aliases WHERE id=?', (alias_id,))
+        return cur.rowcount
+
+
+# ==================== 布标映射 ====================
+
+def query_all_flag_mappings():
+    """列出所有 (排期布标类型, 国家) → 入库布标 映射"""
+    with db_cursor() as cur:
+        cur.execute('SELECT * FROM flag_mappings ORDER BY flag_type, country')
+        return [dict(r) for r in cur.fetchall()]
+
+
+def get_flag_mapping(flag_type, country):
+    """按 (flag_type, country) 取映射"""
+    with db_cursor() as cur:
+        cur.execute(
+            'SELECT * FROM flag_mappings WHERE flag_type=? AND country=?',
+            (flag_type, country)
+        )
+        row = cur.fetchone()
+        return dict(row) if row else None
+
+
+def upsert_flag_mapping(flag_type, country, inventory_flag, username):
+    with db_cursor() as cur:
+        cur.execute('''
+            INSERT INTO flag_mappings (flag_type, country, inventory_flag, created_by)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(flag_type, country) DO UPDATE SET inventory_flag=excluded.inventory_flag
+        ''', (flag_type, country, inventory_flag, username))
+        return cur.lastrowid
+
+
+def delete_flag_mapping(mapping_id):
+    with db_cursor() as cur:
+        cur.execute('DELETE FROM flag_mappings WHERE id=?', (mapping_id,))
+        return cur.rowcount
+
+
+def get_schedule_flag_country_pairs():
+    """从已上传排期里抽出所有 (flag_type, country) 唯一对(非空),用于"待映射"提示"""
+    with db_cursor() as cur:
+        cur.execute('''
+            SELECT DISTINCT flag_type, country
+            FROM po_schedules
+            WHERE flag_type IS NOT NULL AND flag_type != ''
+              AND country IS NOT NULL AND country != ''
+            ORDER BY flag_type, country
+        ''')
+        return [dict(r) for r in cur.fetchall()]
+
+
+def get_schedule_sku_letter_pairs():
+    """
+    从已上传排期里抽出所有 (sku=item_code, letter) 唯一对
+    数据来源:variant_letter(单款行) + letters_json(拼盘行)
+    """
+    import json as _json
+    pairs = set()
+    with db_cursor() as cur:
+        cur.execute('SELECT item_code, variant_letter, letters_json FROM po_schedules')
+        for row in cur.fetchall():
+            ic = row['item_code']
+            vl = row['variant_letter']
+            if vl:
+                pairs.add((ic, vl))
+            try:
+                letters = _json.loads(row['letters_json'] or '[]')
+            except (TypeError, ValueError):
+                letters = []
+            for l in letters:
+                letter = l.get('letter')
+                if letter:
+                    pairs.add((ic, letter))
+    return [{'sku': s, 'letter': l} for s, l in sorted(pairs)]

--- a/apps/PMC跟仓管/华登毛绒仓库/init_db.py
+++ b/apps/PMC跟仓管/华登毛绒仓库/init_db.py
@@ -1,0 +1,130 @@
+"""
+数据库初始化脚本
+
+功能:
+1. 创建所有表
+2. 创建三个默认账号(admin / cg / yk,密码都是 123456)
+3. 创建默认布标(8 个常用国家)
+4. 插入示例数据(毛绒 + 戏服各几条)
+
+使用:
+    python init_db.py
+
+注意:如果数据库已有用户数据,会跳过初始化,不重复插入。
+"""
+import database as db
+from auth import hash_password
+
+
+def seed_initial_data():
+    """初始化基础数据"""
+    with db.db_cursor() as cur:
+        # 检查是否已初始化
+        cur.execute('SELECT COUNT(*) FROM users')
+        if cur.fetchone()[0] > 0:
+            print('✓ 数据库已经初始化过,跳过')
+            return
+
+        print('  - 创建默认用户...')
+        default_users = [
+            ('admin', '123456', 'admin', '系统管理员'),
+            ('cg', '123456', 'operator', '仓管员'),
+            ('yk', '123456', 'viewer', '访客'),
+        ]
+        for username, password, role, display_name in default_users:
+            cur.execute(
+                'INSERT INTO users (username, password_hash, role, display_name) VALUES (?, ?, ?, ?)',
+                (username, hash_password(password), role, display_name)
+            )
+
+        print('  - 创建默认布标...')
+        default_flags = ['中国', '美国', '德国', '日本', '英国', '法国', '澳洲', '加拿大']
+        for i, flag in enumerate(default_flags):
+            cur.execute('INSERT INTO flags (name, sort_order) VALUES (?, ?)', (flag, i))
+
+        print('  - 插入毛绒示例数据...')
+        # (category, date, bill_no, sku, name, style, flag, qty)
+        sample_plush_in = [
+            ('plush', '2026-05-08', 'IN-001', 'HD-T001', '小熊毛绒 25cm 棕色', 'normal', '美国', 800),
+            ('plush', '2026-05-08', 'IN-002', 'HD-T001', '小熊毛绒 25cm 棕色', 'normal', '德国', 500),
+            ('plush', '2026-05-08', 'IN-003', 'HD-T001', '小熊毛绒 25cm 棕色', 'rare', '日本', 120),
+            ('plush', '2026-05-09', 'IN-004', 'HD-T002', '小兔毛绒 30cm 白色', 'normal', '美国', 600),
+            ('plush', '2026-05-09', 'IN-005', 'HD-T002', '小兔毛绒 30cm 白色', 'normal', '英国', 300),
+            ('plush', '2026-05-10', 'IN-006', 'HD-T003', '恐龙毛绒 20cm 绿色', 'normal', '澳洲', 900),
+            ('plush', '2026-05-11', 'IN-007', 'HD-T003', '恐龙毛绒 20cm 绿色', 'rare', '日本', 80),
+        ]
+        for row in sample_plush_in:
+            cur.execute(
+                '''INSERT INTO in_records
+                   (category, date, bill_no, sku, name, style, flag, qty, created_by)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)''',
+                row + ('system',)
+            )
+
+        print('  - 插入戏服示例数据...')
+        # 戏服 style 是自由文本,flag 始终为空字符串(戏服没有布标这个字段)
+        sample_costume_in = [
+            ('costume', '2026-05-09', 'IN-101', 'CS-001', '小熊配套连衣裙', 'M码连衣裙', '', 200),
+            ('costume', '2026-05-09', 'IN-102', 'CS-001', '小熊配套连衣裙', 'L码连衣裙', '', 150),
+            ('costume', '2026-05-10', 'IN-103', 'CS-002', '小兔配套T恤', 'S码T恤', '', 300),
+            ('costume', '2026-05-11', 'IN-104', 'CS-002', '小兔配套T恤', 'M码T恤', '', 250),
+            ('costume', '2026-05-11', 'IN-105', 'CS-003', '恐龙主题外套', 'L码外套', '', 100),
+        ]
+        for row in sample_costume_in:
+            cur.execute(
+                '''INSERT INTO in_records
+                   (category, date, bill_no, sku, name, style, flag, qty, created_by)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)''',
+                row + ('system',)
+            )
+
+        print('  - 插入出库示例数据...')
+        # (category, date, bill_no, po, picker, sku, name, style, flag, qty)
+        # 戏服的 flag 始终为空字符串
+        sample_out = [
+            # 毛绒出库(有布标)
+            ('plush', '2026-05-10', 'OUT-001', 'PO-2026-0418', '王师傅', 'HD-T001', '小熊毛绒 25cm 棕色', 'normal', '美国', 300),
+            ('plush', '2026-05-11', 'OUT-002', 'PO-2026-0422', '李工', 'HD-T002', '小兔毛绒 30cm 白色', 'normal', '英国', 250),
+            ('plush', '2026-05-12', 'OUT-003', 'PO-2026-0429', '王师傅', 'HD-T003', '恐龙毛绒 20cm 绿色', 'rare', '日本', 50),
+            # 戏服出库(无布标)
+            ('costume', '2026-05-11', 'OUT-101', 'PO-2026-0422', '李工', 'CS-001', '小熊配套连衣裙', 'M码连衣裙', '', 80),
+            ('costume', '2026-05-12', 'OUT-102', 'PO-2026-0429', '王师傅', 'CS-002', '小兔配套T恤', 'M码T恤', '', 100),
+        ]
+        for row in sample_out:
+            cur.execute(
+                '''INSERT INTO out_records
+                   (category, date, bill_no, po, picker, sku, name, style, flag, qty, created_by)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)''',
+                row + ('system',)
+            )
+
+
+if __name__ == '__main__':
+    print('=' * 50)
+    print('华登库存系统 - 数据库初始化')
+    print('=' * 50)
+    print()
+
+    print('[1/2] 创建表结构...')
+    db.init_database()
+    print('  ✓ 完成')
+
+    print('[2/2] 插入初始数据...')
+    seed_initial_data()
+    print('  ✓ 完成')
+
+    print()
+    print('=' * 50)
+    print('初始化完成!')
+    print('=' * 50)
+    print()
+    print('默认账号(请尽快修改密码):')
+    print('  admin / 123456 (主管 - 全部权限)')
+    print('  cg / 123456    (仓管员 - 录入和查看)')
+    print('  yk / 123456    (游客 - 只读)')
+    print()
+    print('已插入示例数据:')
+    print('  毛绒仓: 7 条入库 + 3 条出库')
+    print('  戏服仓: 5 条入库 + 2 条出库')
+    print()
+    print('现在可以运行 python app.py 启动服务了')

--- a/apps/PMC跟仓管/华登毛绒仓库/requirements.txt
+++ b/apps/PMC跟仓管/华登毛绒仓库/requirements.txt
@@ -1,0 +1,4 @@
+Flask==3.0.0
+Werkzeug==3.0.1
+waitress==3.0.0
+openpyxl==3.1.2

--- a/apps/PMC跟仓管/华登毛绒仓库/serve.py
+++ b/apps/PMC跟仓管/华登毛绒仓库/serve.py
@@ -1,0 +1,21 @@
+"""
+生产服务器(waitress)
+比 Flask 自带的开发服务器更稳定,适合多人并发访问
+"""
+from waitress import serve
+from app import app
+
+
+if __name__ == '__main__':
+    print('=' * 50)
+    print('华登库存管理系统 - 生产服务器')
+    print('=' * 50)
+    print()
+    print('访问地址:')
+    print('  本机:        http://localhost:5002')
+    print('  局域网其他人: http://<本机IP>:5002')
+    print()
+    print('按 Ctrl+C 停止服务')
+    print('=' * 50)
+
+    serve(app, host='0.0.0.0', port=5002, threads=8)

--- a/apps/PMC跟仓管/华登毛绒仓库/start.bat
+++ b/apps/PMC跟仓管/华登毛绒仓库/start.bat
@@ -1,0 +1,19 @@
+@echo off
+chcp 65001 >nul
+cd /d "%~dp0"
+echo ========================================
+echo 华登库存管理系统 (毛绒 + 戏服) 启动中...
+echo ========================================
+echo.
+
+if not exist "data\inventory.db" (
+    echo [首次启动] 正在初始化数据库...
+    python init_db.py
+    echo.
+)
+
+echo 按 Ctrl+C 停止服务
+echo.
+python serve.py
+
+pause

--- a/apps/PMC跟仓管/华登毛绒仓库/start.sh
+++ b/apps/PMC跟仓管/华登毛绒仓库/start.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+cd "$(dirname "$0")"
+
+echo "========================================"
+echo "华登库存管理系统 (毛绒 + 戏服) 启动中..."
+echo "========================================"
+echo
+
+if [ ! -f "data/inventory.db" ]; then
+    echo "[首次启动] 正在初始化数据库..."
+    python3 init_db.py
+    echo
+fi
+
+echo "按 Ctrl+C 停止服务"
+echo
+python3 serve.py

--- a/apps/PMC跟仓管/华登毛绒仓库/templates/app.html
+++ b/apps/PMC跟仓管/华登毛绒仓库/templates/app.html
@@ -1,0 +1,2405 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>华登塑胶 · 毛绒库存管理 v3</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  :root {
+    --bg: #FAFAF7;
+    --surface: #FFFFFF;
+    --surface-2: #F5F4EF;
+    --border: #E5E3DD;
+    --border-strong: #D1CFC7;
+    --text: #1A1A17;
+    --text-2: #5F5E58;
+    --text-3: #8A8880;
+    --accent: #1A4D8F;
+    --accent-2: #143E72;
+    --accent-light: #E8EFF8;
+    --in: #2D6A3E;
+    --in-light: #E4EFE7;
+    --out: #A03830;
+    --out-light: #F5E5E3;
+    --warn: #8B5F08;
+    --warn-light: #FDF4E1;
+    --rare: #6B3B8A;
+    --rare-light: #EFE5F5;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Microsoft YaHei", sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    font-size: 14px;
+    line-height: 1.5;
+    min-height: 100vh;
+  }
+  .app { display: flex; min-height: 100vh; }
+
+  .sidebar {
+    width: 250px;
+    background: var(--surface);
+    border-right: 1px solid var(--border);
+    padding: 18px 0;
+    overflow-y: auto;
+    max-height: 100vh;
+    position: sticky;
+    top: 0;
+    flex-shrink: 0;
+  }
+  .brand { padding: 0 18px 16px; border-bottom: 1px solid var(--border); margin-bottom: 8px; }
+  .brand-title { font-size: 15px; font-weight: 600; letter-spacing: -0.01em; }
+  .brand-sub { font-size: 11px; color: var(--text-3); margin-top: 2px; letter-spacing: 0.04em; }
+  .nav-section {
+    padding: 14px 18px 6px;
+    font-size: 11px;
+    color: var(--text-3);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+  .nav-section .auto-hint {
+    text-transform: none;
+    letter-spacing: 0;
+    color: var(--in);
+    font-size: 10px;
+    background: var(--in-light);
+    padding: 1px 6px;
+    border-radius: 3px;
+  }
+  .nav-item {
+    padding: 9px 18px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 14px;
+    border-left: 2px solid transparent;
+    transition: background 0.12s;
+  }
+  .nav-item:hover { background: var(--bg); }
+  .nav-item.active { background: var(--accent-light); border-left-color: var(--accent); color: var(--accent); font-weight: 500; }
+  .nav-icon { font-size: 13px; width: 16px; text-align: center; color: var(--text-3); }
+  .nav-item.active .nav-icon { color: var(--accent); }
+
+  .sku-nav-item {
+    padding: 7px 18px 7px 36px;
+    cursor: pointer;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 13px;
+    border-left: 2px solid transparent;
+    transition: background 0.12s;
+  }
+  .sku-nav-item:hover { background: var(--bg); }
+  .sku-nav-item.active { background: var(--accent-light); border-left-color: var(--accent); color: var(--accent); font-weight: 500; }
+  .sku-nav-code { font-weight: 500; }
+  .sku-nav-qty { font-variant-numeric: tabular-nums; font-size: 12px; color: var(--text-2); }
+  .sku-nav-item.active .sku-nav-qty { color: var(--accent); }
+  .sku-nav-item.low .sku-nav-qty { color: var(--out); }
+
+  .sku-search { margin: 6px 16px 8px; padding: 7px 10px; background: var(--bg); border: 1px solid var(--border); border-radius: 6px; font-size: 12.5px; width: calc(100% - 32px); font-family: inherit; color: var(--text); }
+  .sku-search:focus { outline: none; border-color: var(--accent); background: var(--surface); }
+
+  .main { flex: 1; padding: 28px 36px; overflow-x: auto; min-width: 0; }
+  .page-header { margin-bottom: 22px; display: flex; justify-content: space-between; align-items: flex-end; gap: 16px; flex-wrap: wrap; }
+  .page-title { font-size: 22px; font-weight: 600; letter-spacing: -0.02em; }
+  .page-sub { font-size: 13px; color: var(--text-2); margin-top: 4px; }
+  .breadcrumb { font-size: 12px; color: var(--text-3); margin-bottom: 6px; }
+  .breadcrumb a { color: var(--accent); text-decoration: none; cursor: pointer; }
+  .breadcrumb a:hover { text-decoration: underline; }
+
+  .info-banner { background: var(--warn-light); color: var(--warn); padding: 10px 14px; border-radius: 6px; font-size: 12.5px; margin-bottom: 16px; border-left: 3px solid var(--warn); }
+
+  .stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin-bottom: 22px; }
+  .stats.three { grid-template-columns: repeat(3, 1fr); }
+  .stat { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 14px 16px; }
+  .stat-label { font-size: 12px; color: var(--text-2); margin-bottom: 4px; }
+  .stat-value { font-size: 22px; font-weight: 600; font-variant-numeric: tabular-nums; letter-spacing: -0.02em; }
+  .stat-sub { font-size: 11px; color: var(--text-3); margin-top: 4px; }
+
+  .toolbar { display: flex; gap: 8px; align-items: center; margin-bottom: 14px; flex-wrap: wrap; }
+  .btn {
+    padding: 8px 14px;
+    background: var(--surface);
+    border: 1px solid var(--border-strong);
+    border-radius: 6px;
+    font-size: 13px;
+    cursor: pointer;
+    font-family: inherit;
+    color: var(--text);
+    transition: all 0.12s;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    white-space: nowrap;
+  }
+  .btn:hover { background: var(--bg); border-color: var(--text-3); }
+  .btn-primary { background: var(--accent); color: white; border-color: var(--accent); }
+  .btn-primary:hover { background: var(--accent-2); border-color: var(--accent-2); }
+  .btn-in { background: var(--in); color: white; border-color: var(--in); }
+  .btn-in:hover { opacity: 0.9; }
+  .btn-out { background: var(--out); color: white; border-color: var(--out); }
+  .btn-out:hover { opacity: 0.9; }
+  .btn-sm { padding: 4px 10px; font-size: 12px; }
+  .btn-danger { color: var(--out); }
+  .btn-danger:hover { background: var(--out-light); border-color: var(--out); }
+  .btn-ghost { background: transparent; border: none; color: var(--accent); padding: 4px 8px; cursor: pointer; font-size: 13px; font-family: inherit; }
+  .btn-ghost:hover { text-decoration: underline; }
+
+  /* 角色权限:按 body[data-role] 动态隐藏对应按钮和入口 */
+  body[data-role="viewer"] .btn-in,
+  body[data-role="viewer"] .btn-out,
+  body[data-role="viewer"] .btn-edit,
+  body[data-role="viewer"] .btn-danger { display: none !important; }
+  body[data-role="operator"] .btn-danger { display: none !important; }
+  body:not([data-role="admin"]) .admin-only { display: none !important; }
+  body[data-role="viewer"] .viewer-hide { display: none !important; }
+
+  input, select { padding: 8px 10px; background: var(--surface); border: 1px solid var(--border-strong); border-radius: 6px; font-size: 13px; font-family: inherit; color: var(--text); }
+  input:focus, select:focus { outline: none; border-color: var(--accent); }
+
+  .view-toggle { display: inline-flex; background: var(--surface-2); padding: 3px; border-radius: 7px; }
+  .view-toggle button { padding: 6px 14px; background: transparent; border: none; font-size: 13px; cursor: pointer; color: var(--text-2); font-family: inherit; border-radius: 5px; transition: all 0.12s; }
+  .view-toggle button.active { background: var(--surface); color: var(--text); box-shadow: 0 1px 2px rgba(0,0,0,0.06); font-weight: 500; }
+
+  .table-wrap { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; overflow: hidden; margin-bottom: 16px; }
+  .table-header { padding: 12px 16px; border-bottom: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; background: var(--surface-2); }
+  .table-header-title { font-size: 13.5px; font-weight: 500; }
+  .table-header-count { font-size: 12px; color: var(--text-2); }
+  table { width: 100%; border-collapse: collapse; }
+  th, td { padding: 10px 14px; text-align: left; border-bottom: 1px solid var(--border); font-size: 13px; vertical-align: middle; }
+  th { background: var(--surface-2); font-size: 12px; font-weight: 500; color: var(--text-2); text-transform: uppercase; letter-spacing: 0.04em; white-space: nowrap; }
+  tbody tr:hover { background: var(--bg); }
+  tbody tr.row-selected { background: var(--in-light); }
+  tbody tr.row-selected:hover { background: var(--in-light); }
+  tbody tr:last-child td { border-bottom: none; }
+  td.num { text-align: right; font-variant-numeric: tabular-nums; }
+  th.num { text-align: right; }
+  .row-clickable { cursor: pointer; }
+  .row-expanded { background: var(--surface-2) !important; }
+  .sku-link { color: var(--accent); cursor: pointer; font-weight: 500; }
+  .sku-link:hover { text-decoration: underline; }
+
+  .badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-size: 12px; font-weight: 500; line-height: 1.5; }
+  .badge-in { background: var(--in-light); color: var(--in); }
+  .badge-out { background: var(--out-light); color: var(--out); }
+  .badge-normal { background: var(--surface-2); color: var(--text-2); }
+  .badge-rare { background: var(--rare-light); color: var(--rare); }
+  .badge-flag { background: var(--accent-light); color: var(--accent); }
+  .badge-warn { background: var(--warn-light); color: var(--warn); }
+  .badge-low { background: var(--out-light); color: var(--out); }
+  .badge-ok { background: var(--in-light); color: var(--in); }
+
+  .modal-mask { position: fixed; inset: 0; background: rgba(0,0,0,0.4); display: flex; align-items: center; justify-content: center; z-index: 100; padding: 20px; }
+  .modal { background: var(--surface); border-radius: 12px; padding: 24px 28px; width: 100%; max-width: 520px; max-height: 90vh; overflow-y: auto; box-shadow: 0 20px 50px rgba(0,0,0,0.18); }
+  .modal-title { font-size: 16px; font-weight: 600; margin-bottom: 4px; }
+  .modal-sub { font-size: 12px; color: var(--text-3); margin-bottom: 16px; }
+  .form-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px 14px; }
+  .form-row { margin-bottom: 0; }
+  .form-row.full { grid-column: 1 / -1; }
+  .form-label { display: block; font-size: 12px; color: var(--text-2); margin-bottom: 5px; font-weight: 500; }
+  .form-label .req { color: var(--out); margin-left: 2px; }
+  .form-row input, .form-row select { width: 100%; }
+  .form-actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 20px; padding-top: 16px; border-top: 1px solid var(--border); }
+
+  .empty { text-align: center; padding: 50px 20px; color: var(--text-3); background: var(--surface); border: 1px dashed var(--border); border-radius: 8px; }
+  .empty-title { font-size: 15px; margin-bottom: 6px; color: var(--text-2); }
+
+  .flag-manage { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 16px 18px; }
+  .flag-list { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 10px; }
+  .flag-tag { display: inline-flex; align-items: center; gap: 6px; padding: 5px 10px; background: var(--surface-2); border: 1px solid var(--border); border-radius: 999px; font-size: 13px; }
+  .flag-tag button { background: none; border: none; cursor: pointer; color: var(--text-3); padding: 0 0 0 2px; font-size: 14px; line-height: 1; }
+  .flag-tag button:hover { color: var(--out); }
+  .flag-add { display: flex; gap: 6px; margin-top: 10px; }
+  .flag-add input { flex: 1; }
+
+  .expand-icon { display: inline-block; width: 16px; transition: transform 0.15s; color: var(--text-3); }
+  .expand-icon.open { transform: rotate(90deg); }
+
+  .sku-detail-rows td { background: var(--bg); padding-left: 28px; font-size: 12.5px; }
+
+  .filter-bar { display: flex; gap: 8px; flex-wrap: wrap; padding: 12px 16px; background: var(--surface); border: 1px solid var(--border); border-radius: 8px; margin-bottom: 12px; align-items: center; }
+  .filter-bar label { font-size: 12px; color: var(--text-2); }
+
+  .sku-card-header { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 18px 22px; margin-bottom: 16px; display: flex; justify-content: space-between; align-items: center; gap: 16px; flex-wrap: wrap; }
+  .sku-card-info .sku-code { font-size: 20px; font-weight: 600; letter-spacing: -0.01em; margin-bottom: 4px; }
+  .sku-card-info .sku-name { font-size: 13px; color: var(--text-2); }
+  .sku-card-stock { text-align: right; }
+  .sku-card-stock-label { font-size: 11px; color: var(--text-3); margin-bottom: 2px; }
+  .sku-card-stock-value { font-size: 28px; font-weight: 600; font-variant-numeric: tabular-nums; }
+
+  .variant-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 10px; margin-bottom: 20px; }
+  .variant-card { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 12px 14px; }
+  .variant-card-head { display: flex; gap: 6px; margin-bottom: 8px; flex-wrap: wrap; }
+  .variant-card-stock { font-size: 22px; font-weight: 600; font-variant-numeric: tabular-nums; }
+  .variant-card-meta { font-size: 11px; color: var(--text-3); margin-top: 4px; }
+
+  .section-title { font-size: 14px; font-weight: 500; margin: 20px 0 10px; color: var(--text); display: flex; align-items: center; gap: 8px; }
+  .section-title .auto-tag { font-size: 11px; background: var(--in-light); color: var(--in); padding: 1px 7px; border-radius: 3px; font-weight: 400; }
+
+  @media (max-width: 1100px) { .stats { grid-template-columns: repeat(2, 1fr); } }
+  @media (max-width: 700px) {
+    .app { flex-direction: column; }
+    .sidebar { width: 100%; max-height: none; position: relative; }
+    .main { padding: 20px 16px; }
+    .form-grid { grid-template-columns: 1fr; }
+  }
+</style>
+</head>
+<body>
+<div class="app">
+
+  <aside class="sidebar">
+    <div class="brand">
+      <div class="brand-title">华登库存</div>
+      <div class="brand-sub">毛绒 · 戏服 · v1</div>
+      <div style="margin-top: 10px; padding-top: 10px; border-top: 0.5px solid var(--border); font-size: 11.5px; color: var(--text-2);">
+        <div id="user-name">{{ user.display_name }}</div>
+        <div style="display: flex; justify-content: space-between; align-items: center; margin-top: 4px;">
+          <span id="user-role" style="color: var(--text-3); font-size: 10.5px;">{{ user.role }}</span>
+          <a onclick="logout()" style="color: var(--accent); cursor: pointer; font-size: 11px;">退出</a>
+        </div>
+      </div>
+    </div>
+
+    <div class="nav-section">品类切换</div>
+    <div style="padding: 0 16px 8px; display: flex; gap: 4px;">
+      <button id="cat-btn-plush" onclick="switchCategory('plush')" style="flex:1; padding:6px 0; border:1px solid var(--border-strong); background:var(--surface); border-radius:6px; font-size:12.5px; cursor:pointer; font-family:inherit;">毛绒</button>
+      <button id="cat-btn-costume" onclick="switchCategory('costume')" style="flex:1; padding:6px 0; border:1px solid var(--border-strong); background:var(--surface); border-radius:6px; font-size:12.5px; cursor:pointer; font-family:inherit;">戏服</button>
+      <button id="cat-btn-all" onclick="switchCategory('all')" style="flex:1; padding:6px 0; border:1px solid var(--border-strong); background:var(--surface); border-radius:6px; font-size:12.5px; cursor:pointer; font-family:inherit;">全部</button>
+    </div>
+
+    <div class="nav-section">手动录入</div>
+    <div class="nav-item" data-page="stock" onclick="navigate('stock')">
+      <span class="nav-icon">▤</span><span>库存总览(总表)</span>
+    </div>
+    <div class="nav-item" data-page="in" onclick="navigate('in')">
+      <span class="nav-icon">↓</span><span>入库流水</span>
+    </div>
+    <div class="nav-item" data-page="out" onclick="navigate('out')">
+      <span class="nav-icon">↑</span><span>出库流水</span>
+    </div>
+
+    <div class="nav-section">
+      <span>货号细表</span>
+      <span class="auto-hint">自动生成</span>
+    </div>
+    <input class="sku-search" id="sku-nav-search" placeholder="搜索货号..." oninput="renderSkuNav()">
+    <div id="sku-nav-list"></div>
+
+    <div class="nav-section admin-only">基础数据</div>
+    <div class="nav-item admin-only" data-page="flags" onclick="navigate('flags')">
+      <span class="nav-icon">◇</span><span>布标维护</span>
+    </div>
+    <div class="nav-item admin-only" data-page="users" onclick="navigate('users')">
+      <span class="nav-icon">👤</span><span>用户管理</span>
+    </div>
+    <div class="nav-item" data-page="schedule" onclick="navigate('schedule')">
+      <span class="nav-icon">◷</span><span>排期对比</span>
+    </div>
+    <div class="nav-item viewer-hide" data-page="bindings" onclick="navigate('bindings')">
+      <span class="nav-icon">⇋</span><span>字母绑定</span>
+    </div>
+    <div class="nav-item viewer-hide" data-page="flag-map" onclick="navigate('flag-map')">
+      <span class="nav-icon">⇄</span><span>布标映射</span>
+    </div>
+
+    <div class="nav-section">导出</div>
+    <div class="nav-item" onclick="exportAll()">
+      <span class="nav-icon">⇩</span><span>导出 Excel</span>
+    </div>
+  </aside>
+
+  <main class="main">
+    <div id="page-content"></div>
+  </main>
+
+</div>
+
+<div id="modal-host"></div>
+
+<script>
+// ==================== 状态 ====================
+
+const SAFE_STOCK = 100;
+
+let state = {
+  inRecords: [],
+  outRecords: [],
+  flags: [],
+  users: [],
+  currentUser: null
+};
+let currentPage = 'stock';
+let currentSku = null;
+let currentCategory = 'plush';  // 当前查看的品类:plush / costume / all
+let stockView = 'group';
+let expanded = new Set();
+let filters = { date: '', sku: '', flag: '', po: '' };
+// 编辑模式记录 id(null 表示新增模式)
+let editingInId = null;
+let editingOutId = null;
+// 入/出库流水多选删除:选中的记录 id + 当前所属页面(in/out)
+let selectedRecords = new Set();
+let selectedType = null;
+
+// ==================== API 封装 ====================
+
+// 部署前缀：兼容本地直跑 (5009) 和云端 nginx 反代 /huadeng-maorong/
+const BASE_URL = location.pathname.startsWith('/huadeng-maorong') ? '/huadeng-maorong' : '';
+
+async function api(path, options = {}) {
+  const opts = {
+    headers: {'Content-Type': 'application/json'},
+    credentials: 'same-origin',
+    ...options
+  };
+  if (opts.body && typeof opts.body !== 'string') {
+    opts.body = JSON.stringify(opts.body);
+  }
+  const resp = await fetch(BASE_URL + path, opts);
+  if (resp.status === 401) {
+    window.location.href = BASE_URL + '/login';
+    throw new Error('未登录');
+  }
+  const data = await resp.json().catch(() => ({}));
+  if (!resp.ok) {
+    throw new Error(data.error || `请求失败 (${resp.status})`);
+  }
+  return data;
+}
+
+// 后端 snake_case 转前端 camelCase
+function normalizeRecord(r) {
+  return {
+    id: r.id,
+    category: r.category || 'plush',  // 兼容旧数据
+    date: r.date,
+    billNo: r.bill_no !== undefined ? r.bill_no : r.billNo,
+    po: r.po,
+    picker: r.picker,
+    sku: r.sku,
+    name: r.name,
+    style: r.style,
+    flag: r.flag,
+    qty: r.qty
+  };
+}
+
+async function loadAllData() {
+  try {
+    const [me, inRecords, outRecords, flags] = await Promise.all([
+      api('/api/me'),
+      api('/api/in'),
+      api('/api/out').catch(() => []),  // 后端未实现时容错
+      api('/api/flags').catch(() => ['中国','美国','德国','日本','英国','法国','澳洲','加拿大'])
+    ]);
+    state.currentUser = me;
+    state.inRecords = inRecords.map(normalizeRecord);
+    state.outRecords = outRecords.map(normalizeRecord);
+    state.flags = flags;
+    document.body.dataset.role = me.role || 'viewer';
+  } catch (err) {
+    console.error('数据加载失败:', err);
+    alert('数据加载失败: ' + err.message);
+  }
+}
+
+async function logout() {
+  if (!confirm('确定要退出登录吗?')) return;
+  try {
+    await api('/api/logout', { method: 'POST' });
+    window.location.href = BASE_URL + '/login';
+  } catch (err) {
+    alert('登出失败');
+  }
+}
+
+// 切换品类(毛绒 / 戏服 / 全部)
+function switchCategory(cat) {
+  currentCategory = cat;
+  expanded.clear();
+  // 更新按钮视觉
+  ['plush', 'costume', 'all'].forEach(c => {
+    const btn = document.getElementById('cat-btn-' + c);
+    if (btn) {
+      if (c === cat) {
+        btn.style.background = 'var(--accent)';
+        btn.style.color = 'white';
+        btn.style.borderColor = 'var(--accent)';
+        btn.style.fontWeight = '500';
+      } else {
+        btn.style.background = 'var(--surface)';
+        btn.style.color = 'var(--text)';
+        btn.style.borderColor = 'var(--border-strong)';
+        btn.style.fontWeight = '400';
+      }
+    }
+  });
+  if (currentPage === 'sku') {
+    // 切换品类时,如果当前在某个货号细表,返回总览
+    navigate('stock');
+  } else {
+    render();
+  }
+}
+
+// 按当前品类过滤记录
+function filterByCategory(records) {
+  if (currentCategory === 'all') return records;
+  return records.filter(r => (r.category || 'plush') === currentCategory);
+}
+
+function categoryLabel(c) { return c === 'costume' ? '戏服' : '毛绒'; }
+function categoryBadge(c) {
+  const cls = c === 'costume' ? 'badge-rare' : 'badge-normal';
+  return `<span class="badge ${cls}">${categoryLabel(c)}</span>`;
+}
+
+// 兼容老代码:占位
+function seedIn() { return []; }
+function seedOut() { return []; }
+function loadState() { return state; }
+function saveState() { /* no-op,数据通过 API 保存 */ }
+
+function navigate(page) {
+  currentPage = page;
+  currentSku = null;
+  document.querySelectorAll('.nav-item').forEach(el => {
+    el.classList.toggle('active', el.dataset.page === page);
+  });
+  document.querySelectorAll('.sku-nav-item').forEach(el => el.classList.remove('active'));
+  render();
+}
+
+function openSku(sku) {
+  currentPage = 'sku';
+  currentSku = sku;
+  document.querySelectorAll('.nav-item').forEach(el => el.classList.remove('active'));
+  document.querySelectorAll('.sku-nav-item').forEach(el => {
+    el.classList.toggle('active', el.dataset.sku === sku);
+  });
+  render();
+}
+
+function styleLabel(s) {
+  // 毛绒款式:normal/rare → 中文;戏服:原样返回
+  if (s === 'normal') return '普通款';
+  if (s === 'rare') return '稀有款';
+  return s || '';  // 戏服直接显示文本
+}
+function styleBadge(s) {
+  // normal/rare 用预设颜色;戏服文本用 normal 颜色
+  const cls = s === 'rare' ? 'badge-rare' : 'badge-normal';
+  return `<span class="badge ${cls}">${styleLabel(s)}</span>`;
+}
+function flagBadge(f) { return `<span class="badge badge-flag">${f}</span>`; }
+
+function getStockMap() {
+  const map = {};
+  const inRecs = filterByCategory(state.inRecords);
+  const outRecs = filterByCategory(state.outRecords);
+  inRecs.forEach(r => {
+    const cat = r.category || 'plush';
+    const name = r.name || '';
+    const key = `${cat}|${r.sku}|${name}|${r.style}|${r.flag}`;
+    if (!map[key]) map[key] = { category: cat, sku: r.sku, name: name, style: r.style, flag: r.flag, stock: 0, inTotal: 0, outTotal: 0, lastIn: '', lastOut: '' };
+    map[key].stock += r.qty;
+    map[key].inTotal += r.qty;
+    if (r.date > map[key].lastIn) map[key].lastIn = r.date;
+  });
+  outRecs.forEach(r => {
+    const cat = r.category || 'plush';
+    const name = r.name || '';
+    const key = `${cat}|${r.sku}|${name}|${r.style}|${r.flag}`;
+    if (!map[key]) map[key] = { category: cat, sku: r.sku, name: name, style: r.style, flag: r.flag, stock: 0, inTotal: 0, outTotal: 0, lastIn: '', lastOut: '' };
+    map[key].stock -= r.qty;
+    map[key].outTotal += r.qty;
+    if (r.date > map[key].lastOut) map[key].lastOut = r.date;
+  });
+  return map;
+}
+
+function getSkuGroups() {
+  const stockMap = getStockMap();
+  const groups = {};
+  Object.values(stockMap).forEach(item => {
+    if (!groups[item.sku]) groups[item.sku] = { sku: item.sku, name: item.name, totalStock: 0, variants: [], lastIn: '', lastOut: '' };
+    groups[item.sku].totalStock += item.stock;
+    groups[item.sku].variants.push(item);
+    if (item.name) groups[item.sku].name = item.name;
+    if (item.lastIn > groups[item.sku].lastIn) groups[item.sku].lastIn = item.lastIn;
+    if (item.lastOut > groups[item.sku].lastOut) groups[item.sku].lastOut = item.lastOut;
+  });
+  Object.values(groups).forEach(g => {
+    g.variants.sort((a,b) => (a.style+(a.name||'')+a.flag).localeCompare(b.style+(b.name||'')+b.flag));
+  });
+  return Object.values(groups).sort((a,b) => a.sku.localeCompare(b.sku));
+}
+
+function renderSkuNav() {
+  const q = (document.getElementById('sku-nav-search')?.value || '').trim().toLowerCase();
+  let groups = getSkuGroups();
+  if (q) groups = groups.filter(g => g.sku.toLowerCase().includes(q) || (g.name||'').toLowerCase().includes(q));
+
+  document.getElementById('sku-nav-list').innerHTML = groups.length ? groups.map(g => {
+    const low = g.totalStock < SAFE_STOCK;
+    const active = currentPage === 'sku' && currentSku === g.sku;
+    return `
+      <div class="sku-nav-item ${active?'active':''} ${low?'low':''}" data-sku="${g.sku}" onclick="openSku('${g.sku}')" title="${g.name||''}">
+        <span class="sku-nav-code">${g.sku}</span>
+        <span class="sku-nav-qty">${g.totalStock}</span>
+      </div>
+    `;
+  }).join('') : '<div style="padding:10px 18px;font-size:12px;color:var(--text-3);">还没有货号</div>';
+}
+
+function render() {
+  renderSkuNav();
+  if (currentPage === 'stock') renderStock();
+  else if (currentPage === 'in') renderInOut('in');
+  else if (currentPage === 'out') renderInOut('out');
+  else if (currentPage === 'flags') renderFlags();
+  else if (currentPage === 'users') renderUsers();
+  else if (currentPage === 'schedule') renderSchedule();
+  else if (currentPage === 'bindings') renderBindings();
+  else if (currentPage === 'flag-map') renderFlagMappings();
+  else if (currentPage === 'sku') renderSkuDetail(currentSku);
+}
+
+function renderStock() {
+  const groups = getSkuGroups();
+  const totalSkus = groups.length;
+  const totalVariants = groups.reduce((s,g) => s + g.variants.length, 0);
+  const totalStock = groups.reduce((s,g) => s + g.totalStock, 0);
+  const lowVariants = Object.values(getStockMap()).filter(v => v.stock < SAFE_STOCK && v.stock > 0).length;
+
+  document.getElementById('page-content').innerHTML = `
+    <div class="page-header">
+      <div>
+        <div class="page-title">库存总览 · 总表</div>
+        <div class="page-sub">所有出入库都在这里录入,左侧"货号细表"自动按货号汇总</div>
+      </div>
+      <div style="display:flex;gap:10px;">
+        <button class="btn btn-in" onclick="openInModal()">+ 录入入库</button>
+        <button class="btn btn-out" onclick="openOutModal()">+ 录入出库</button>
+      </div>
+    </div>
+
+    <div class="stats">
+      <div class="stat"><div class="stat-label">货号总数</div><div class="stat-value">${totalSkus}</div><div class="stat-sub">不同 SKU</div></div>
+      <div class="stat"><div class="stat-label">规格总数</div><div class="stat-value">${totalVariants}</div><div class="stat-sub">货号×款式×布标 组合</div></div>
+      <div class="stat"><div class="stat-label">库存总量</div><div class="stat-value">${totalStock.toLocaleString()}</div><div class="stat-sub">所有规格累计</div></div>
+      <div class="stat"><div class="stat-label">库存预警</div><div class="stat-value" style="color:${lowVariants>0?'var(--out)':'inherit'}">${lowVariants}</div><div class="stat-sub">低于安全库存 ${SAFE_STOCK}</div></div>
+    </div>
+
+    <div class="toolbar">
+      <div class="view-toggle">
+        <button class="${stockView==='group'?'active':''}" onclick="setStockView('group')">按货号汇总</button>
+        <button class="${stockView==='flat'?'active':''}" onclick="setStockView('flat')">全展开明细</button>
+      </div>
+      <div style="margin-left:auto;display:flex;gap:8px;align-items:center;">
+        <input id="stock-search" placeholder="搜索货号/物料名称" style="width:200px;" oninput="renderStockTable()">
+      </div>
+    </div>
+
+    <div id="stock-table-wrap"></div>
+  `;
+
+  renderStockTable();
+}
+
+function renderStockTable() {
+  const q = (document.getElementById('stock-search')?.value || '').trim().toLowerCase();
+  let groups = getSkuGroups();
+  if (q) groups = groups.filter(g => g.sku.toLowerCase().includes(q) || (g.name||'').toLowerCase().includes(q));
+
+  let html = '';
+  if (!groups.length) {
+    html = '<div class="empty"><div class="empty-title">还没有库存数据</div><div>点击上方"录入入库"开始</div></div>';
+  } else if (stockView === 'group') {
+    html = `
+      <div class="table-wrap"><table>
+        <thead><tr>
+          <th style="width:30px;"></th>
+          <th>货号</th>
+          <th>物料名称</th>
+          <th>规格数</th>
+          <th class="num">总库存</th>
+          <th>最近入库</th>
+          <th>最近出库</th>
+          <th>状态</th>
+          <th></th>
+        </tr></thead>
+        <tbody>
+          ${groups.map(g => {
+            const isOpen = expanded.has(g.sku);
+            const status = g.totalStock <= 0 ? `<span class="badge badge-low">缺货</span>` :
+                          g.variants.some(v => v.stock < SAFE_STOCK) ? `<span class="badge badge-warn">部分预警</span>` :
+                          `<span class="badge badge-ok">充足</span>`;
+            return `
+              <tr class="${isOpen?'row-expanded':''}">
+                <td class="row-clickable" onclick="toggleExpand('${g.sku}')"><span class="expand-icon ${isOpen?'open':''}">▸</span></td>
+                <td><span class="sku-link" onclick="openSku('${g.sku}')">${g.sku}</span></td>
+                <td>${g.name||'—'}</td>
+                <td>${g.variants.length}</td>
+                <td class="num"><strong>${g.totalStock.toLocaleString()}</strong></td>
+                <td>${g.lastIn||'—'}</td>
+                <td>${g.lastOut||'—'}</td>
+                <td>${status}</td>
+                <td><button class="btn-ghost" onclick="openSku('${g.sku}')">查看细表 →</button></td>
+              </tr>
+              ${isOpen ? g.variants.map(v => `
+                <tr class="sku-detail-rows">
+                  <td></td>
+                  <td colspan="2">└ ${styleBadge(v.style)} ${flagBadge(v.flag)}</td>
+                  <td></td>
+                  <td class="num" style="color:${v.stock<SAFE_STOCK?'var(--out)':'inherit'};font-weight:500;">${v.stock.toLocaleString()}</td>
+                  <td>${v.lastIn||'—'}</td>
+                  <td>${v.lastOut||'—'}</td>
+                  <td>${v.stock<=0?'<span class="badge badge-low">缺货</span>':v.stock<SAFE_STOCK?'<span class="badge badge-warn">预警</span>':'<span class="badge badge-ok">充足</span>'}</td>
+                  <td></td>
+                </tr>
+              `).join('') : ''}
+            `;
+          }).join('')}
+        </tbody>
+      </table></div>
+    `;
+  } else {
+    const flat = [];
+    groups.forEach(g => g.variants.forEach(v => flat.push(v)));
+    html = `
+      <div class="table-wrap"><table>
+        <thead><tr>
+          <th>货号</th>
+          <th>物料名称</th>
+          <th>款式</th>
+          <th>布标</th>
+          <th class="num">当前库存</th>
+          <th class="num">累计入</th>
+          <th class="num">累计出</th>
+          <th>最近入</th>
+          <th>最近出</th>
+          <th>状态</th>
+        </tr></thead>
+        <tbody>
+          ${flat.map(v => `
+            <tr>
+              <td><span class="sku-link" onclick="openSku('${v.sku}')">${v.sku}</span></td>
+              <td>${v.name||'—'}</td>
+              <td>${styleBadge(v.style)}</td>
+              <td>${flagBadge(v.flag)}</td>
+              <td class="num" style="color:${v.stock<SAFE_STOCK?'var(--out)':'inherit'};font-weight:500;">${v.stock.toLocaleString()}</td>
+              <td class="num" style="color:var(--in);">${v.inTotal.toLocaleString()}</td>
+              <td class="num" style="color:var(--out);">${v.outTotal.toLocaleString()}</td>
+              <td>${v.lastIn||'—'}</td>
+              <td>${v.lastOut||'—'}</td>
+              <td>${v.stock<=0?'<span class="badge badge-low">缺货</span>':v.stock<SAFE_STOCK?'<span class="badge badge-warn">预警</span>':'<span class="badge badge-ok">充足</span>'}</td>
+            </tr>
+          `).join('')}
+        </tbody>
+      </table></div>
+    `;
+  }
+
+  document.getElementById('stock-table-wrap').innerHTML = html;
+}
+
+function setStockView(v) {
+  stockView = v;
+  renderStockTable();
+  document.querySelectorAll('.view-toggle button').forEach((b,i) => b.classList.toggle('active', (i===0&&v==='group')||(i===1&&v==='flat')));
+}
+
+function toggleExpand(sku) {
+  if (expanded.has(sku)) expanded.delete(sku);
+  else expanded.add(sku);
+  renderStockTable();
+}
+
+function renderSkuDetail(sku) {
+  const groups = getSkuGroups();
+  const g = groups.find(x => x.sku === sku);
+
+  if (!g) {
+    document.getElementById('page-content').innerHTML = `
+      <div class="page-header">
+        <div>
+          <div class="breadcrumb"><a onclick="navigate('stock')">库存总览</a> / 未找到</div>
+          <div class="page-title">货号不存在</div>
+        </div>
+      </div>
+      <div class="empty"><div class="empty-title">该货号已被删除或不存在</div></div>
+    `;
+    return;
+  }
+
+  const inRecords = state.inRecords.filter(r => r.sku === sku).sort((a,b) => b.date.localeCompare(a.date) || b.id - a.id);
+  const outRecords = state.outRecords.filter(r => r.sku === sku).sort((a,b) => b.date.localeCompare(a.date) || b.id - a.id);
+  const inTotalQty = inRecords.reduce((s,r) => s + r.qty, 0);
+  const outTotalQty = outRecords.reduce((s,r) => s + r.qty, 0);
+
+  document.getElementById('page-content').innerHTML = `
+    <div class="page-header">
+      <div>
+        <div class="breadcrumb"><a onclick="navigate('stock')">库存总览</a> / 货号细表 / ${sku}</div>
+        <div class="page-title">${sku} · 细表</div>
+        <div class="page-sub">${g.name || '—'} · 数据自动从总表筛选,所有改动在总表完成</div>
+      </div>
+      <div style="display:flex;gap:10px;">
+        <button class="btn btn-in" onclick="openInModal({sku:'${sku}',name:'${(g.name||'').replace(/'/g,'\\\'')}'})">+ 录入此货号入库</button>
+        <button class="btn btn-out" onclick="openOutModal({sku:'${sku}',name:'${(g.name||'').replace(/'/g,'\\\'')}'})">+ 录入此货号出库</button>
+      </div>
+    </div>
+
+    <div class="info-banner">
+      ℹ 此页面所有数据自动从总表生成。需要修改或删除某笔记录,请前往"入库流水"或"出库流水"操作。
+    </div>
+
+    <div class="sku-card-header">
+      <div class="sku-card-info">
+        <div class="sku-code">${sku}</div>
+        <div class="sku-name">${g.name || '—'}</div>
+      </div>
+      <div class="sku-card-stock">
+        <div class="sku-card-stock-label">该货号总库存</div>
+        <div class="sku-card-stock-value" style="color:${g.totalStock<SAFE_STOCK?'var(--out)':'inherit'};">${g.totalStock.toLocaleString()}</div>
+      </div>
+    </div>
+
+    <div class="stats three">
+      <div class="stat"><div class="stat-label">规格数</div><div class="stat-value">${g.variants.length}</div><div class="stat-sub">款式×布标 组合</div></div>
+      <div class="stat"><div class="stat-label">累计入库</div><div class="stat-value" style="color:var(--in);">${inTotalQty.toLocaleString()}</div><div class="stat-sub">${inRecords.length} 笔</div></div>
+      <div class="stat"><div class="stat-label">累计出库</div><div class="stat-value" style="color:var(--out);">${outTotalQty.toLocaleString()}</div><div class="stat-sub">${outRecords.length} 笔</div></div>
+    </div>
+
+    <div class="section-title">各规格库存 <span class="auto-tag">自动汇总</span></div>
+    <div class="variant-grid">
+      ${g.variants.map(v => `
+        <div class="variant-card">
+          <div class="variant-card-head">
+            ${styleBadge(v.style)} ${flagBadge(v.flag)}
+          </div>
+          <div style="font-size:13px;color:var(--text-1);margin-bottom:4px;">${v.name || '<span style="color:var(--text-3);">(未填物料名)</span>'}</div>
+          <div class="variant-card-stock" style="color:${v.stock<SAFE_STOCK?'var(--out)':v.stock<=0?'var(--out)':'inherit'};">${v.stock.toLocaleString()}</div>
+          <div class="variant-card-meta">入 ${v.inTotal.toLocaleString()} / 出 ${v.outTotal.toLocaleString()}</div>
+        </div>
+      `).join('')}
+    </div>
+
+    <div class="section-title">入库流水 <span class="auto-tag">自动筛选</span></div>
+    ${inRecords.length ? `
+      <div class="table-wrap">
+        <div class="table-header">
+          <span class="table-header-title">${sku} 的入库记录</span>
+          <span class="table-header-count">${inRecords.length} 笔 · 合计 ${inTotalQty.toLocaleString()}</span>
+        </div>
+        <table>
+          <thead><tr>
+            <th>日期</th><th>单号</th><th>物料</th><th>款式</th><th>布标</th><th class="num">数量</th>
+          </tr></thead>
+          <tbody>
+            ${inRecords.map(r => `
+              <tr>
+                <td>${r.date}</td>
+                <td><code style="font-size:12px;">${r.billNo||'—'}</code></td>
+                <td>${r.name||'—'}</td>
+                <td>${styleBadge(r.style)}</td>
+                <td>${flagBadge(r.flag)}</td>
+                <td class="num" style="color:var(--in);font-weight:500;">+${r.qty.toLocaleString()}</td>
+              </tr>
+            `).join('')}
+          </tbody>
+        </table>
+      </div>
+    ` : '<div class="empty" style="padding:30px;"><div>此货号还没有入库记录</div></div>'}
+
+    <div class="section-title">出库流水 <span class="auto-tag">自动筛选</span></div>
+    ${outRecords.length ? `
+      <div class="table-wrap">
+        <div class="table-header">
+          <span class="table-header-title">${sku} 的出库记录</span>
+          <span class="table-header-count">${outRecords.length} 笔 · 合计 ${outTotalQty.toLocaleString()}</span>
+        </div>
+        <table>
+          <thead><tr>
+            <th>日期</th><th>单号</th><th>PO号</th><th>领货人</th><th>物料</th><th>款式</th><th>布标</th><th class="num">数量</th>
+          </tr></thead>
+          <tbody>
+            ${outRecords.map(r => `
+              <tr>
+                <td>${r.date}</td>
+                <td><code style="font-size:12px;">${r.billNo||'—'}</code></td>
+                <td><code style="font-size:12px;">${r.po||'—'}</code></td>
+                <td>${r.picker||'—'}</td>
+                <td>${r.name||'—'}</td>
+                <td>${styleBadge(r.style)}</td>
+                <td>${flagBadge(r.flag)}</td>
+                <td class="num" style="color:var(--out);font-weight:500;">−${r.qty.toLocaleString()}</td>
+              </tr>
+            `).join('')}
+          </tbody>
+        </table>
+      </div>
+    ` : '<div class="empty" style="padding:30px;"><div>此货号还没有出库记录</div></div>'}
+
+    <div style="display:flex;gap:8px;margin-top:16px;">
+      <button class="btn" onclick="exportSku('${sku}')">导出此货号细表</button>
+    </div>
+  `;
+}
+
+function renderInOut(type) {
+  const records = filterByCategory(type === 'in' ? state.inRecords : state.outRecords);
+  const sorted = [...records].sort((a,b) => b.date.localeCompare(a.date) || b.id - a.id);
+
+  let filtered = sorted;
+  if (filters.date) filtered = filtered.filter(r => r.date === filters.date);
+  if (filters.sku) filtered = filtered.filter(r => r.sku.toLowerCase().includes(filters.sku.toLowerCase()));
+  if (filters.flag) filtered = filtered.filter(r => r.flag === filters.flag);
+  if (type === 'out' && filters.po) filtered = filtered.filter(r => (r.po||'').toLowerCase().includes(filters.po.toLowerCase()));
+
+  // 多选删除:切换 in/out 页时清空;只保留当前筛选结果里仍可见的选中项
+  if (selectedType !== type) { selectedRecords.clear(); selectedType = type; }
+  const visibleIds = new Set(filtered.map(r => r.id));
+  for (const id of [...selectedRecords]) if (!visibleIds.has(id)) selectedRecords.delete(id);
+  const selCount = selectedRecords.size;
+  const allChecked = filtered.length > 0 && filtered.every(r => selectedRecords.has(r.id));
+
+  const totalQty = filtered.reduce((s,r) => s + r.qty, 0);
+  const today = new Date().toISOString().slice(0,10);
+  const todayQty = records.filter(r => r.date === today).reduce((s,r) => s + r.qty, 0);
+
+  document.getElementById('page-content').innerHTML = `
+    <div class="page-header">
+      <div>
+        <div class="page-title">${type==='in'?'入库流水':'出库流水'}</div>
+        <div class="page-sub">${type==='in'?'毛绒厂送货 / 补货 / 退货入库':'出货给客户 / 装柜 / 调拨'}</div>
+      </div>
+      <div style="display:flex;gap:8px;align-items:center;">
+        ${selCount > 0 ? `<button class="btn btn-danger admin-only" onclick="deleteSelected('${type}')">删除选中 (${selCount})</button>` : ''}
+        <button class="btn ${type==='in'?'btn-in':'btn-out'}" onclick="${type==='in'?'openInModal()':'openOutModal()'}">+ 录入${type==='in'?'入库':'出库'}</button>
+      </div>
+    </div>
+
+    <div class="stats">
+      <div class="stat"><div class="stat-label">流水笔数</div><div class="stat-value">${records.length}</div><div class="stat-sub">${type==='in'?'入库':'出库'}记录</div></div>
+      <div class="stat"><div class="stat-label">数量合计</div><div class="stat-value">${records.reduce((s,r)=>s+r.qty,0).toLocaleString()}</div></div>
+      <div class="stat"><div class="stat-label">今日</div><div class="stat-value">${todayQty.toLocaleString()}</div></div>
+      <div class="stat"><div class="stat-label">筛选结果</div><div class="stat-value">${filtered.length}</div><div class="stat-sub">${totalQty.toLocaleString()} 件</div></div>
+    </div>
+
+    <div class="filter-bar">
+      <label>日期</label>
+      <input type="date" value="${filters.date}" onchange="filters.date=this.value;render()">
+      <label>货号</label>
+      <input placeholder="搜索货号" value="${filters.sku}" oninput="filters.sku=this.value;render()" style="width:140px;">
+      <label>布标</label>
+      <select onchange="filters.flag=this.value;render()">
+        <option value="">全部</option>
+        ${state.flags.map(f => `<option ${filters.flag===f?'selected':''}>${f}</option>`).join('')}
+      </select>
+      ${type==='out' ? `
+        <label>PO号</label>
+        <input placeholder="搜索 PO" value="${filters.po}" oninput="filters.po=this.value;render()" style="width:140px;">
+      ` : ''}
+      <button class="btn btn-sm" onclick="filters={date:'',sku:'',flag:'',po:''};render()">清空筛选</button>
+    </div>
+
+    ${filtered.length ? `
+      <div class="table-wrap"><table>
+        <thead><tr>
+          <th class="admin-only" style="width:34px;text-align:center;"><input type="checkbox" ${allChecked?'checked':''} onclick="toggleSelectAll('${type}')" title="全选/取消"></th>
+          <th>日期</th>
+          <th>单号</th>
+          ${type==='out' ? '<th>PO号</th><th>领货人</th>' : ''}
+          <th>货号</th>
+          <th>物料名称</th>
+          <th>款式</th>
+          <th>布标</th>
+          <th class="num">数量</th>
+          <th></th>
+        </tr></thead>
+        <tbody>
+          ${filtered.map(r => `
+            <tr class="${selectedRecords.has(r.id)?'row-selected':''}">
+              <td class="admin-only" style="text-align:center;"><input type="checkbox" ${selectedRecords.has(r.id)?'checked':''} onclick="toggleSelect(${r.id})"></td>
+              <td>${r.date}</td>
+              <td><code style="font-size:12px;">${r.billNo||'—'}</code></td>
+              ${type==='out' ? `<td><code style="font-size:12px;">${r.po||'—'}</code></td><td>${r.picker||'—'}</td>` : ''}
+              <td><span class="sku-link" onclick="openSku('${r.sku}')">${r.sku}</span></td>
+              <td>${r.name||'—'}</td>
+              <td>${styleBadge(r.style)}</td>
+              <td>${flagBadge(r.flag)}</td>
+              <td class="num" style="color:${type==='in'?'var(--in)':'var(--out)'};font-weight:500;">${type==='in'?'+':'−'}${r.qty.toLocaleString()}</td>
+              <td>
+                <button class="btn btn-sm btn-edit" onclick="openEdit('${type}',${r.id})">编辑</button>
+                <button class="btn btn-sm btn-danger" onclick="deleteRecord('${type}',${r.id})">删除</button>
+              </td>
+            </tr>
+          `).join('')}
+        </tbody>
+      </table></div>
+    ` : '<div class="empty"><div class="empty-title">没有符合条件的记录</div></div>'}
+  `;
+}
+
+function renderFlags() {
+  document.getElementById('page-content').innerHTML = `
+    <div class="page-header">
+      <div>
+        <div class="page-title">布标维护</div>
+        <div class="page-sub">布标是出入库的必填项,在这里管理可选项</div>
+      </div>
+    </div>
+
+    <div class="flag-manage">
+      <div style="font-size:13px;color:var(--text-2);">当前布标 (共 ${state.flags.length} 个)</div>
+      <div class="flag-list">
+        ${state.flags.map((f,i) => `<span class="flag-tag">${f}<button onclick="deleteFlag(${i})" title="删除">×</button></span>`).join('')}
+      </div>
+      <div class="flag-add">
+        <input id="new-flag" placeholder="输入新布标名称,如:荷兰 / 韩国 / 内销..." onkeydown="if(event.key==='Enter')addFlag()">
+        <button class="btn btn-primary" onclick="addFlag()">+ 添加</button>
+      </div>
+      <div style="font-size:12px;color:var(--text-3);margin-top:14px;line-height:1.7;">
+        提示:删除布标不会影响已经录入的出入库记录,只是新录入时不再出现在下拉选项中。
+      </div>
+    </div>
+  `;
+}
+
+async function addFlag() {
+  const input = document.getElementById('new-flag');
+  const v = input.value.trim();
+  if (!v) return;
+  if (state.flags.includes(v)) { alert('该布标已存在'); return; }
+  try {
+    await api('/api/flags', { method: 'POST', body: { name: v } });
+    await loadAllData();
+    input.value = '';
+    render();
+  } catch (err) {
+    alert('添加失败(可能 /api/flags POST 还没实现): ' + err.message);
+  }
+}
+
+async function deleteFlag(i) {
+  const name = state.flags[i];
+  if (!confirm(`确定删除布标"${name}"吗?`)) return;
+  try {
+    await api(`/api/flags/${encodeURIComponent(name)}`, { method: 'DELETE' });
+    await loadAllData();
+    render();
+  } catch (err) {
+    alert('删除失败: ' + err.message);
+  }
+}
+
+// ==================== 用户管理 ====================
+
+async function loadUsers() {
+  try {
+    state.users = await api('/api/users');
+  } catch (err) {
+    state.users = [];
+    alert('加载用户列表失败: ' + err.message);
+  }
+}
+
+async function renderUsers() {
+  // 进入页面时按需加载(仅 admin 能调,其他角色看不到入口)
+  if (!state.users.length) await loadUsers();
+  const me = state.currentUser || {};
+  document.getElementById('page-content').innerHTML = `
+    <div class="page-header">
+      <div>
+        <div class="page-title">用户管理</div>
+        <div class="page-sub">管理可登录系统的账号(共 ${state.users.length} 个)</div>
+      </div>
+      <div>
+        <button class="btn btn-primary" onclick="openCreateUserModal()">+ 新增用户</button>
+      </div>
+    </div>
+
+    <div class="table-wrap"><table>
+      <thead><tr>
+        <th>用户名</th><th>显示名</th><th>角色</th><th>创建时间</th><th style="width:200px;">操作</th>
+      </tr></thead>
+      <tbody>
+        ${state.users.map(u => `
+          <tr>
+            <td><strong>${u.username}</strong>${u.id===me.id?' <span style="color:var(--text-3);font-size:12px;">(我)</span>':''}</td>
+            <td>${u.display_name || ''}</td>
+            <td>${ROLE_NAMES[u.role] || u.role}</td>
+            <td>${u.created_at || ''}</td>
+            <td>
+              <button class="btn btn-sm" onclick="openChangePasswordModal(${u.id}, '${u.username}')">改密码</button>
+              ${u.id===me.id ? '' : `<button class="btn btn-sm btn-danger" onclick="deleteUserById(${u.id}, '${u.username}')">删除</button>`}
+            </td>
+          </tr>
+        `).join('')}
+      </tbody>
+    </table></div>
+  `;
+}
+
+function openCreateUserModal() {
+  document.getElementById('modal-host').innerHTML = `
+    <div class="modal-mask" onclick="if(event.target===this)closeModal()">
+      <div class="modal">
+        <div class="modal-title">新增用户</div>
+        <div class="modal-sub">用户名 4-20 字符,密码至少 4 位</div>
+        <div class="form-grid">
+          <div class="form-row">
+            <label class="form-label">用户名<span class="req">*</span></label>
+            <input id="u-username" placeholder="登录用,4-20 字符">
+          </div>
+          <div class="form-row">
+            <label class="form-label">密码<span class="req">*</span></label>
+            <input id="u-password" type="password" placeholder="至少 4 位">
+          </div>
+          <div class="form-row">
+            <label class="form-label">角色<span class="req">*</span></label>
+            <select id="u-role">
+              <option value="operator">仓管员(录入和查看)</option>
+              <option value="viewer">游客(只读)</option>
+              <option value="admin">主管(全部权限)</option>
+            </select>
+          </div>
+          <div class="form-row">
+            <label class="form-label">显示名</label>
+            <input id="u-display" placeholder="如: 张三">
+          </div>
+        </div>
+        <div class="form-actions">
+          <button class="btn" onclick="closeModal()">取消</button>
+          <button class="btn btn-primary" onclick="saveNewUser()">保存</button>
+        </div>
+      </div>
+    </div>
+  `;
+  setTimeout(() => document.getElementById('u-username').focus(), 50);
+}
+
+async function saveNewUser() {
+  const username = document.getElementById('u-username').value.trim();
+  const password = document.getElementById('u-password').value;
+  const role = document.getElementById('u-role').value;
+  const display_name = document.getElementById('u-display').value.trim();
+
+  if (username.length < 4 || username.length > 20) { alert('用户名长度必须为 4-20 个字符'); return; }
+  if (password.length < 4) { alert('密码至少 4 位'); return; }
+
+  try {
+    await api('/api/users', { method: 'POST', body: { username, password, role, display_name } });
+    await loadUsers();
+    closeModal();
+    render();
+  } catch (err) {
+    alert('新增失败: ' + err.message);
+  }
+}
+
+function openChangePasswordModal(userId, username) {
+  document.getElementById('modal-host').innerHTML = `
+    <div class="modal-mask" onclick="if(event.target===this)closeModal()">
+      <div class="modal">
+        <div class="modal-title">修改密码</div>
+        <div class="modal-sub">为用户 <strong>${username}</strong> 设置新密码(管理员可直接修改,无需旧密码)</div>
+        <div class="form-grid">
+          <div class="form-row full">
+            <label class="form-label">新密码<span class="req">*</span></label>
+            <input id="u-newpwd" type="password" placeholder="至少 4 位">
+          </div>
+        </div>
+        <div class="form-actions">
+          <button class="btn" onclick="closeModal()">取消</button>
+          <button class="btn btn-primary" onclick="saveChangePassword(${userId})">保存</button>
+        </div>
+      </div>
+    </div>
+  `;
+  setTimeout(() => document.getElementById('u-newpwd').focus(), 50);
+}
+
+async function saveChangePassword(userId) {
+  const newPassword = document.getElementById('u-newpwd').value;
+  if (newPassword.length < 4) { alert('密码至少 4 位'); return; }
+  try {
+    await api(`/api/users/${userId}/password`, { method: 'PUT', body: { new_password: newPassword } });
+    closeModal();
+    alert('密码已修改');
+  } catch (err) {
+    alert('修改失败: ' + err.message);
+  }
+}
+
+async function deleteUserById(userId, username) {
+  if (!confirm(`确定删除用户"${username}"吗?此操作不可恢复。`)) return;
+  try {
+    await api(`/api/users/${userId}`, { method: 'DELETE' });
+    await loadUsers();
+    render();
+  } catch (err) {
+    alert('删除失败: ' + err.message);
+  }
+}
+
+// ==================== 布标映射 ====================
+
+let flagMapData = null;
+
+async function renderFlagMappings() {
+  try {
+    flagMapData = await api('/api/flag-mappings');
+  } catch (err) {
+    flagMapData = { mappings: [], unmapped: [], inventory_flags: [] };
+    alert('加载映射失败: ' + err.message);
+  }
+  const { mappings, unmapped, inventory_flags } = flagMapData;
+  const canEdit = state.currentUser?.role !== 'viewer';
+
+  document.getElementById('page-content').innerHTML = `
+    <div class="page-header">
+      <div>
+        <div class="page-title">布标映射</div>
+        <div class="page-sub">把排期里 (布标类型, 国家) 翻译成你库存里实际录的布标名,排期对比才能查到精确库存</div>
+      </div>
+    </div>
+
+    <div class="flag-manage" style="margin-bottom:14px;">
+      <div style="font-size:13px;font-weight:500;margin-bottom:8px;">已映射 (${mappings.length})</div>
+      ${mappings.length ? `
+      <div class="table-wrap"><table>
+        <thead><tr>
+          <th>排期布标类型</th><th>国家</th><th>→ 库存布标</th><th>录入人</th><th>时间</th>
+          ${canEdit ? '<th style="width:140px;">操作</th>' : ''}
+        </tr></thead>
+        <tbody>
+          ${mappings.map(m => `
+            <tr>
+              <td>${m.flag_type}</td>
+              <td>${m.country}</td>
+              <td><code style="font-size:12px;">${m.inventory_flag}</code></td>
+              <td style="font-size:12px;color:var(--text-2);">${m.created_by||'—'}</td>
+              <td style="font-size:12px;color:var(--text-2);">${m.created_at||'—'}</td>
+              ${canEdit ? `<td>
+                <button class="btn btn-sm btn-edit" onclick="openFlagMapModal('${escAttr(m.flag_type)}', '${escAttr(m.country)}', '${escAttr(m.inventory_flag)}')">改</button>
+                <button class="btn btn-sm btn-danger" onclick="deleteFlagMap(${m.id})">删</button>
+              </td>` : ''}
+            </tr>
+          `).join('')}
+        </tbody>
+      </table></div>
+      ` : '<div style="color:var(--text-3);font-size:13px;">还没有映射,下面是排期里需要映射的组合</div>'}
+    </div>
+
+    <div class="flag-manage">
+      <div style="font-size:13px;font-weight:500;margin-bottom:8px;">待映射 (${unmapped.length})</div>
+      ${unmapped.length ? `
+      <div class="table-wrap"><table>
+        <thead><tr>
+          <th>排期布标类型</th><th>国家</th>
+          ${canEdit ? '<th style="width:120px;">操作</th>' : ''}
+        </tr></thead>
+        <tbody>
+          ${unmapped.map(u => `
+            <tr>
+              <td>${u.flag_type}</td>
+              <td>${u.country}</td>
+              ${canEdit ? `<td>
+                <button class="btn btn-sm btn-primary" onclick="openFlagMapModal('${escAttr(u.flag_type)}', '${escAttr(u.country)}', '')">映射</button>
+              </td>` : ''}
+            </tr>
+          `).join('')}
+        </tbody>
+      </table></div>
+      ` : '<div style="color:var(--text-3);font-size:13px;">没有待映射项,所有排期组合都配过了</div>'}
+    </div>
+  `;
+}
+
+function openFlagMapModal(flagType, country, currentInvFlag) {
+  const isEdit = !!(flagType && country && currentInvFlag);
+  const flags = flagMapData?.inventory_flags || [];
+  document.getElementById('modal-host').innerHTML = `
+    <div class="modal-mask" onclick="if(event.target===this)closeModal()">
+      <div class="modal">
+        <div class="modal-title">${isEdit ? '修改映射' : '新增映射'}</div>
+        <div class="modal-sub">排期 ${flagType||''} + ${country||''} → 库存里的实际布标</div>
+        <div class="form-grid">
+          <div class="form-row">
+            <label class="form-label">排期布标类型<span class="req">*</span></label>
+            <input id="fm-type" value="${flagType||''}" placeholder="如: MA布标" ${isEdit?'readonly':''}>
+          </div>
+          <div class="form-row">
+            <label class="form-label">国家<span class="req">*</span></label>
+            <input id="fm-country" value="${country||''}" placeholder="如: 美国" ${isEdit?'readonly':''}>
+          </div>
+          <div class="form-row full">
+            <label class="form-label">→ 库存布标<span class="req">*</span></label>
+            <input id="fm-inv" list="fm-inv-sug" value="${currentInvFlag||''}" placeholder="如: MA标美国版">
+            <datalist id="fm-inv-sug">${flags.map(f => `<option value="${f}">`).join('')}</datalist>
+            ${flags.length ? `<div style="font-size:11px;color:var(--text-3);margin-top:4px;">从你的布标维护列表选(或自由输入):${flags.slice(0,8).join(' / ')}${flags.length>8?'...':''}</div>` : '<div style="font-size:11px;color:var(--out);margin-top:4px;">布标维护页里还没有布标,可以自由输入</div>'}
+          </div>
+        </div>
+        <div class="form-actions">
+          <button class="btn" onclick="closeModal()">取消</button>
+          <button class="btn btn-primary" onclick="saveFlagMap()">保存</button>
+        </div>
+      </div>
+    </div>
+  `;
+  setTimeout(() => document.getElementById(isEdit ? 'fm-inv' : 'fm-type').focus(), 50);
+}
+
+async function saveFlagMap() {
+  const flag_type = document.getElementById('fm-type').value.trim();
+  const country = document.getElementById('fm-country').value.trim();
+  const inventory_flag = document.getElementById('fm-inv').value.trim();
+  if (!flag_type || !country) { alert('请填写排期布标和国家'); return; }
+  if (!inventory_flag) { alert('请填写库存布标'); return; }
+  try {
+    await api('/api/flag-mappings', { method: 'POST', body: { flag_type, country, inventory_flag } });
+    closeModal();
+    await renderFlagMappings();
+  } catch (err) {
+    alert('保存失败: ' + err.message);
+  }
+}
+
+async function deleteFlagMap(id) {
+  if (!confirm('删除该映射?')) return;
+  try {
+    await api(`/api/flag-mappings/${id}`, { method: 'DELETE' });
+    await renderFlagMappings();
+  } catch (err) {
+    alert('删除失败: ' + err.message);
+  }
+}
+
+// ==================== 字母绑定(主数据维护) ====================
+
+let bindingsData = null;
+let aliasesData = [];
+
+async function renderBindings() {
+  try {
+    [bindingsData, aliasesData] = await Promise.all([
+      api('/api/letter-bindings'),
+      api('/api/sku-aliases').catch(() => []),
+    ]);
+  } catch (err) {
+    bindingsData = { bindings: [], materials_by_sku: {} };
+    aliasesData = [];
+    alert('加载绑定失败: ' + err.message);
+  }
+  const { bindings } = bindingsData;
+  const canEdit = state.currentUser?.role !== 'viewer';
+  // 按父货号分组别名
+  const aliasesByPrimary = {};
+  aliasesData.forEach(a => {
+    (aliasesByPrimary[a.primary_prefix] = aliasesByPrimary[a.primary_prefix] || []).push(a);
+  });
+
+  document.getElementById('page-content').innerHTML = `
+    <div class="page-header">
+      <div>
+        <div class="page-title">字母绑定</div>
+        <div class="page-sub">主数据:填写"货号 + 字母 + 物料名称"。排期对比时按 ITEM# 前面的数字找你这里配置的绑定。子货号通过"关联"自动复用父货号的物料。</div>
+      </div>
+      <div>
+        ${canEdit ? '<button class="btn btn-in" onclick="openBindModal()">+ 新增绑定</button>' : ''}
+      </div>
+    </div>
+
+    <div class="flag-manage">
+      <div style="font-size:13px;color:var(--text-2);margin-bottom:8px;">共 ${bindings.length} 条 · ${(() => { const s = new Set(); bindings.forEach(b => s.add(b.sku)); return s.size; })()} 个货号 · ${aliasesData.length} 个子货号别名</div>
+      ${bindings.length ? (() => {
+        const groups = {};
+        bindings.forEach(b => { (groups[b.sku] = groups[b.sku] || []).push(b); });
+        const skuOrder = Object.keys(groups).sort();
+        return skuOrder.map(sku => {
+          const rows = groups[sku].slice().sort((a,b) => a.letter.localeCompare(b.letter));
+          const aliases = aliasesByPrimary[sku] || [];
+          const aliasChips = aliases.map(a => `
+            <span style="display:inline-flex;align-items:center;gap:4px;background:#EEF2FF;border:1px solid #C7D2FE;border-radius:4px;padding:2px 8px;font-size:12px;color:#3730A3;margin-right:4px;">
+              <code style="background:transparent;padding:0;color:inherit;">${a.alias_prefix}</code>
+              ${canEdit ? `<span style="cursor:pointer;color:#6366F1;" onclick="deleteAlias(${a.id}, '${escAttr(a.alias_prefix)}', '${escAttr(sku)}')" title="删除别名">×</span>` : ''}
+            </span>
+          `).join('');
+          return `
+            <div style="margin-bottom:18px;">
+              <div style="display:flex;align-items:center;gap:10px;padding:6px 4px;border-bottom:1px solid var(--border);margin-bottom:6px;flex-wrap:wrap;">
+                <code style="font-size:15px;font-weight:600;color:var(--text-1);">${sku}</code>
+                <span style="font-size:12px;color:var(--text-3);">${rows.length} 条字母 · ${aliases.length} 个子货号</span>
+                <div style="flex:1;"></div>
+                ${aliasChips}
+                ${canEdit ? `<button class="btn btn-sm" onclick="openAliasModal('${escAttr(sku)}')" title="关联子货号 → 自动复用本父货号的物料">+ 关联子货号</button>` : ''}
+              </div>
+              <div class="table-wrap"><table>
+                <thead><tr>
+                  <th style="width:80px;">字母</th><th>物料名称</th>
+                  <th style="width:100px;">录入人</th><th style="width:150px;">时间</th>
+                  ${canEdit ? '<th style="width:140px;">操作</th>' : ''}
+                </tr></thead>
+                <tbody>
+                  ${rows.map(b => `
+                    <tr>
+                      <td><span class="badge badge-flag">${b.letter}</span></td>
+                      <td>${b.material_name}</td>
+                      <td style="font-size:12px;color:var(--text-2);">${b.created_by||'—'}</td>
+                      <td style="font-size:12px;color:var(--text-2);">${b.created_at||'—'}</td>
+                      ${canEdit ? `<td>
+                        <button class="btn btn-sm btn-edit" onclick="openBindModal('${escAttr(b.sku)}', '${b.letter}', '${escAttr(b.material_name)}')">改</button>
+                        <button class="btn btn-sm btn-danger" onclick="deleteBinding(${b.id}, '${escAttr(b.sku)}', '${b.letter}')">删</button>
+                      </td>` : ''}
+                    </tr>
+                  `).join('')}
+                </tbody>
+              </table></div>
+            </div>
+          `;
+        }).join('');
+      })() : '<div style="color:var(--text-3);font-size:13px;padding:18px;text-align:center;">还没有绑定。点右上角"+ 新增绑定"开始配置。</div>'}
+    </div>
+  `;
+}
+
+function escAttr(s) {
+  return (s||'').replace(/'/g, "\\'").replace(/"/g, '&quot;');
+}
+
+function openBindModal(presetSku, presetLetter, presetName) {
+  const isEdit = !!(presetSku && presetLetter);
+  // 物料名建议:如果填了 sku,从该 sku 已入库物料名拉建议
+  const sugList = bindingsData?.materials_by_sku?.[presetSku] || [];
+  document.getElementById('modal-host').innerHTML = `
+    <div class="modal-mask" onclick="if(event.target===this)closeModal()">
+      <div class="modal">
+        <div class="modal-title">${isEdit ? '修改绑定' : '新增绑定'}</div>
+        <div class="modal-sub">绑定关系:同一货号 + 字母 唯一,重复会覆盖原绑定</div>
+        <div class="form-grid">
+          <div class="form-row">
+            <label class="form-label">货号(纯数字)<span class="req">*</span></label>
+            <input id="b-sku" placeholder="如: 15758" value="${presetSku||''}" ${isEdit?'readonly':''}>
+          </div>
+          <div class="form-row">
+            <label class="form-label">字母<span class="req">*</span></label>
+            <input id="b-letter" placeholder="如: A" maxlength="2" style="text-transform:uppercase;" value="${presetLetter||''}" ${isEdit?'readonly':''}>
+          </div>
+          <div class="form-row full">
+            <label class="form-label">物料名称<span class="req">*</span></label>
+            <input id="b-mat" list="b-mat-sug" placeholder="如: 小杏怪" value="${presetName||''}">
+            <datalist id="b-mat-sug">${sugList.map(m => `<option value="${m}">`).join('')}</datalist>
+            ${sugList.length ? `<div style="font-size:11px;color:var(--text-3);margin-top:4px;">该货号已入库的物料名:${sugList.join(' / ')}</div>` : ''}
+          </div>
+        </div>
+        <div class="form-actions">
+          <button class="btn" onclick="closeModal()">取消</button>
+          <button class="btn btn-primary" onclick="saveBinding()">保存</button>
+        </div>
+      </div>
+    </div>
+  `;
+  setTimeout(() => document.getElementById(isEdit ? 'b-mat' : 'b-sku').focus(), 50);
+}
+
+async function saveBinding() {
+  const sku = document.getElementById('b-sku').value.trim();
+  const letter = document.getElementById('b-letter').value.trim().toUpperCase();
+  const name = document.getElementById('b-mat').value.trim();
+  if (!sku) { alert('请填写货号'); return; }
+  if (!letter || !/^[A-Z]+$/.test(letter)) { alert('字母只允许 A-Z(大写),长度 1-2'); return; }
+  if (!name) { alert('请填写物料名称'); return; }
+  try {
+    await api('/api/letter-bindings', {
+      method: 'POST',
+      body: { sku, letter, material_name: name }
+    });
+    closeModal();
+    await renderBindings();
+  } catch (err) {
+    alert('保存失败: ' + err.message);
+  }
+}
+
+function openAliasModal(primarySku) {
+  document.getElementById('modal-host').innerHTML = `
+    <div class="modal-mask" onclick="if(event.target===this)closeModal()">
+      <div class="modal">
+        <div class="modal-title">关联子货号 → ${primarySku}</div>
+        <div class="modal-sub">子货号(纯数字前缀)会自动复用父货号 <code>${primarySku}</code> 的全部字母→物料映射。一个子货号只能映射到一个父货号。</div>
+        <div class="form-grid">
+          <div class="form-row full">
+            <label class="form-label">子货号前缀<span class="req">*</span></label>
+            <input id="a-alias" placeholder="如: 157101" autofocus>
+            <div style="font-size:11px;color:var(--text-3);margin-top:4px;">举例:排期里出现 <code>157101-S001-MB</code> 这种,父货号是 <code>${primarySku}</code>,这里填 <code>157101</code></div>
+          </div>
+        </div>
+        <div class="form-actions">
+          <button class="btn" onclick="closeModal()">取消</button>
+          <button class="btn btn-primary" onclick="saveAlias('${escAttr(primarySku)}')">保存</button>
+        </div>
+      </div>
+    </div>
+  `;
+  setTimeout(() => document.getElementById('a-alias').focus(), 50);
+}
+
+async function saveAlias(primarySku) {
+  const alias = document.getElementById('a-alias').value.trim();
+  if (!alias || !/^\d+$/.test(alias)) { alert('子货号必须是纯数字'); return; }
+  try {
+    await api('/api/sku-aliases', {
+      method: 'POST',
+      body: { alias_prefix: alias, primary_prefix: primarySku }
+    });
+    closeModal();
+    await renderBindings();
+  } catch (err) {
+    alert('保存失败: ' + err.message);
+  }
+}
+
+async function deleteAlias(id, alias, primary) {
+  if (!confirm(`解除子货号 ${alias} → 父货号 ${primary} 的关联?\n解除后,排期里的 ${alias} 将不再自动匹配 ${primary} 的物料。`)) return;
+  try {
+    await api(`/api/sku-aliases/${id}`, { method: 'DELETE' });
+    await renderBindings();
+  } catch (err) {
+    alert('删除失败: ' + err.message);
+  }
+}
+
+async function deleteBinding(id, sku, letter) {
+  if (!confirm(`删除货号 ${sku} 字母 ${letter} 的绑定?`)) return;
+  try {
+    await api(`/api/letter-bindings/${id}`, { method: 'DELETE' });
+    await renderBindings();
+  } catch (err) {
+    alert('删除失败: ' + err.message);
+  }
+}
+
+// ==================== 排期对比 ====================
+
+let scheduleInfo = null;
+let scheduleResult = null;
+let scheduleSearch = '';
+
+async function renderSchedule() {
+  // 加载状态(每次进入都刷新)
+  try {
+    scheduleInfo = await api('/api/schedule/info');
+  } catch (err) {
+    scheduleInfo = { count: 0 };
+  }
+  const info = scheduleInfo;
+  const empty = !info.count;
+
+  document.getElementById('page-content').innerHTML = `
+    <div class="page-header">
+      <div>
+        <div class="page-title">排期对比</div>
+        <div class="page-sub">上传排期 xlsx,按 PO 号查需求并比对库存</div>
+      </div>
+      <div>
+        <button class="btn btn-in" onclick="document.getElementById('schedule-file').click()">↑ 上传排期表</button>
+        <input type="file" id="schedule-file" accept=".xlsx" style="display:none" onchange="uploadSchedule(this)">
+      </div>
+    </div>
+
+    <div class="flag-manage" style="margin-bottom:16px;">
+      ${empty
+        ? '<div style="color:var(--text-3);">还没有导入排期数据。点击右上角"上传排期表"。</div>'
+        : `
+          <div style="font-size:13px;color:var(--text-2);">
+            当前已导入:<strong>${info.count}</strong> 行 ·
+            <strong>${info.po_count}</strong> 个 PO ·
+            <strong>${info.item_count}</strong> 个货号
+          </div>
+          <div style="font-size:12px;color:var(--text-3);margin-top:6px;">
+            上次上传:${info.last_uploaded_at}  by  ${info.last_uploaded_by}
+          </div>
+        `}
+    </div>
+
+    <div class="flag-manage" style="margin-bottom:16px;">
+      <div style="display:flex;gap:8px;align-items:center;">
+        <input id="schedule-po" placeholder="输入 PO 号 或 货号,如 4500193080 / 15704UQ1-S001" value="${scheduleSearch}"
+               style="flex:1;" onkeydown="if(event.key==='Enter')querySchedule()">
+        <button class="btn btn-primary" onclick="querySchedule()">搜索</button>
+      </div>
+      <div style="font-size:12px;color:var(--text-3);margin-top:8px;">
+        提示:PO 号 → 看这个 PO 需哪些货号,库存够否;货号 → 看该货号被哪些 PO 需要,合计够否
+      </div>
+    </div>
+
+    <div id="schedule-result"></div>
+  `;
+
+  if (scheduleResult) renderScheduleResult();
+}
+
+async function uploadSchedule(input) {
+  const file = input.files[0];
+  if (!file) return;
+  if (!confirm(`将上传 ${file.name} 并替换现有排期数据(${(scheduleInfo?.count || 0)} 行),继续?`)) {
+    input.value = '';
+    return;
+  }
+  const fd = new FormData();
+  fd.append('file', file);
+  try {
+    const resp = await fetch(BASE_URL + '/api/schedule/upload', { method: 'POST', body: fd, credentials: 'same-origin' });
+    const data = await resp.json();
+    if (!resp.ok) { alert('上传失败: ' + (data.error || resp.status)); input.value = ''; return; }
+    const s = data.stats;
+    alert(`上传成功:\n- 解析 ${s.sheets_processed.length} 个 sheet${s.sheets_skipped.length?(' (跳过 '+s.sheets_skipped.length+')'):''}\n- 导入 ${s.rows_inserted} 行\n- 跳过蓝色已完货 ${s.rows_skipped_blue} 行\n- 跳过无效 ${s.rows_skipped_invalid} 行`);
+    scheduleResult = null;
+    await renderSchedule();
+  } catch (err) {
+    alert('上传失败: ' + err.message);
+  }
+  input.value = '';
+}
+
+async function querySchedule() {
+  const q = document.getElementById('schedule-po').value.trim();
+  if (!q) { alert('请输入 PO 号或货号'); return; }
+  scheduleSearch = q;
+  try {
+    scheduleResult = await api('/api/schedule/query?q=' + encodeURIComponent(q));
+    renderScheduleResult();
+  } catch (err) {
+    alert('查询失败: ' + err.message);
+  }
+}
+
+function letterChip(l) {
+  // 单 letter chip 渲染:[图][字母·数量][绑定状态/库存差]
+  if (!l.letter) return `<span style="color:var(--text-3);">${(l.qty||0).toLocaleString()}</span>`;
+  const img = l.image_url ? `<img src="${BASE_URL}${l.image_url}" style="width:28px;height:28px;object-fit:cover;border-radius:4px;vertical-align:middle;margin-right:4px;" alt="${l.letter}">` : '';
+  let status = '';
+  if (l.bound_name) {
+    if (l.letter_sufficient) {
+      status = `<span style="color:var(--in);font-size:11px;margin-left:4px;">✓ 库${(l.letter_stock||0).toLocaleString()}</span>`;
+    } else {
+      status = `<span style="color:var(--out);font-size:11px;margin-left:4px;">✗ 差${(l.letter_shortage||0).toLocaleString()}</span>`;
+    }
+  } else {
+    status = `<span style="color:var(--text-3);font-size:11px;margin-left:4px;" title="点&quot;字母绑定&quot;页配置">⚠未绑</span>`;
+  }
+  return `<span style="display:inline-flex;align-items:center;margin-right:10px;margin-bottom:3px;">${img}<span class="badge badge-flag">${l.letter}·${l.qty.toLocaleString()}</span>${status}</span>`;
+}
+
+function _banner(ok, leftText, rightText) {
+  const bg = ok ? '#e8f8ee' : '#fdecec';
+  const fg = ok ? '#1f7a3c' : '#a03434';
+  const bd = ok ? '#b8e5c8' : '#f4c2c2';
+  const icon = ok ? '✓' : '✗';
+  return `<div style="padding:10px 14px;background:${bg};color:${fg};border:1px solid ${bd};border-radius:6px;margin-bottom:12px;">
+    ${icon} <strong>${leftText}</strong> · ${rightText}
+  </div>`;
+}
+
+// 一键出库工具栏:viewer 自动隐藏(.btn-out 的全局 CSS 规则)
+let _batchOutPending = [];
+function _batchOutBar(allRows) {
+  const usable = allRows.filter(r => r.sku && r.bound_name);
+  _batchOutPending = usable;
+  if (!usable.length) return '';
+  const totalQty = usable.reduce((s,r) => s + (r.qty||0), 0);
+  const unboundCount = allRows.length - usable.length;
+  const note = unboundCount > 0
+    ? `<span style="color:var(--text-3);font-size:12px;margin-left:8px;">${unboundCount} 行未绑/缺翻译,已跳过</span>`
+    : '';
+  return `<div style="display:flex;align-items:center;gap:10px;margin-bottom:12px;">
+    <button class="btn btn-out" onclick="openBatchOutModal()">一键出库</button>
+    <span style="font-size:13px;color:var(--text-2);">将为 ${usable.length} 条记录生成出库流水 · 合计 ${totalQty.toLocaleString()} 件</span>
+    ${note}
+  </div>`;
+}
+
+function renderScheduleResult() {
+  const host = document.getElementById('schedule-result');
+  if (!host) return;
+  const data = scheduleResult;
+
+  if (data.not_found) {
+    host.innerHTML = `
+      <div class="empty">
+        <div class="empty-title">未找到 "${data.query}"</div>
+        <div style="color:var(--text-3);font-size:13px;">既不是已知 PO 号也不是已知货号(ITEM#)。确认输入正确,或检查是否已上传最新排期。</div>
+      </div>`;
+    return;
+  }
+
+  if (data.type === 'po') {
+    const ok = data.all_sufficient;
+    const banner = _banner(ok,
+      ok ? '库存充足' : '库存不足',
+      `PO ${data.po_no} · ${ok ? '计划' : '缺口'} ${(ok?data.total_scheduled:data.total_shortage).toLocaleString()}(计划 ${data.total_scheduled.toLocaleString()} / 库存 ${data.total_stock.toLocaleString()})`
+    );
+
+    // 把每个 item 的字母按"普通 / 稀有"拍平成两个行数组
+    const normalRows = [], rareRows = [];
+    data.items.forEach(it => {
+      (it.letters||[]).forEach(l => {
+        const base = {
+          item_code: it.item_code, sku: l.bound_sku || '',
+          letter: l.letter, image_url: l.image_url || '',
+          bound_name: l.bound_name || '',
+          flag: l.flag || it.flag || '',
+          inventory_flag: l.inventory_flag || '',
+          customer_sku: it.customer_sku || '',
+          name_cn: it.name_cn || '',
+          ratio_normal_text: it.ratio_normal_text || '',
+          ratio_rare_text: it.ratio_rare_text || '',
+        };
+        if (l.normal_qty != null && l.normal_qty > 0) {
+          normalRows.push({...base, _style:'normal', no_letter: l.no_letter, qty: l.normal_qty,
+            stock: l.normal_stock, shortage: l.normal_shortage, sufficient: l.normal_sufficient,
+            ratio_text: l.no_letter ? '(无字母款·按整数)' : (l.ratio_assumed ? '(未识别·默认归普通)' : it.ratio_normal_text)});
+        }
+        if (l.rare_qty != null && l.rare_qty > 0) {
+          rareRows.push({...base, _style:'rare', no_letter: l.no_letter, qty: l.rare_qty,
+            stock: l.rare_stock, shortage: l.rare_shortage, sufficient: l.rare_sufficient,
+            ratio_text: it.ratio_rare_text});
+        }
+      });
+    });
+
+    function renderStyleTable(title, rows, accent) {
+      if (!rows.length) return `<div style="margin-top:14px;color:var(--text-3);font-size:13px;">${title}:无需求</div>`;
+      return `
+        <div style="margin-top:18px;">
+          <div style="font-size:14px;font-weight:500;margin-bottom:8px;color:${accent};">${title} (${rows.length} 行)</div>
+          <div class="table-wrap"><table>
+            <thead><tr>
+              <th>货号</th><th>字母</th><th>物料</th><th>布标</th>
+              <th>比例</th>
+              <th class="num">计划</th><th class="num">库存</th>
+              <th class="num">缺口</th><th>够否</th>
+            </tr></thead>
+            <tbody>
+              ${rows.map(r => {
+                const img = r.image_url ? `<img src="${BASE_URL}${r.image_url}" style="width:24px;height:24px;object-fit:cover;border-radius:3px;vertical-align:middle;margin-right:4px;">` : '';
+                const stockTd = r.stock != null
+                  ? `<td class="num" style="color:${r.sufficient?'var(--in)':'var(--out)'};font-weight:500;">${r.stock.toLocaleString()}</td>`
+                  : `<td class="num" style="color:var(--text-3);">—</td>`;
+                const shortageTd = r.stock != null
+                  ? `<td class="num" style="color:${r.shortage?'var(--out)':'var(--text-3)'};">${r.shortage ? r.shortage.toLocaleString() : '—'}</td>`
+                  : `<td class="num" style="color:var(--text-3);">—</td>`;
+                const statusTd = !r.bound_name
+                  ? `<td><span style="color:var(--text-3);font-size:11px;">⚠ 未绑</span></td>`
+                  : r.sufficient
+                    ? `<td><span style="color:var(--in);">✓ 够</span></td>`
+                    : `<td><span style="color:var(--out);">✗ 差 ${(r.shortage||0).toLocaleString()}</span></td>`;
+                return `
+                  <tr>
+                    <td><code style="font-size:12px;">${r.sku || r.item_code}</code></td>
+                    <td>${img}${r.letter ? `<span class="badge badge-flag">${r.letter}</span>` : '<span style="color:var(--text-3);font-size:11px;">无字母</span>'}</td>
+                    <td>${r.bound_name || '<span style="color:var(--text-3);">未绑定</span>'}</td>
+                    <td style="font-size:12px;">${r.inventory_flag ? r.inventory_flag + (r.inventory_flag !== r.flag ? `<div style="font-size:10px;color:var(--text-3);">排期: ${r.flag}</div>` : '') : (r.flag || '—')}</td>
+                    <td style="font-size:11px;color:var(--text-3);">${r.ratio_text || '—'}</td>
+                    <td class="num">${r.qty.toLocaleString()}</td>
+                    ${stockTd}${shortageTd}${statusTd}
+                  </tr>
+                `;
+              }).join('')}
+            </tbody>
+          </table></div>
+        </div>
+      `;
+    }
+
+    host.innerHTML = banner +
+      _batchOutBar([...normalRows, ...rareRows]) +
+      renderStyleTable('普通款需求', normalRows, 'var(--in)') +
+      renderStyleTable('稀有款需求', rareRows, 'var(--out)');
+    return;
+  }
+
+  if (data.type === 'sku') {
+    const ok = data.sufficient;
+    const matchLabel = data.matched_by === 'customer_sku' ? '客户 SKU(F 列)' : 'ITEM#(G 列)';
+    const banner = _banner(ok,
+      ok ? '库存覆盖全部排期' : '库存不足以覆盖全部排期',
+      `匹配 ${matchLabel} = ${data.item_code} · 排期合计 ${data.total_scheduled.toLocaleString()} · 当前库存 ${data.current_stock.toLocaleString()}` + (ok ? '' : ` · 缺口 ${data.shortage.toLocaleString()}`)
+    );
+
+    // 把 pos.letters 拍平成普通 / 稀有两表
+    const normalRows = [], rareRows = [];
+    data.pos.forEach(p => {
+      (p.letters||[]).forEach(l => {
+        const base = {
+          po_no: p.po_no, item_code: p.item_code, sku: l.bound_sku || '',
+          letter: l.letter, image_url: l.image_url || '',
+          bound_name: l.bound_name || '',
+          flag: l.flag || p.flag || '',
+          inventory_flag: l.inventory_flag || '',
+          customer_sku: p.customer_sku || '',
+          plan_ship_date: p.plan_ship_date || '',
+          customer: p.customer || '',
+        };
+        if (l.normal_qty != null && l.normal_qty > 0) {
+          normalRows.push({...base, _style:'normal', no_letter: l.no_letter, qty: l.normal_qty,
+            stock: l.normal_stock, shortage: l.normal_shortage, sufficient: l.normal_sufficient,
+            ratio_text: l.no_letter ? '(无字母款·按整数)' : (l.ratio_assumed ? '(未识别·默认归普通)' : (p.ratio_normal_text || ''))});
+        }
+        if (l.rare_qty != null && l.rare_qty > 0) {
+          rareRows.push({...base, _style:'rare', no_letter: l.no_letter, qty: l.rare_qty,
+            stock: l.rare_stock, shortage: l.rare_shortage, sufficient: l.rare_sufficient,
+            ratio_text: p.ratio_rare_text || ''});
+        }
+      });
+    });
+
+    function renderSkuStyleTable(title, rows, accent) {
+      if (!rows.length) return `<div style="margin-top:14px;color:var(--text-3);font-size:13px;">${title}:无需求</div>`;
+      return `
+        <div style="margin-top:18px;">
+          <div style="font-size:14px;font-weight:500;margin-bottom:8px;color:${accent};">${title} (${rows.length} 行)</div>
+          <div class="table-wrap"><table>
+            <thead><tr>
+              <th>PO 号</th><th>字母</th><th>物料</th><th>布标</th>
+              <th>客户 SKU</th><th>出货期</th>
+              <th>比例</th>
+              <th class="num">计划</th><th class="num">库存</th>
+              <th class="num">缺口</th><th>够否</th>
+            </tr></thead>
+            <tbody>
+              ${rows.map(r => {
+                const img = r.image_url ? `<img src="${BASE_URL}${r.image_url}" style="width:24px;height:24px;object-fit:cover;border-radius:3px;vertical-align:middle;margin-right:4px;">` : '';
+                const stockTd = r.stock != null
+                  ? `<td class="num" style="color:${r.sufficient?'var(--in)':'var(--out)'};font-weight:500;">${r.stock.toLocaleString()}</td>`
+                  : `<td class="num" style="color:var(--text-3);">—</td>`;
+                const shortageTd = r.stock != null
+                  ? `<td class="num" style="color:${r.shortage?'var(--out)':'var(--text-3)'};">${r.shortage ? r.shortage.toLocaleString() : '—'}</td>`
+                  : `<td class="num" style="color:var(--text-3);">—</td>`;
+                const statusTd = !r.bound_name
+                  ? `<td><span style="color:var(--text-3);font-size:11px;">⚠ 未绑</span></td>`
+                  : r.sufficient
+                    ? `<td><span style="color:var(--in);">✓ 够</span></td>`
+                    : `<td><span style="color:var(--out);">✗ 差 ${(r.shortage||0).toLocaleString()}</span></td>`;
+                return `
+                  <tr>
+                    <td><code style="font-size:12px;">${r.po_no}</code></td>
+                    <td>${img}${r.letter ? `<span class="badge badge-flag">${r.letter}</span>` : '<span style="color:var(--text-3);font-size:11px;">无字母</span>'}</td>
+                    <td>${r.bound_name || '<span style="color:var(--text-3);">未绑定</span>'}</td>
+                    <td style="font-size:12px;">${r.inventory_flag ? r.inventory_flag + (r.inventory_flag !== r.flag ? `<div style="font-size:10px;color:var(--text-3);">排期: ${r.flag}</div>` : '') : (r.flag || '—')}</td>
+                    <td><code style="font-size:11px;color:var(--text-2);">${r.customer_sku||'—'}</code></td>
+                    <td style="font-size:12px;color:var(--text-2);">${r.plan_ship_date||'—'}</td>
+                    <td style="font-size:11px;color:var(--text-3);">${r.ratio_text || '—'}</td>
+                    <td class="num">${r.qty.toLocaleString()}</td>
+                    ${stockTd}${shortageTd}${statusTd}
+                  </tr>
+                `;
+              }).join('')}
+            </tbody>
+          </table></div>
+        </div>
+      `;
+    }
+
+    host.innerHTML = banner +
+      _batchOutBar([...normalRows, ...rareRows]) +
+      renderSkuStyleTable('普通款需求', normalRows, 'var(--in)') +
+      renderSkuStyleTable('稀有款需求', rareRows, 'var(--out)');
+    return;
+  }
+
+  host.innerHTML = '<div class="empty"><div class="empty-title">未知的查询结果</div></div>';
+}
+
+function openInModal(preset) {
+  editingInId = preset?.id || null;
+  const isEditing = !!editingInId;
+  const today = new Date().toISOString().slice(0,10);
+  const presetCat = preset?.category || currentCategory || 'plush';
+  const allNames = getAllSkuNames(presetCat);
+  document.getElementById('modal-host').innerHTML = `
+    <div class="modal-mask" onclick="if(event.target===this)closeModal()">
+      <div class="modal">
+        <div class="modal-title">${isEditing ? '编辑入库' : '录入入库'}</div>
+        <div class="modal-sub">字段:品类 / 日期 / 单号 / 货号 / 物料名称 / 款式 / 布标 / 数量</div>
+        <div class="form-grid">
+          <div class="form-row">
+            <label class="form-label">品类<span class="req">*</span></label>
+            <select id="f-category" onchange="onCategoryChange()">
+              <option value="plush" ${presetCat==='plush'?'selected':''}>毛绒</option>
+              <option value="costume" ${presetCat==='costume'?'selected':''}>戏服</option>
+            </select>
+          </div>
+          <div class="form-row">
+            <label class="form-label">日期<span class="req">*</span></label>
+            <input type="date" id="f-date" value="${preset?.date || today}">
+          </div>
+          <div class="form-row">
+            <label class="form-label">单号<span class="req">*</span></label>
+            <input id="f-bill" value="${preset?.billNo||''}">
+          </div>
+          <div class="form-row">
+            <label class="form-label">货号<span class="req">*</span></label>
+            <input id="f-sku" list="sku-dl" value="${preset?.sku||''}">
+            <datalist id="sku-dl">${Object.keys(allNames).map(s => `<option value="${s}">`).join('')}</datalist>
+          </div>
+          <div class="form-row">
+            <label class="form-label">物料名称</label>
+            <input id="f-name" value="${preset?.name||''}">
+          </div>
+          <div class="form-row" id="style-row">
+            <label class="form-label"><span id="style-label">${presetCat==='costume'?'类型':'款式'}</span><span id="style-req" class="req" style="${presetCat==='costume'?'display:none':''}">*</span></label>
+            ${presetCat==='plush'
+              ? `<select id="f-style">
+                  <option value="normal" ${preset?.style!=='rare'?'selected':''}>普通款</option>
+                  <option value="rare" ${preset?.style==='rare'?'selected':''}>稀有款</option>
+                </select>`
+              : `<input id="f-style" placeholder="如: M 码 / 大号 / 童装" value="${preset?.style||''}">`}
+          </div>
+          <div class="form-row" id="flag-row">
+            <label class="form-label">布标<span class="req">*</span></label>
+            <select id="f-flag">
+              <option value="">请选择</option>
+              ${state.flags.map(f => `<option ${preset?.flag===f?'selected':''}>${f}</option>`).join('')}
+            </select>
+          </div>
+          <div class="form-row full">
+            <label class="form-label">数量<span class="req">*</span></label>
+            <input id="f-qty" type="number" min="1" placeholder="数量" value="${preset?.qty||''}">
+          </div>
+        </div>
+        <div class="form-actions">
+          <button class="btn" onclick="closeModal()">取消</button>
+          ${isEditing ? '' : '<button class="btn" onclick="clearInForm()">清空</button>'}
+          <button class="btn btn-in" onclick="saveIn(false)">保存</button>
+          ${isEditing ? '' : '<button class="btn btn-primary" onclick="saveIn(true)">保存并继续录入</button>'}
+        </div>
+      </div>
+    </div>
+  `;
+  setTimeout(() => {
+    const skuEl = document.getElementById('f-sku');
+    skuEl.addEventListener('change', () => {
+      const name = allNames[skuEl.value];
+      if (name) document.getElementById('f-name').value = name;
+    });
+    // 初始打开时,根据当前品类立即隐藏/显示布标行
+    onCategoryChange();
+    (preset?.sku ? document.getElementById('f-qty') : document.getElementById('f-bill')).focus();
+  }, 50);
+}
+
+// 品类切换时重建款式输入框(毛绒下拉 / 戏服自由文本)
+function onCategoryChange() {
+  const cat = document.getElementById('f-category').value;
+  const styleRow = document.getElementById('style-row');
+  const styleLabel = document.getElementById('style-label');
+  if (styleLabel) styleLabel.textContent = cat === 'costume' ? '类型' : '款式';
+  const styleReq = document.getElementById('style-req');
+  if (styleReq) styleReq.style.display = cat === 'costume' ? 'none' : '';
+
+  // 戏服时隐藏布标行(戏服没有布标这个字段)
+  const flagRow = document.getElementById('flag-row');
+  if (flagRow) {
+    flagRow.style.display = cat === 'costume' ? 'none' : '';
+    // 戏服时清空 flag 值,避免误传
+    const flagEl = document.getElementById('f-flag');
+    if (flagEl && cat === 'costume') flagEl.value = '';
+  }
+
+  if (!styleRow) return;
+  const oldVal = document.getElementById('f-style')?.value || '';
+  const inputs = styleRow.querySelectorAll('select, input');
+  inputs.forEach(el => { if (el.id === 'f-style') el.remove(); });
+  let newEl;
+  if (cat === 'plush') {
+    newEl = document.createElement('select');
+    newEl.id = 'f-style';
+    newEl.innerHTML = '<option value="normal">普通款</option><option value="rare">稀有款</option>';
+    newEl.value = (oldVal === 'rare' ? 'rare' : 'normal');
+  } else {
+    newEl = document.createElement('input');
+    newEl.id = 'f-style';
+    newEl.placeholder = '如: M 码 / 大号 / 童装';
+    newEl.value = (oldVal && oldVal !== 'normal' && oldVal !== 'rare') ? oldVal : '';
+  }
+  styleRow.appendChild(newEl);
+}
+
+function openOutModal(preset) {
+  editingOutId = preset?.id || null;
+  const isEditing = !!editingOutId;
+  const today = new Date().toISOString().slice(0,10);
+  const presetCat = preset?.category || currentCategory || 'plush';
+  const allNames = getAllSkuNames(presetCat);
+  document.getElementById('modal-host').innerHTML = `
+    <div class="modal-mask" onclick="if(event.target===this)closeModal()">
+      <div class="modal">
+        <div class="modal-title">${isEditing ? '编辑出库' : '录入出库'}</div>
+        <div class="modal-sub">字段:品类 / 日期 / 单号 / PO号 / 领货人 / 货号 / 物料名称 / 款式 / 布标 / 数量</div>
+        <div class="form-grid">
+          <div class="form-row">
+            <label class="form-label">品类<span class="req">*</span></label>
+            <select id="f-category" onchange="onCategoryChange()">
+              <option value="plush" ${presetCat==='plush'?'selected':''}>毛绒</option>
+              <option value="costume" ${presetCat==='costume'?'selected':''}>戏服</option>
+            </select>
+          </div>
+          <div class="form-row">
+            <label class="form-label">日期<span class="req">*</span></label>
+            <input type="date" id="f-date" value="${preset?.date || today}">
+          </div>
+          <div class="form-row">
+            <label class="form-label">单号<span class="req">*</span></label>
+            <input id="f-bill" value="${preset?.billNo||''}">
+          </div>
+          <div class="form-row">
+            <label class="form-label">PO号</label>
+            <input id="f-po" value="${preset?.po||''}">
+          </div>
+          <div class="form-row">
+            <label class="form-label">领货人</label>
+            <input id="f-picker" value="${preset?.picker||''}">
+          </div>
+          <div class="form-row">
+            <label class="form-label">货号<span class="req">*</span></label>
+            <input id="f-sku" list="sku-dl" value="${preset?.sku||''}">
+            <datalist id="sku-dl">${Object.keys(allNames).map(s => `<option value="${s}">`).join('')}</datalist>
+          </div>
+          <div class="form-row">
+            <label class="form-label">物料名称</label>
+            <input id="f-name" value="${preset?.name||''}">
+          </div>
+          <div class="form-row" id="style-row">
+            <label class="form-label"><span id="style-label">${presetCat==='costume'?'类型':'款式'}</span><span id="style-req" class="req" style="${presetCat==='costume'?'display:none':''}">*</span></label>
+            ${presetCat==='plush'
+              ? `<select id="f-style">
+                  <option value="normal" ${preset?.style!=='rare'?'selected':''}>普通款</option>
+                  <option value="rare" ${preset?.style==='rare'?'selected':''}>稀有款</option>
+                </select>`
+              : `<input id="f-style" placeholder="如: M 码" value="${preset?.style||''}">`}
+          </div>
+          <div class="form-row" id="flag-row">
+            <label class="form-label">布标<span class="req">*</span></label>
+            <select id="f-flag">
+              <option value="">请选择</option>
+              ${state.flags.map(f => `<option ${preset?.flag===f?'selected':''}>${f}</option>`).join('')}
+            </select>
+          </div>
+          <div class="form-row full">
+            <label class="form-label">数量<span class="req">*</span></label>
+            <input id="f-qty" type="number" min="1" placeholder="数量" value="${preset?.qty||''}">
+            <div id="stock-hint" style="font-size:12px;color:var(--text-3);margin-top:4px;"></div>
+          </div>
+        </div>
+        <div class="form-actions">
+          <button class="btn" onclick="closeModal()">取消</button>
+          ${isEditing ? '' : '<button class="btn" onclick="clearOutForm()">清空</button>'}
+          <button class="btn btn-out" onclick="saveOut(false)">保存</button>
+          ${isEditing ? '' : '<button class="btn btn-primary" onclick="saveOut(true)">保存并继续录入</button>'}
+        </div>
+      </div>
+    </div>
+  `;
+  setTimeout(() => {
+    const skuEl = document.getElementById('f-sku');
+    const flagEl = document.getElementById('f-flag');
+    const updateHint = () => {
+      const cat = document.getElementById('f-category').value;
+      const styleEl = document.getElementById('f-style');
+      const nameEl = document.getElementById('f-name');
+      const sku = skuEl.value, style = styleEl?.value || '';
+      const name = nameEl?.value?.trim() || '';
+      const flag = cat === 'costume' ? '' : (flagEl?.value || '');
+      // 戏服: 只要 sku+style 就能查;毛绒: 需要 sku+style+flag
+      const ready = cat === 'costume' ? (sku && style) : (sku && style && flag);
+      if (ready) {
+        const stockMap = getStockMap();
+        const key = `${cat}|${sku}|${name}|${style}|${flag}`;
+        const stock = stockMap[key]?.stock || 0;
+        document.getElementById('stock-hint').innerHTML = `当前库存: <strong style="color:${stock<100?'var(--out)':'var(--in)'};">${stock.toLocaleString()}</strong>` + (name ? '' : ' <span style="color:var(--text-3);font-size:11px;">(填写物料名后会按 4 维精确查)</span>');
+      } else {
+        document.getElementById('stock-hint').textContent = '';
+      }
+    };
+    skuEl.addEventListener('change', () => {
+      const name = allNames[skuEl.value];
+      if (name) document.getElementById('f-name').value = name;
+      updateHint();
+    });
+    flagEl.addEventListener('change', updateHint);
+    document.getElementById('f-style')?.addEventListener('change', updateHint);
+    document.getElementById('f-name')?.addEventListener('input', updateHint);
+    // 初始打开时,根据当前品类立即隐藏/显示布标行
+    onCategoryChange();
+    updateHint();
+    (preset?.sku ? document.getElementById('f-qty') : document.getElementById('f-bill')).focus();
+  }, 50);
+}
+
+function getAllSkuNames(category) {
+  const map = {};
+  const match = (r) => !category || category === 'all' || (r.category || 'plush') === category;
+  state.inRecords.forEach(r => { if (r.name && match(r)) map[r.sku] = r.name; });
+  state.outRecords.forEach(r => { if (r.name && match(r) && !map[r.sku]) map[r.sku] = r.name; });
+  return map;
+}
+
+function clearInForm() {
+  // 清空除品类、日期外的所有字段,焦点回到单号
+  document.getElementById('f-bill').value = '';
+  document.getElementById('f-sku').value = '';
+  document.getElementById('f-name').value = '';
+  document.getElementById('f-qty').value = '';
+  const flagEl = document.getElementById('f-flag');
+  if (flagEl) flagEl.value = '';
+  const styleEl = document.getElementById('f-style');
+  if (styleEl) styleEl.value = styleEl.tagName === 'SELECT' ? 'normal' : '';
+  document.getElementById('f-bill').focus();
+}
+
+async function saveIn(keepGoing) {
+  const category = document.getElementById('f-category')?.value || currentCategory;
+  const date = document.getElementById('f-date').value;
+  const billNo = document.getElementById('f-bill').value.trim();
+  const sku = document.getElementById('f-sku').value.trim();
+  const name = document.getElementById('f-name').value.trim();
+  const style = document.getElementById('f-style').value.trim();
+  // 戏服没有布标字段,自动设为空字符串
+  const flag = category === 'costume' ? '' : document.getElementById('f-flag').value;
+  const qty = parseInt(document.getElementById('f-qty').value);
+
+  // 校验:戏服 style/flag 都可空,毛绒必须有 style+flag
+  const flagOk = category === 'costume' ? true : !!flag;
+  const styleOk = category === 'costume' ? true : !!style;
+  if (!date || !billNo || !sku || !styleOk || !flagOk || !qty || qty <= 0) {
+    alert('请填写所有必填字段(标 * 的)'); return;
+  }
+
+  try {
+    const body = { category, date, billNo, sku, name, style, flag, qty };
+    if (editingInId) {
+      await api('/api/in/' + editingInId, { method: 'PUT', body });
+    } else {
+      await api('/api/in', { method: 'POST', body });
+    }
+    await loadAllData();
+    if (keepGoing && !editingInId) {
+      openInModal({ category, billNo, sku, name, style, flag });
+    } else {
+      closeModal();
+      if (category !== currentCategory && currentCategory !== 'all') {
+        switchCategory(category);  // 自动切到对应品类,否则记录被过滤挡掉
+      } else {
+        render();
+      }
+    }
+  } catch (err) {
+    alert('保存失败: ' + err.message);
+  }
+}
+
+function clearOutForm() {
+  // 清空除品类、日期外的所有字段,焦点回到单号
+  document.getElementById('f-bill').value = '';
+  document.getElementById('f-po').value = '';
+  document.getElementById('f-picker').value = '';
+  document.getElementById('f-sku').value = '';
+  document.getElementById('f-name').value = '';
+  document.getElementById('f-qty').value = '';
+  const flagEl = document.getElementById('f-flag');
+  if (flagEl) flagEl.value = '';
+  const styleEl = document.getElementById('f-style');
+  if (styleEl) styleEl.value = styleEl.tagName === 'SELECT' ? 'normal' : '';
+  const hintEl = document.getElementById('stock-hint');
+  if (hintEl) hintEl.textContent = '';
+  document.getElementById('f-bill').focus();
+}
+
+async function saveOut(keepGoing) {
+  const category = document.getElementById('f-category')?.value || currentCategory;
+  const date = document.getElementById('f-date').value;
+  const billNo = document.getElementById('f-bill').value.trim();
+  const po = document.getElementById('f-po').value.trim();
+  const picker = document.getElementById('f-picker').value.trim();
+  const sku = document.getElementById('f-sku').value.trim();
+  const name = document.getElementById('f-name').value.trim();
+  const style = document.getElementById('f-style').value.trim();
+  // 戏服没有布标字段,自动设为空字符串
+  const flag = category === 'costume' ? '' : document.getElementById('f-flag').value;
+  const qty = parseInt(document.getElementById('f-qty').value);
+
+  // 校验:戏服 style/flag 都可空,毛绒必须有 style+flag
+  const flagOk = category === 'costume' ? true : !!flag;
+  const styleOk = category === 'costume' ? true : !!style;
+  if (!date || !billNo || !sku || !styleOk || !flagOk || !qty || qty <= 0) {
+    alert('请填写所有必填字段(标 * 的)'); return;
+  }
+
+  const stockMap = getStockMap();
+  const key = `${category}|${sku}|${name||''}|${style}|${flag}`;
+  const currentStock = stockMap[key]?.stock || 0;
+  if (qty > currentStock) {
+    // 戏服没有布标,提示文本不显示布标
+    const nameDesc = name ? `/${name}` : '';
+    const desc = category === 'costume' ? `${sku}${nameDesc} (${style})` : `${sku}${nameDesc} (${style}/${flag})`;
+    if (!confirm(`当前 ${desc} 库存只有 ${currentStock},出库 ${qty} 将变为负数。继续?`)) return;
+  }
+
+  try {
+    const body = { category, date, billNo, po, picker, sku, name, style, flag, qty };
+    if (editingOutId) {
+      await api('/api/out/' + editingOutId, { method: 'PUT', body });
+    } else {
+      await api('/api/out', { method: 'POST', body });
+    }
+    await loadAllData();
+    if (keepGoing && !editingOutId) {
+      openOutModal({ category, billNo, po, picker, sku, name, style, flag });
+    } else {
+      closeModal();
+      if (category !== currentCategory && currentCategory !== 'all') {
+        switchCategory(category);
+      } else {
+        render();
+      }
+    }
+  } catch (err) {
+    alert('保存失败: ' + err.message);
+  }
+}
+
+function openBatchOutModal() {
+  if (!_batchOutPending.length) { alert('没有可出库的记录'); return; }
+  const today = new Date().toISOString().slice(0,10);
+  const fallbackPo = scheduleResult?.type === 'po' ? (scheduleResult.po_no || '') : '';
+  const totalQty = _batchOutPending.reduce((s,r) => s + (r.qty||0), 0);
+  document.getElementById('modal-host').innerHTML = `
+    <div class="modal-mask" onclick="if(event.target===this)closeModal()">
+      <div class="modal" style="max-width:980px;">
+        <div class="modal-title">一键出库</div>
+        <div class="modal-sub">日期固定为今天,所有勾选行同一单号/同一领货人;库存不足的行会标红但仍可勾选(允许出成负库存)</div>
+        <div class="form-grid">
+          <div class="form-row">
+            <label class="form-label">日期</label>
+            <input type="date" id="bo-date" value="${today}" readonly>
+          </div>
+          <div class="form-row">
+            <label class="form-label">出库单号<span class="req">*</span></label>
+            <input id="bo-bill" placeholder="如 OUT-20260514-001">
+          </div>
+          <div class="form-row">
+            <label class="form-label">领货人<span class="req">*</span></label>
+            <input id="bo-picker" placeholder="如 ZURU / 张三">
+          </div>
+        </div>
+        <div style="margin-top:14px;font-size:13px;color:var(--text-2);">勾选要出库的行(默认全勾,合计 ${totalQty.toLocaleString()} 件):</div>
+        <div class="table-wrap" style="margin-top:8px;max-height:400px;overflow:auto;">
+          <table>
+            <thead><tr>
+              <th style="width:36px;"><input type="checkbox" id="bo-all" checked onchange="document.querySelectorAll('.bo-chk').forEach(c=>c.checked=this.checked)"></th>
+              <th>PO 号</th><th>货号</th><th>字母</th><th>物料</th><th>款式</th><th>布标</th>
+              <th class="num">出库</th><th class="num">库存</th><th>状态</th>
+            </tr></thead>
+            <tbody>
+              ${_batchOutPending.map((r,i) => `
+                <tr>
+                  <td><input type="checkbox" class="bo-chk" data-idx="${i}" checked></td>
+                  <td><code style="font-size:12px;">${r.po_no || fallbackPo || '—'}</code></td>
+                  <td><code style="font-size:12px;">${r.sku}</code></td>
+                  <td><span class="badge badge-flag">${r.letter}</span></td>
+                  <td>${r.bound_name}</td>
+                  <td>${r._style === 'rare' ? '稀有款' : '普通款'}</td>
+                  <td style="font-size:12px;">${r.inventory_flag || r.flag || '—'}</td>
+                  <td class="num">${r.qty.toLocaleString()}</td>
+                  <td class="num" style="color:${r.sufficient?'var(--in)':'var(--out)'};">${r.stock != null ? r.stock.toLocaleString() : '—'}</td>
+                  <td>${r.sufficient ? '<span style="color:var(--in);">✓ 够</span>' : `<span style="color:var(--out);">✗ 差 ${(r.shortage||0).toLocaleString()}</span>`}</td>
+                </tr>
+              `).join('')}
+            </tbody>
+          </table>
+        </div>
+        <div class="form-actions">
+          <button class="btn" onclick="closeModal()">取消</button>
+          <button class="btn btn-out" onclick="submitBatchOut()">确认出库</button>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+async function submitBatchOut() {
+  const date = document.getElementById('bo-date').value;
+  const billNo = document.getElementById('bo-bill').value.trim();
+  const picker = document.getElementById('bo-picker').value.trim();
+  if (!billNo) { alert('请填写出库单号'); return; }
+  if (!picker) { alert('请填写领货人'); return; }
+  const checked = [...document.querySelectorAll('.bo-chk:checked')].map(c => parseInt(c.dataset.idx));
+  if (!checked.length) { alert('请至少勾选一条记录'); return; }
+  const fallbackPo = scheduleResult?.type === 'po' ? (scheduleResult.po_no || '') : '';
+  const records = checked.map(i => {
+    const r = _batchOutPending[i];
+    return {
+      category: 'plush',
+      date, billNo, picker,
+      po: r.po_no || fallbackPo,
+      sku: r.sku,
+      name: r.bound_name,
+      style: r._style || 'normal',
+      flag: r.inventory_flag || r.flag || '',
+      qty: r.qty,
+    };
+  });
+  // 库存不足提醒
+  const shortRows = checked.map(i => _batchOutPending[i]).filter(r => !r.sufficient);
+  if (shortRows.length) {
+    if (!confirm(`有 ${shortRows.length} 条记录库存不足,出库后将变为负库存。确认继续?`)) return;
+  }
+  try {
+    const res = await api('/api/out/batch', { method: 'POST', body: { records } });
+    await loadAllData();
+    closeModal();
+    alert(`成功生成 ${res.count} 条出库流水`);
+    // 重新搜索,刷新库存视图
+    const q = document.getElementById('schedule-po')?.value?.trim();
+    if (q) { querySchedule(); } else { render(); }
+  } catch (err) {
+    alert('批量出库失败: ' + err.message);
+  }
+}
+
+function closeModal() { document.getElementById('modal-host').innerHTML = ''; }
+
+async function deleteRecord(type, id) {
+  if (!confirm('确定删除这条记录吗?库存会自动重算')) return;
+  try {
+    await api(`/api/${type}/${id}`, { method: 'DELETE' });
+    await loadAllData();
+    render();
+  } catch (err) {
+    alert('删除失败: ' + err.message);
+  }
+}
+
+function toggleSelect(id) {
+  if (selectedRecords.has(id)) selectedRecords.delete(id);
+  else selectedRecords.add(id);
+  render();
+}
+
+function toggleSelectAll(type) {
+  let filtered = filterByCategory(type === 'in' ? state.inRecords : state.outRecords);
+  if (filters.date) filtered = filtered.filter(r => r.date === filters.date);
+  if (filters.sku) filtered = filtered.filter(r => r.sku.toLowerCase().includes(filters.sku.toLowerCase()));
+  if (filters.flag) filtered = filtered.filter(r => r.flag === filters.flag);
+  if (type === 'out' && filters.po) filtered = filtered.filter(r => (r.po||'').toLowerCase().includes(filters.po.toLowerCase()));
+  const allChecked = filtered.length > 0 && filtered.every(r => selectedRecords.has(r.id));
+  if (allChecked) filtered.forEach(r => selectedRecords.delete(r.id));
+  else filtered.forEach(r => selectedRecords.add(r.id));
+  render();
+}
+
+async function deleteSelected(type) {
+  const ids = [...selectedRecords];
+  if (!ids.length) return;
+  if (!confirm(`确定删除选中的 ${ids.length} 条${type==='in'?'入库':'出库'}记录吗?库存会自动重算`)) return;
+  try {
+    const res = await api(`/api/${type}/batch-delete`, { method: 'POST', body: { ids } });
+    selectedRecords.clear();
+    await loadAllData();
+    render();
+    alert(`已删除 ${res.count} 条记录`);
+  } catch (err) {
+    alert('批量删除失败: ' + err.message);
+  }
+}
+
+function openEdit(type, id) {
+  // 根据 id 在 state 中找到记录,然后用 preset(含 id)打开对应弹窗触发编辑模式
+  const records = type === 'in' ? state.inRecords : state.outRecords;
+  const r = records.find(x => x.id === id);
+  if (!r) { alert('记录不存在(请刷新页面)'); return; }
+  const preset = {
+    id: r.id, category: r.category, date: r.date,
+    billNo: r.billNo, sku: r.sku, name: r.name,
+    style: r.style, flag: r.flag, qty: r.qty
+  };
+  if (type === 'out') { preset.po = r.po; preset.picker = r.picker; }
+  (type === 'in' ? openInModal : openOutModal)(preset);
+}
+
+function exportSku(sku) {
+  // 调后端生成多 sheet xlsx(入库 / 出库),矩阵布局:列 = (款式, 布标)
+  window.location.href = BASE_URL + '/api/export/sku/' + encodeURIComponent(sku);
+}
+
+function exportAll() {
+  const inRows = [['日期','单号','货号','物料名称','款式','布标','数量']];
+  [...state.inRecords].sort((a,b)=>a.date.localeCompare(b.date)||a.id-b.id).forEach(r => {
+    inRows.push([r.date, r.billNo, r.sku, r.name||'', styleLabel(r.style), r.flag, r.qty]);
+  });
+
+  const outRows = [['日期','单号','PO号','领货人','货号','物料名称','款式','布标','数量']];
+  [...state.outRecords].sort((a,b)=>a.date.localeCompare(b.date)||a.id-b.id).forEach(r => {
+    outRows.push([r.date, r.billNo, r.po||'', r.picker||'', r.sku, r.name||'', styleLabel(r.style), r.flag, r.qty]);
+  });
+
+  const stockRows = [['货号','物料名称','款式','布标','当前库存','累计入库','累计出库','最近入库','最近出库']];
+  Object.values(getStockMap()).sort((a,b)=>(a.sku+(a.name||'')+a.style+a.flag).localeCompare(b.sku+(b.name||'')+b.style+b.flag)).forEach(v => {
+    stockRows.push([v.sku, v.name||'', styleLabel(v.style), v.flag, v.stock, v.inTotal, v.outTotal, v.lastIn||'', v.lastOut||'']);
+  });
+
+  const date = new Date().toISOString().slice(0,10);
+  downloadCsv(stockRows, `华登毛绒_库存总览_${date}.csv`);
+  setTimeout(() => downloadCsv(inRows, `华登毛绒_入库流水_${date}.csv`), 300);
+  setTimeout(() => downloadCsv(outRows, `华登毛绒_出库流水_${date}.csv`), 600);
+}
+
+function downloadCsv(rows, filename) {
+  const BOM = '\uFEFF';
+  const csv = BOM + rows.map(row =>
+    row.map(cell => {
+      const s = String(cell);
+      if (s.includes(',') || s.includes('"') || s.includes('\n')) return '"' + s.replace(/"/g,'""') + '"';
+      return s;
+    }).join(',')
+  ).join('\n');
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url; a.download = filename; a.click();
+  URL.revokeObjectURL(url);
+}
+
+// ==================== 启动 ====================
+
+const ROLE_NAMES = {
+  admin: '主管',
+  operator: '仓管员',
+  viewer: '游客'
+};
+
+(async function init() {
+  await loadAllData();
+  if (state.currentUser) {
+    const roleEl = document.getElementById('user-role');
+    if (roleEl) roleEl.textContent = ROLE_NAMES[state.currentUser.role] || state.currentUser.role;
+    const nameEl = document.getElementById('user-name');
+    if (nameEl) nameEl.textContent = state.currentUser.display_name || state.currentUser.username;
+  }
+  switchCategory('plush');  // 默认毛绒
+  navigate('stock');
+})();
+</script>
+</body>
+</html>

--- a/apps/PMC跟仓管/华登毛绒仓库/templates/login.html
+++ b/apps/PMC跟仓管/华登毛绒仓库/templates/login.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>登录 · 华登库存</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Microsoft YaHei", sans-serif;
+    background: #FAFAF7;
+    color: #1A1A17;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 20px;
+  }
+  .login-card {
+    background: white;
+    border: 1px solid #E5E3DD;
+    border-radius: 12px;
+    padding: 40px 36px;
+    width: 100%;
+    max-width: 380px;
+    box-shadow: 0 4px 20px rgba(0,0,0,0.04);
+  }
+  .brand { text-align: center; margin-bottom: 32px; }
+  .brand-title { font-size: 20px; font-weight: 600; margin-bottom: 6px; letter-spacing: -0.01em; }
+  .brand-sub { font-size: 13px; color: #5F5E58; }
+  .form-row { margin-bottom: 14px; }
+  .form-label { display: block; font-size: 12px; color: #5F5E58; margin-bottom: 6px; font-weight: 500; }
+  input {
+    width: 100%;
+    padding: 10px 12px;
+    border: 1px solid #D1CFC7;
+    border-radius: 6px;
+    font-size: 14px;
+    font-family: inherit;
+    color: #1A1A17;
+  }
+  input:focus { outline: none; border-color: #1A4D8F; }
+  button {
+    width: 100%;
+    padding: 11px;
+    background: #1A4D8F;
+    color: white;
+    border: none;
+    border-radius: 6px;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    font-family: inherit;
+    margin-top: 8px;
+  }
+  button:hover { background: #143E72; }
+  button:disabled { opacity: 0.6; cursor: not-allowed; }
+  .error {
+    background: #F5E5E3;
+    color: #A03830;
+    padding: 9px 12px;
+    border-radius: 6px;
+    font-size: 13px;
+    margin-bottom: 14px;
+    display: none;
+  }
+  .error.show { display: block; }
+</style>
+</head>
+<body>
+  <div class="login-card">
+    <div class="brand">
+      <div class="brand-title">华登库存</div>
+      <div class="brand-sub">毛绒 · 戏服 库存管理</div>
+    </div>
+
+    <div class="error" id="error"></div>
+
+    <form id="login-form">
+      <div class="form-row">
+        <label class="form-label">用户名</label>
+        <input id="username" autocomplete="username" autofocus required>
+      </div>
+      <div class="form-row">
+        <label class="form-label">密码</label>
+        <input id="password" type="password" autocomplete="current-password" required>
+      </div>
+      <button type="submit" id="submit-btn">登录</button>
+    </form>
+  </div>
+
+<script>
+// 部署前缀：兼容本地直跑 (5009) 和云端 nginx 反代 /huadeng-maorong/
+const BASE_URL = location.pathname.startsWith('/huadeng-maorong') ? '/huadeng-maorong' : '';
+
+const form = document.getElementById('login-form');
+const errorEl = document.getElementById('error');
+const submitBtn = document.getElementById('submit-btn');
+
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  errorEl.classList.remove('show');
+  submitBtn.disabled = true;
+  submitBtn.textContent = '登录中...';
+
+  try {
+    const resp = await fetch(BASE_URL + '/api/login', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({
+        username: document.getElementById('username').value.trim(),
+        password: document.getElementById('password').value
+      })
+    });
+    const data = await resp.json();
+    if (resp.ok && data.success) {
+      window.location.href = BASE_URL + '/';
+    } else {
+      errorEl.textContent = data.error || '登录失败';
+      errorEl.classList.add('show');
+    }
+  } catch (err) {
+    errorEl.textContent = '网络错误';
+    errorEl.classList.add('show');
+  } finally {
+    submitBtn.disabled = false;
+    submitBtn.textContent = '登录';
+  }
+});
+</script>
+</body>
+</html>

--- a/apps/PMC跟仓管/华登毛绒仓库/test_logic.py
+++ b/apps/PMC跟仓管/华登毛绒仓库/test_logic.py
@@ -1,0 +1,361 @@
+"""
+华登库存系统 - 自动化测试脚本
+
+【作用】
+确保 Claude Code 写的代码逻辑正确,特别是库存计算这种容易出错的地方。
+
+【运行】
+    python test_logic.py
+
+【全部通过的标志】
+看到 "✓ 全部测试通过!" 才算 OK,否则按错误提示修复。
+
+【注意】
+本脚本会创建一个独立测试数据库(test_inventory.db),不影响生产数据。
+"""
+import os
+import sys
+import shutil
+import tempfile
+
+# 用临时数据库做测试,不影响生产
+TEST_DB_DIR = tempfile.mkdtemp(prefix='huadeng_test_')
+TEST_DB_PATH = os.path.join(TEST_DB_DIR, 'inventory.db')
+
+# 重要:在 import database 之前先改路径
+import database
+database.DB_PATH = TEST_DB_PATH
+os.makedirs(os.path.dirname(TEST_DB_PATH), exist_ok=True)
+
+
+# ==================== 测试工具 ====================
+
+passed = 0
+failed = 0
+errors = []
+
+
+def assert_eq(actual, expected, name):
+    global passed, failed
+    if actual == expected:
+        passed += 1
+        print(f'  ✓ {name}')
+    else:
+        failed += 1
+        msg = f'  ✗ {name}: 期望 {expected}, 实际 {actual}'
+        errors.append(msg)
+        print(msg)
+
+
+def section(title):
+    print(f'\n[{title}]')
+
+
+def reset_db():
+    """每个测试组开始前,清空数据库重建"""
+    if os.path.exists(TEST_DB_PATH):
+        os.remove(TEST_DB_PATH)
+    database.init_database()
+
+
+# ==================== 测试 1: 基本入库出库 ====================
+
+def test_basic_in_out():
+    section('测试 1:基本入库 / 出库 / 库存计算')
+    reset_db()
+
+    # 入库 100 件
+    database.insert_in_record({
+        'category': 'plush', 'date': '2026-05-12', 'billNo': 'IN-T001',
+        'sku': 'HD-T001', 'name': '小熊', 'style': 'normal', 'flag': '美国', 'qty': 100
+    }, 'test')
+
+    stock = database.calculate_stock('plush', 'HD-T001', 'normal', '美国')
+    assert_eq(stock, 100, '入库 100 后库存 = 100')
+
+    # 再入 50 件
+    database.insert_in_record({
+        'category': 'plush', 'date': '2026-05-12', 'billNo': 'IN-T002',
+        'sku': 'HD-T001', 'name': '小熊', 'style': 'normal', 'flag': '美国', 'qty': 50
+    }, 'test')
+
+    stock = database.calculate_stock('plush', 'HD-T001', 'normal', '美国')
+    assert_eq(stock, 150, '再入 50 后库存 = 150')
+
+    # 出库 30 件(出库 API 还没实现,直接用 SQL)
+    with database.db_cursor() as cur:
+        cur.execute(
+            '''INSERT INTO out_records
+               (category, date, bill_no, sku, name, style, flag, qty, created_by)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)''',
+            ('plush', '2026-05-12', 'OUT-T001', 'HD-T001', '小熊', 'normal', '美国', 30, 'test')
+        )
+
+    stock = database.calculate_stock('plush', 'HD-T001', 'normal', '美国')
+    assert_eq(stock, 120, '出库 30 后库存 = 120(150-30)')
+
+
+# ==================== 测试 2: 三级模型严格性 ====================
+
+def test_three_level_separation():
+    section('测试 2:三级模型独立性(货号+款式+布标 唯一)')
+    reset_db()
+
+    # 同货号、不同款式、不同布标
+    database.insert_in_record({
+        'category': 'plush', 'date': '2026-05-12', 'billNo': 'IN-A',
+        'sku': 'HD-T001', 'name': '小熊', 'style': 'normal', 'flag': '美国', 'qty': 100
+    }, 'test')
+
+    database.insert_in_record({
+        'category': 'plush', 'date': '2026-05-12', 'billNo': 'IN-B',
+        'sku': 'HD-T001', 'name': '小熊', 'style': 'normal', 'flag': '德国', 'qty': 200
+    }, 'test')
+
+    database.insert_in_record({
+        'category': 'plush', 'date': '2026-05-12', 'billNo': 'IN-C',
+        'sku': 'HD-T001', 'name': '小熊', 'style': 'rare', 'flag': '美国', 'qty': 50
+    }, 'test')
+
+    # 三个组合互不影响
+    assert_eq(database.calculate_stock('plush', 'HD-T001', 'normal', '美国'), 100,
+              '普通款+美国 = 100')
+    assert_eq(database.calculate_stock('plush', 'HD-T001', 'normal', '德国'), 200,
+              '普通款+德国 = 200')
+    assert_eq(database.calculate_stock('plush', 'HD-T001', 'rare', '美国'), 50,
+              '稀有款+美国 = 50')
+    assert_eq(database.calculate_stock('plush', 'HD-T001', 'rare', '德国'), 0,
+              '稀有款+德国 = 0(没录过)')
+
+
+# ==================== 测试 3: 品类隔离 ====================
+
+def test_category_isolation():
+    section('测试 3:毛绒和戏服的库存完全隔离')
+    reset_db()
+
+    # 毛绒入库 100
+    database.insert_in_record({
+        'category': 'plush', 'date': '2026-05-12', 'billNo': 'IN-P',
+        'sku': 'HD-T001', 'name': '小熊', 'style': 'normal', 'flag': '美国', 'qty': 100
+    }, 'test')
+
+    # 戏服入库 50,假设货号也叫 HD-T001(虽然实际不太可能,但要验证隔离)
+    # 注意:戏服没有布标字段,flag 始终为空字符串
+    database.insert_in_record({
+        'category': 'costume', 'date': '2026-05-12', 'billNo': 'IN-C',
+        'sku': 'HD-T001', 'name': '小熊裙子', 'style': 'M码连衣裙', 'flag': '', 'qty': 50
+    }, 'test')
+
+    # 同名货号但品类不同,完全独立
+    plush_stock = database.calculate_stock('plush', 'HD-T001', 'normal', '美国')
+    costume_stock = database.calculate_stock('costume', 'HD-T001', 'M码连衣裙', '')
+
+    assert_eq(plush_stock, 100, '毛绒 HD-T001 库存 = 100')
+    assert_eq(costume_stock, 50, '戏服 HD-T001 库存 = 50')
+
+
+# ==================== 测试 4: 删除后库存自动重算 ====================
+
+def test_delete_recalculate():
+    section('测试 4:删除流水后库存自动重算')
+    reset_db()
+
+    # 入库三笔
+    id1 = database.insert_in_record({
+        'category': 'plush', 'date': '2026-05-12', 'billNo': 'IN-1',
+        'sku': 'HD-T001', 'name': '小熊', 'style': 'normal', 'flag': '美国', 'qty': 100
+    }, 'test')
+
+    id2 = database.insert_in_record({
+        'category': 'plush', 'date': '2026-05-12', 'billNo': 'IN-2',
+        'sku': 'HD-T001', 'name': '小熊', 'style': 'normal', 'flag': '美国', 'qty': 200
+    }, 'test')
+
+    id3 = database.insert_in_record({
+        'category': 'plush', 'date': '2026-05-12', 'billNo': 'IN-3',
+        'sku': 'HD-T001', 'name': '小熊', 'style': 'normal', 'flag': '美国', 'qty': 50
+    }, 'test')
+
+    assert_eq(database.calculate_stock('plush', 'HD-T001', 'normal', '美国'), 350,
+              '初始库存 = 100+200+50 = 350')
+
+    # 删除中间那笔(200)
+    database.delete_in_record(id2)
+
+    assert_eq(database.calculate_stock('plush', 'HD-T001', 'normal', '美国'), 150,
+              '删除 200 那笔后,库存 = 100+50 = 150')
+
+
+# ==================== 测试 5: 负库存允许 ====================
+
+def test_negative_stock_allowed():
+    section('测试 5:允许负库存(警告而非禁止)')
+    reset_db()
+
+    # 入库 100
+    database.insert_in_record({
+        'category': 'plush', 'date': '2026-05-12', 'billNo': 'IN',
+        'sku': 'HD-T001', 'name': '小熊', 'style': 'normal', 'flag': '美国', 'qty': 100
+    }, 'test')
+
+    # 出库 150(超出 50)— 在数据库层面应该允许
+    with database.db_cursor() as cur:
+        cur.execute(
+            '''INSERT INTO out_records
+               (category, date, bill_no, sku, name, style, flag, qty, created_by)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)''',
+            ('plush', '2026-05-12', 'OUT', 'HD-T001', '小熊', 'normal', '美国', 150, 'test')
+        )
+
+    stock = database.calculate_stock('plush', 'HD-T001', 'normal', '美国')
+    assert_eq(stock, -50, '允许负库存,库存 = 100-150 = -50')
+
+
+# ==================== 测试 6: 库存汇总聚合正确 ====================
+
+def test_stock_summary():
+    section('测试 6:库存汇总 API 聚合正确')
+    reset_db()
+
+    # 准备数据:毛绒 2 种规格 + 戏服 1 种规格
+    database.insert_in_record({
+        'category': 'plush', 'date': '2026-05-12', 'billNo': 'IN-1',
+        'sku': 'HD-T001', 'name': '小熊', 'style': 'normal', 'flag': '美国', 'qty': 100
+    }, 'test')
+    database.insert_in_record({
+        'category': 'plush', 'date': '2026-05-12', 'billNo': 'IN-2',
+        'sku': 'HD-T002', 'name': '小兔', 'style': 'rare', 'flag': '日本', 'qty': 30
+    }, 'test')
+    database.insert_in_record({
+        'category': 'costume', 'date': '2026-05-12', 'billNo': 'IN-3',
+        'sku': 'CS-001', 'name': '裙子', 'style': 'M码', 'flag': '', 'qty': 50
+    }, 'test')
+
+    # 查全部
+    summary = database.get_stock_summary()
+    assert_eq(len(summary), 3, '总规格数 = 3')
+
+    # 查毛绒
+    plush_summary = database.get_stock_summary(category='plush')
+    assert_eq(len(plush_summary), 2, '毛绒规格数 = 2')
+    assert_eq(sum(s['stock'] for s in plush_summary), 130, '毛绒库存合计 = 130')
+
+    # 查戏服
+    costume_summary = database.get_stock_summary(category='costume')
+    assert_eq(len(costume_summary), 1, '戏服规格数 = 1')
+    assert_eq(costume_summary[0]['stock'], 50, '戏服库存 = 50')
+
+
+# ==================== 测试 7: 戏服款式是自由文本 ====================
+
+def test_costume_free_style():
+    section('测试 7:戏服款式可以是任意中文文本')
+    reset_db()
+
+    # 戏服款式可以是各种自由文本,戏服没有布标(flag 为空字符串)
+    free_styles = ['M码连衣裙', 'L码外套', 'XS码儿童款', '均码-粉色']
+    for i, style in enumerate(free_styles):
+        database.insert_in_record({
+            'category': 'costume', 'date': '2026-05-12', 'billNo': f'IN-{i}',
+            'sku': 'CS-001', 'name': '戏服', 'style': style, 'flag': '', 'qty': 10
+        }, 'test')
+
+    summary = database.get_stock_summary(category='costume')
+    assert_eq(len(summary), 4, '4 种不同款式被独立统计')
+
+    for s in summary:
+        assert_eq(s['stock'], 10, f'款式 "{s["style"]}" 库存 = 10')
+
+
+# ==================== 测试 8: 入库查询按品类筛选 ====================
+
+def test_query_filter_by_category():
+    section('测试 8:查询入库流水按品类筛选')
+    reset_db()
+
+    database.insert_in_record({
+        'category': 'plush', 'date': '2026-05-12', 'billNo': 'IN-P-1',
+        'sku': 'HD-T001', 'name': '小熊', 'style': 'normal', 'flag': '美国', 'qty': 100
+    }, 'test')
+    database.insert_in_record({
+        'category': 'costume', 'date': '2026-05-12', 'billNo': 'IN-C-1',
+        'sku': 'CS-001', 'name': '裙子', 'style': 'M码', 'flag': '', 'qty': 50
+    }, 'test')
+
+    assert_eq(len(database.query_all_in_records()), 2, '全部入库 = 2 条')
+    assert_eq(len(database.query_all_in_records(category='plush')), 1, '毛绒入库 = 1 条')
+    assert_eq(len(database.query_all_in_records(category='costume')), 1, '戏服入库 = 1 条')
+
+
+# ==================== 测试 9: 戏服没有布标字段 ====================
+
+def test_costume_no_flag():
+    section('测试 9:戏服 flag 字段必须为空字符串')
+    reset_db()
+
+    # 戏服入库,不传 flag 字段(后端应该自动设为空)
+    database.insert_in_record({
+        'category': 'costume', 'date': '2026-05-12', 'billNo': 'IN-1',
+        'sku': 'CS-001', 'name': '连衣裙', 'style': 'M码', 'flag': '', 'qty': 100
+    }, 'test')
+
+    records = database.query_all_in_records(category='costume')
+    assert_eq(len(records), 1, '戏服入库成功 1 条')
+    assert_eq(records[0]['flag'], '', '戏服 flag 应为空字符串')
+
+    # 同一货号 + 同一类型,不管录几次都汇总到一起(因为没有 flag 维度)
+    database.insert_in_record({
+        'category': 'costume', 'date': '2026-05-13', 'billNo': 'IN-2',
+        'sku': 'CS-001', 'name': '连衣裙', 'style': 'M码', 'flag': '', 'qty': 50
+    }, 'test')
+
+    summary = database.get_stock_summary(category='costume')
+    assert_eq(len(summary), 1, '戏服只汇总成 1 种规格(同货号+同类型)')
+    assert_eq(summary[0]['stock'], 150, '戏服库存合计 = 150')
+
+
+# ==================== 主测试入口 ====================
+
+def main():
+    print('=' * 60)
+    print('华登库存系统 - 逻辑测试')
+    print(f'测试数据库:{TEST_DB_PATH}')
+    print('=' * 60)
+
+    try:
+        test_basic_in_out()
+        test_three_level_separation()
+        test_category_isolation()
+        test_delete_recalculate()
+        test_negative_stock_allowed()
+        test_stock_summary()
+        test_costume_free_style()
+        test_query_filter_by_category()
+        test_costume_no_flag()
+    except Exception as e:
+        print(f'\n!! 测试运行异常:{e}')
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)
+    finally:
+        # 清理测试数据库
+        shutil.rmtree(TEST_DB_DIR, ignore_errors=True)
+
+    print('\n' + '=' * 60)
+    print(f'测试结果:✓ 通过 {passed} 个 / ✗ 失败 {failed} 个')
+    print('=' * 60)
+
+    if failed == 0:
+        print('✓ 全部测试通过!核心逻辑正确,可以放心使用')
+        sys.exit(0)
+    else:
+        print('✗ 有测试失败,请修复后重新运行')
+        print('\n失败明细:')
+        for err in errors:
+            print(err)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/deploy/update-server.sh
+++ b/deploy/update-server.sh
@@ -238,6 +238,21 @@ for match in re.findall(r'^\s*-\s+\./([^:]+):', content, re.MULTILINE):
             print(f'  [chmod 777] {path} (was {oct(cur)})')
     except OSError as e:
         print(f'  [WARN] chmod {path}: {e}', file=sys.stderr)
+    # 文件级权限：data 目录下的所有文件，确保容器内 appuser (UID 100) 能读写
+    # 之前 huadeng-maorong 初始 db 是 git 跟踪/CI root 拉的，appuser 启动时 CREATE TABLE 直接崩。
+    # 用 OR 加权，不降级。pgsql 等基础设施不在 apps/ 下不会被走到。
+    for root_dir, dirs, files in os.walk(path):
+        for f in files:
+            fp = os.path.join(root_dir, f)
+            try:
+                fst = os.stat(fp)
+                fmode = stat.S_IMODE(fst.st_mode)
+                want = fmode | 0o666
+                if fmode != want:
+                    os.chmod(fp, want)
+                    print(f'  [chmod {oct(want)}] {fp} (was {oct(fmode)})')
+            except OSError as e:
+                print(f'  [WARN] chmod file {fp}: {e}', file=sys.stderr)
 " || true
 
 # ─── Step 5: 备份数据库（只在影响 db 或全量时）───

--- a/docker-compose.cloud.yml
+++ b/docker-compose.cloud.yml
@@ -582,6 +582,32 @@ services:
     networks:
       - platform-net
 
+  huadeng-maorong:
+    build:
+      context: ./apps/PMC跟仓管/华登毛绒仓库
+      dockerfile: Dockerfile
+    environment:
+      - DATA_PATH=/app/data
+      # Secret 强制从 env 注入；admin 默认密码请上线后立即从前台修改
+      - HUADENG_MAORONG_SECRET_KEY=${HUADENG_MAORONG_SECRET_KEY:?HUADENG_MAORONG_SECRET_KEY is required}
+    volumes:
+      - ./apps/PMC跟仓管/华登毛绒仓库/data:/app/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5009/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    mem_limit: 512m
+    memswap_limit: 512m
+    restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    networks:
+      - platform-net
+
 networks:
   platform-net:
     driver: bridge

--- a/nginx/nginx.cloud.conf
+++ b/nginx/nginx.cloud.conf
@@ -805,6 +805,51 @@ http {
             add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         }
 
+        # ─── Standalone: 华登毛绒仓库 (huadeng-maorong) ───
+        # Flask app, 用绝对路径模板；用 sub_filter 把 / 重写成 /huadeng-maorong/
+        location = /huadeng-maorong {
+            return 301 /huadeng-maorong/;
+        }
+        location = /huadeng-maorong/health {
+            auth_basic off;
+            set $ups "huadeng-maorong:5009";
+            proxy_pass http://$ups/health;
+            proxy_set_header Host $host;
+        }
+        location /huadeng-maorong/ {
+            set $ups "huadeng-maorong:5009";
+            rewrite ^/huadeng-maorong/(.*)$ /$1 break;
+            proxy_pass http://$ups;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_set_header Accept-Encoding "";
+            proxy_redirect / /huadeng-maorong/;
+            client_max_body_size 32m;
+            proxy_read_timeout 120s;
+            proxy_send_timeout 120s;
+
+            sub_filter_types text/html application/javascript;
+            sub_filter_once off;
+            sub_filter 'href="/'       'href="/huadeng-maorong/';
+            sub_filter "href='/"       "href='/huadeng-maorong/";
+            sub_filter 'action="/'     'action="/huadeng-maorong/';
+            sub_filter "action='/"     "action='/huadeng-maorong/";
+            sub_filter 'fetch("/'      'fetch("/huadeng-maorong/';
+            sub_filter "fetch('/"      "fetch('/huadeng-maorong/";
+            sub_filter 'src="/static/' 'src="/huadeng-maorong/static/';
+            sub_filter "src='/static/" "src='/huadeng-maorong/static/";
+
+            add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'self';" always;
+            add_header X-Frame-Options "SAMEORIGIN" always;
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header X-XSS-Protection "1; mode=block" always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        }
+
         # ─── Removed apps: return 404 to stop stale health check polling ───
         location /indonesia/ { return 404; }
         location /api/indonesia/ { return 404; }


### PR DESCRIPTION
## Summary

**追认线上现状 + 修复 + 新功能 + 防呆**，一个 PR 收齐。

### 1. 把 huadeng-maorong 纳入 git
线上 ECS 已经跑了几周（`/opt/rr-portal/apps/PMC跟仓管/华登毛绒仓库/`），但 git 仓库一直没有 → 本 PR 追认线上现状，含完整源码 + docker-compose + nginx 配置 + CLAUDE.md 注册。

### 2. 修复 4 个生产 bug
线上版本已经过 hotfix（safe-redeploy），本 PR 把修复版纳入 git：
- **登录后跳错地方**：`login.html` `window.location.href = '/'` → 跳 portal 根。改成带 BASE_URL 前缀
- **数据加载失败**：`api()` helper 用 `fetch(path)` 变量调用，nginx sub_filter 抓不到字面量 → 所有 `/api/...` 请求 404。引入 `BASE_URL` 推断
- **排期导入上传失败 / 登出失败**：同根因
- **字母图片 [?] 占位**：JS 动态 `<img src="${r.image_url}">` 没经过 sub_filter，加 BASE_URL 前缀

### 3. 新功能：子货号别名
排期里出现的子货号（如 `157101-S001-MB`），可在「字母绑定」页通过「+ 关联子货号」按钮挂到父货号（如 `15756`）下，自动复用父货号的字母→物料映射 + 库存。

实现：新表 `sku_aliases`、`_resolve_sku_prefix()` 函数（带缓存 + CUD invalidate）、3 个 CRUD API、字母绑定页 UI 加按钮 + chip。

### 4. 修历史数据
- 30 行 `ratio_rare_text='每款数量的23/24'` （xlsx 录错）SQL 重算成 1/24，rare_qty 已正确（这部分只在线上做了，不进 git）

### 5. deploy 防呆 (`update-server.sh`)
`apps/.../data/` 下所有文件 OR 加 `0o666` 权限。修复初始 git-checked-out 的 db 文件 root:root 644 → 容器内 appuser 启动时 `CREATE TABLE` 直接 readonly crash 的隐患（本次 huadeng-maorong 初始化 sku_aliases 表时翻车，临时手动 chmod 666 救场）。

## Test plan
- [x] Hotfix 后浏览器实测：登录/数据加载/排期上传/登出/字母图片/子货号关联匹配（4500199988-10 → 海绵宝宝 5 角色）全部 OK
- [x] sku_aliases 表 CRUD API 通过 curl 验证
- [ ] 本 PR 触发 GHA 自动 deploy huadeng-maorong（重 build 同样代码 + 容器 recreate），等 GHA 绿 + 浏览器再验证一次
- [ ] deploy script 的文件级 chmod 在 ECS 实际跑出来的 log 里有正确输出（idempotent，不会报错）

🤖 Generated with [Claude Code](https://claude.com/claude-code)