### PR TITLE
fix(production-plan): 三条反馈未解决问题

### DIFF
--- a/apps/生产部/生产计划管理系统/client/src/pages/LuckysheetEditor.jsx
+++ b/apps/生产部/生产计划管理系统/client/src/pages/LuckysheetEditor.jsx
@@ -92,8 +92,9 @@ function ordersToCelldata(orders, columns, newImportedIds) {
           }
           if (serial != null) {
             valueToStore = serial;
-            // 用标准 yyyy-MM-dd 触发日期选择器，m 字段控制显示成 "5月8日"
-            ct = { t: 'd', fa: 'yyyy-MM-dd' };
+            // Excel 自定义日期格式 m"月"d"日" — Luckysheet 按 fa 渲染才显示 "5月8日"，
+            // 不能用 yyyy-MM-dd（会被重写覆盖 m 字段）
+            ct = { t: 'd', fa: 'm"月"d"日"' };
           } else {
             valueToStore = displayVal;
             ct = { t: 'g', fa: 'General' };

--- a/apps/生产部/生产计划管理系统/client/src/pages/SchedulingSheet.jsx
+++ b/apps/生产部/生产计划管理系统/client/src/pages/SchedulingSheet.jsx
@@ -221,6 +221,10 @@ export default function SchedulingSheet({ workshop, tab, lineName = 'all', lines
         if (!order.client && r.clientFromFile) {
           order.client = r.clientFromFile;
         }
+        // 半成品 sheet 上的行强制打上 work_type=半成品，跟同 PO 的成品区分开
+        if (r.sheet && r.sheet.includes('半成品')) {
+          order.work_type = '半成品';
+        }
         return {
           ...order,
           workshop,

--- a/apps/生产部/生产计划管理系统/server/routes/orders.js
+++ b/apps/生产部/生产计划管理系统/server/routes/orders.js
@@ -169,12 +169,12 @@ router.post('/', async (req, res) => {
   // 归一化函数：去空格、转大写
   const norm = (v) => v == null ? '' : String(v).replace(/\s+/g, '').toUpperCase();
 
-  // 一次性加载该车间所有现存订单的 (contract|item_no|work_type) 做指纹
+  // 指纹：合同+货号+做工+走货期。同一 PO 拆多批次（不同走货期）算不同订单不该合并。
   function loadExisting(workshop) {
-    const rows = db.prepare('SELECT contract, item_no, work_type FROM orders WHERE workshop = ?').all(workshop);
+    const rows = db.prepare('SELECT contract, item_no, work_type, ship_date FROM orders WHERE workshop = ?').all(workshop);
     const set = new Set();
     for (const r of rows) {
-      set.add(`${norm(r.contract)}|${norm(r.item_no)}|${norm(r.work_type)}`);
+      set.add(`${norm(r.contract)}|${norm(r.item_no)}|${norm(r.work_type)}|${norm(r.ship_date)}`);
     }
     return set;
   }
@@ -190,7 +190,7 @@ router.post('/', async (req, res) => {
       for (const o of chunk) {
         if (o.workshop && o.contract && o.item_no) {
           if (!cache[o.workshop]) cache[o.workshop] = loadExisting(o.workshop);
-          const fp = `${norm(o.contract)}|${norm(o.item_no)}|${norm(o.work_type)}`;
+          const fp = `${norm(o.contract)}|${norm(o.item_no)}|${norm(o.work_type)}|${norm(o.ship_date)}`;
           if (cache[o.workshop].has(fp)) { skipped++; continue; }
           cache[o.workshop].add(fp);
         }

--- a/apps/生产部/生产计划管理系统/server/services/color-reader.js
+++ b/apps/生产部/生产计划管理系统/server/services/color-reader.js
@@ -299,7 +299,8 @@ async function parseSheetData(sheetXml, styleColorMap, sharedStrings) {
 }
 
 // 不需要读的 sheet 名关键词
-const SKIP_SHEET_KEYWORDS = ['MA', '包装', '包裝', '半成品', '车缝', '布料', '取消', '转', '樣板', '样板', 'Sheet', '_xlnm', 'microsoft'];
+// 半成品 sheet 要读：同一 PO 的半成品 + 成品 是两条独立订单，半成品早一周完成，必须排进生产计划
+const SKIP_SHEET_KEYWORDS = ['MA', '包装', '包裝', '车缝', '布料', '取消', '转', '樣板', '样板', 'Sheet', '_xlnm', 'microsoft'];
 
 function shouldSkipSheet(name) {
   return SKIP_SHEET_KEYWORDS.some(kw => name.includes(kw));


### PR DESCRIPTION
1. 同一PO多订单只导出一个 → dedup 指纹加 ship_date，同 PO 拆多批次不再合并
2. 半成品+成品不能自动分别 → 解除 SKIP_SHEET_KEYWORDS 对"半成品"的过滤； 导入时按 sheet 名给半成品行打 work_type='半成品'，跟成品行区分
3. 日期格式 yyyy-MM-dd → "5月8日"：cell ct.fa 改用 Excel 自定义格式 m"月"d"日" （原 fa='yyyy-MM-dd' 会被 Luckysheet 重新渲染覆盖 m 字段）