### PR TITLE
fix(huadeng-maorong): subpath routing + sku alias feature

### DIFF
--- a/apps/PMC跟仓管/华登毛绒仓库/app.py
+++ b/apps/PMC跟仓管/华登毛绒仓库/app.py
@@ -1039,6 +1039,28 @@ def _extract_sku_prefix(item_code):
     return m.group(1) if m else ''
 
 
+# 货号别名缓存:子货号 → 父货号。CUD 后置空触发重载。
+_alias_cache = None
+
+def _invalidate_alias_cache():
+    global _alias_cache
+    _alias_cache = None
+
+def _resolve_sku_prefix(prefix):
+    """如果 prefix 是别名,返回 primary;否则返回原值。"""
+    global _alias_cache
+    if not prefix:
+        return prefix
+    if _alias_cache is None:
+        _alias_cache = db.get_sku_alias_map()
+    return _alias_cache.get(prefix, prefix)
+
+
+def _match_sku_prefix(item_code):
+    """提取 + 别名解析,业务匹配字母绑定/库存时用这个。"""
+    return _resolve_sku_prefix(_extract_sku_prefix(item_code))
+
+
 def _resolve_inventory_flag(flag_type, country, fallback):
     """
     把排期里的 (布标类型, 国家) 用 flag_mappings 翻译成入库布标
@@ -1071,7 +1093,7 @@ def _enrich_letters_with_binding(item_code, letters, row_flag='', row_flag_type=
     特殊情况:letter['letter'] == '' 表示"无字母款"(如 15789),不查 letter_bindings,
     直接用 letter['_name_cn'] 清洗后的中文当物料名,整 qty 当普通款。
     """
-    sku_prefix = _extract_sku_prefix(item_code)
+    sku_prefix = _match_sku_prefix(item_code)
     # 翻译入库布标
     inventory_flag = _resolve_inventory_flag(row_flag_type, row_country, row_flag)
     out = []
@@ -1146,7 +1168,7 @@ def _build_po_view(po, rows):
             row_flag_type=r.get('flag_type') or '',
             row_country=r.get('country') or '',
         )
-        sku_prefix = _extract_sku_prefix(r['item_code'])
+        sku_prefix = _match_sku_prefix(r['item_code'])
         stock = db.get_sku_total_stock(sku_prefix) if sku_prefix else 0
         # 行级"是否够做":有绑定的字母都 sufficient;无绑定的字母按 total 模式判断
         bound_letters = [l for l in letters if l['bound_name']]
@@ -1309,6 +1331,49 @@ def api_letter_bindings_delete(binding_id):
     affected = db.delete_letter_binding(binding_id)
     if affected == 0:
         return jsonify({'error': '绑定不存在'}), 404
+    return jsonify({'success': True})
+
+
+# ---- 货号别名 (子货号 → 父货号) ----
+
+@app.route('/api/sku-aliases', methods=['GET'])
+@login_required
+def api_sku_aliases_list():
+    return jsonify(db.query_all_sku_aliases())
+
+
+@app.route('/api/sku-aliases', methods=['POST'])
+@role_required('admin', 'operator')
+def api_sku_aliases_create():
+    """新增子货号→父货号映射。body: {alias_prefix, primary_prefix}"""
+    data = request.get_json() or {}
+    alias = (data.get('alias_prefix') or '').strip()
+    primary = (data.get('primary_prefix') or '').strip()
+    if not alias or not primary:
+        return jsonify({'error': '缺少 alias_prefix 或 primary_prefix'}), 400
+    if alias == primary:
+        return jsonify({'error': '子货号不能跟父货号相同'}), 400
+    # 防止链式别名(alias→primary→primary2)
+    existing_map = db.get_sku_alias_map()
+    if primary in existing_map:
+        return jsonify({'error': f'父货号 {primary} 自己已经是子货号(映射到 {existing_map[primary]}),不能再当父货号'}), 400
+    if alias in existing_map:
+        return jsonify({'error': f'子货号 {alias} 已经映射到 {existing_map[alias]},先删除再加'}), 400
+    try:
+        aid = db.insert_sku_alias(alias, primary, session.get('username'))
+    except Exception as e:
+        return jsonify({'error': f'新增失败: {e}'}), 400
+    _invalidate_alias_cache()
+    return jsonify({'success': True, 'id': aid})
+
+
+@app.route('/api/sku-aliases/<int:alias_id>', methods=['DELETE'])
+@role_required('admin', 'operator')
+def api_sku_aliases_delete(alias_id):
+    affected = db.delete_sku_alias(alias_id)
+    if affected == 0:
+        return jsonify({'error': '别名不存在'}), 404
+    _invalidate_alias_cache()
     return jsonify({'success': True})
 
 

--- a/apps/PMC跟仓管/华登毛绒仓库/database.py
+++ b/apps/PMC跟仓管/华登毛绒仓库/database.py
@@ -183,6 +183,18 @@ def init_database():
         ''')
         cur.execute('CREATE INDEX IF NOT EXISTS idx_lb_sku_letter ON letter_bindings(sku, letter)')
 
+        # 货号别名:子货号 → 父货号(自动复用父货号的字母绑定 + 库存)
+        cur.execute('''
+            CREATE TABLE IF NOT EXISTS sku_aliases (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                alias_prefix   TEXT NOT NULL UNIQUE,
+                primary_prefix TEXT NOT NULL,
+                created_by TEXT,
+                created_at TEXT DEFAULT CURRENT_TIMESTAMP
+            )
+        ''')
+        cur.execute('CREATE INDEX IF NOT EXISTS idx_sa_primary ON sku_aliases(primary_prefix)')
+
         # 布标映射:(排期布标, 国家) → 入库实际布标
         cur.execute('''
             CREATE TABLE IF NOT EXISTS flag_mappings (
@@ -704,6 +716,38 @@ def delete_letter_binding(binding_id):
     """删除绑定"""
     with db_cursor() as cur:
         cur.execute('DELETE FROM letter_bindings WHERE id=?', (binding_id,))
+        return cur.rowcount
+
+
+# ==================== 货号别名 ====================
+
+def query_all_sku_aliases():
+    """列出所有 (子货号 → 父货号) 别名"""
+    with db_cursor() as cur:
+        cur.execute('SELECT * FROM sku_aliases ORDER BY primary_prefix, alias_prefix')
+        return [dict(r) for r in cur.fetchall()]
+
+
+def get_sku_alias_map():
+    """返回 {alias_prefix: primary_prefix} 全表字典"""
+    with db_cursor() as cur:
+        cur.execute('SELECT alias_prefix, primary_prefix FROM sku_aliases')
+        return {r['alias_prefix']: r['primary_prefix'] for r in cur.fetchall()}
+
+
+def insert_sku_alias(alias_prefix, primary_prefix, username):
+    """新增别名,UNIQUE(alias_prefix) 冲突会抛 IntegrityError"""
+    with db_cursor() as cur:
+        cur.execute('''
+            INSERT INTO sku_aliases (alias_prefix, primary_prefix, created_by)
+            VALUES (?, ?, ?)
+        ''', (alias_prefix, primary_prefix, username))
+        return cur.lastrowid
+
+
+def delete_sku_alias(alias_id):
+    with db_cursor() as cur:
+        cur.execute('DELETE FROM sku_aliases WHERE id=?', (alias_id,))
         return cur.rowcount
 
 

--- a/apps/PMC跟仓管/华登毛绒仓库/templates/app.html
+++ b/apps/PMC跟仓管/华登毛绒仓库/templates/app.html
@@ -350,6 +350,9 @@ let selectedType = null;
 
 // ==================== API 封装 ====================
 
+// 部署前缀：兼容本地直跑 (5009) 和云端 nginx 反代 /huadeng-maorong/
+const BASE_URL = location.pathname.startsWith('/huadeng-maorong') ? '/huadeng-maorong' : '';
+
 async function api(path, options = {}) {
   const opts = {
     headers: {'Content-Type': 'application/json'},
@@ -359,9 +362,9 @@ async function api(path, options = {}) {
   if (opts.body && typeof opts.body !== 'string') {
     opts.body = JSON.stringify(opts.body);
   }
-  const resp = await fetch(path, opts);
+  const resp = await fetch(BASE_URL + path, opts);
   if (resp.status === 401) {
-    window.location.href = '/login';
+    window.location.href = BASE_URL + '/login';
     throw new Error('未登录');
   }
   const data = await resp.json().catch(() => ({}));
@@ -411,7 +414,7 @@ async function logout() {
   if (!confirm('确定要退出登录吗?')) return;
   try {
     await api('/api/logout', { method: 'POST' });
-    window.location.href = '/login';
+    window.location.href = BASE_URL + '/login';
   } catch (err) {
     alert('登出失败');
   }
@@ -1285,22 +1288,32 @@ async function deleteFlagMap(id) {
 // ==================== 字母绑定(主数据维护) ====================
 
 let bindingsData = null;
+let aliasesData = [];
 
 async function renderBindings() {
   try {
-    bindingsData = await api('/api/letter-bindings');
+    [bindingsData, aliasesData] = await Promise.all([
+      api('/api/letter-bindings'),
+      api('/api/sku-aliases').catch(() => []),
+    ]);
   } catch (err) {
     bindingsData = { bindings: [], materials_by_sku: {} };
+    aliasesData = [];
     alert('加载绑定失败: ' + err.message);
   }
   const { bindings } = bindingsData;
   const canEdit = state.currentUser?.role !== 'viewer';
+  // 按父货号分组别名
+  const aliasesByPrimary = {};
+  aliasesData.forEach(a => {
+    (aliasesByPrimary[a.primary_prefix] = aliasesByPrimary[a.primary_prefix] || []).push(a);
+  });
 
   document.getElementById('page-content').innerHTML = `
     <div class="page-header">
       <div>
         <div class="page-title">字母绑定</div>
-        <div class="page-sub">主数据:填写"货号 + 字母 + 物料名称"。排期对比时按 ITEM# 前面的数字找你这里配置的绑定。</div>
+        <div class="page-sub">主数据:填写"货号 + 字母 + 物料名称"。排期对比时按 ITEM# 前面的数字找你这里配置的绑定。子货号通过"关联"自动复用父货号的物料。</div>
       </div>
       <div>
         ${canEdit ? '<button class="btn btn-in" onclick="openBindModal()">+ 新增绑定</button>' : ''}
@@ -1308,18 +1321,28 @@ async function renderBindings() {
     </div>
 
     <div class="flag-manage">
-      <div style="font-size:13px;color:var(--text-2);margin-bottom:8px;">共 ${bindings.length} 条 · ${(() => { const s = new Set(); bindings.forEach(b => s.add(b.sku)); return s.size; })()} 个货号</div>
+      <div style="font-size:13px;color:var(--text-2);margin-bottom:8px;">共 ${bindings.length} 条 · ${(() => { const s = new Set(); bindings.forEach(b => s.add(b.sku)); return s.size; })()} 个货号 · ${aliasesData.length} 个子货号别名</div>
       ${bindings.length ? (() => {
         const groups = {};
         bindings.forEach(b => { (groups[b.sku] = groups[b.sku] || []).push(b); });
         const skuOrder = Object.keys(groups).sort();
         return skuOrder.map(sku => {
           const rows = groups[sku].slice().sort((a,b) => a.letter.localeCompare(b.letter));
+          const aliases = aliasesByPrimary[sku] || [];
+          const aliasChips = aliases.map(a => `
+            <span style="display:inline-flex;align-items:center;gap:4px;background:#EEF2FF;border:1px solid #C7D2FE;border-radius:4px;padding:2px 8px;font-size:12px;color:#3730A3;margin-right:4px;">
+              <code style="background:transparent;padding:0;color:inherit;">${a.alias_prefix}</code>
+              ${canEdit ? `<span style="cursor:pointer;color:#6366F1;" onclick="deleteAlias(${a.id}, '${escAttr(a.alias_prefix)}', '${escAttr(sku)}')" title="删除别名">×</span>` : ''}
+            </span>
+          `).join('');
           return `
             <div style="margin-bottom:18px;">
-              <div style="display:flex;align-items:center;gap:10px;padding:6px 4px;border-bottom:1px solid var(--border);margin-bottom:6px;">
+              <div style="display:flex;align-items:center;gap:10px;padding:6px 4px;border-bottom:1px solid var(--border);margin-bottom:6px;flex-wrap:wrap;">
                 <code style="font-size:15px;font-weight:600;color:var(--text-1);">${sku}</code>
-                <span style="font-size:12px;color:var(--text-3);">${rows.length} 条</span>
+                <span style="font-size:12px;color:var(--text-3);">${rows.length} 条字母 · ${aliases.length} 个子货号</span>
+                <div style="flex:1;"></div>
+                ${aliasChips}
+                ${canEdit ? `<button class="btn btn-sm" onclick="openAliasModal('${escAttr(sku)}')" title="关联子货号 → 自动复用本父货号的物料">+ 关联子货号</button>` : ''}
               </div>
               <div class="table-wrap"><table>
                 <thead><tr>
@@ -1408,6 +1431,54 @@ async function saveBinding() {
   }
 }
 
+function openAliasModal(primarySku) {
+  document.getElementById('modal-host').innerHTML = `
+    <div class="modal-mask" onclick="if(event.target===this)closeModal()">
+      <div class="modal">
+        <div class="modal-title">关联子货号 → ${primarySku}</div>
+        <div class="modal-sub">子货号(纯数字前缀)会自动复用父货号 <code>${primarySku}</code> 的全部字母→物料映射。一个子货号只能映射到一个父货号。</div>
+        <div class="form-grid">
+          <div class="form-row full">
+            <label class="form-label">子货号前缀<span class="req">*</span></label>
+            <input id="a-alias" placeholder="如: 157101" autofocus>
+            <div style="font-size:11px;color:var(--text-3);margin-top:4px;">举例:排期里出现 <code>157101-S001-MB</code> 这种,父货号是 <code>${primarySku}</code>,这里填 <code>157101</code></div>
+          </div>
+        </div>
+        <div class="form-actions">
+          <button class="btn" onclick="closeModal()">取消</button>
+          <button class="btn btn-primary" onclick="saveAlias('${escAttr(primarySku)}')">保存</button>
+        </div>
+      </div>
+    </div>
+  `;
+  setTimeout(() => document.getElementById('a-alias').focus(), 50);
+}
+
+async function saveAlias(primarySku) {
+  const alias = document.getElementById('a-alias').value.trim();
+  if (!alias || !/^\d+$/.test(alias)) { alert('子货号必须是纯数字'); return; }
+  try {
+    await api('/api/sku-aliases', {
+      method: 'POST',
+      body: { alias_prefix: alias, primary_prefix: primarySku }
+    });
+    closeModal();
+    await renderBindings();
+  } catch (err) {
+    alert('保存失败: ' + err.message);
+  }
+}
+
+async function deleteAlias(id, alias, primary) {
+  if (!confirm(`解除子货号 ${alias} → 父货号 ${primary} 的关联?\n解除后,排期里的 ${alias} 将不再自动匹配 ${primary} 的物料。`)) return;
+  try {
+    await api(`/api/sku-aliases/${id}`, { method: 'DELETE' });
+    await renderBindings();
+  } catch (err) {
+    alert('删除失败: ' + err.message);
+  }
+}
+
 async function deleteBinding(id, sku, letter) {
   if (!confirm(`删除货号 ${sku} 字母 ${letter} 的绑定?`)) return;
   try {
@@ -1488,7 +1559,7 @@ async function uploadSchedule(input) {
   const fd = new FormData();
   fd.append('file', file);
   try {
-    const resp = await fetch('/api/schedule/upload', { method: 'POST', body: fd, credentials: 'same-origin' });
+    const resp = await fetch(BASE_URL + '/api/schedule/upload', { method: 'POST', body: fd, credentials: 'same-origin' });
     const data = await resp.json();
     if (!resp.ok) { alert('上传失败: ' + (data.error || resp.status)); input.value = ''; return; }
     const s = data.stats;
@@ -1516,7 +1587,7 @@ async function querySchedule() {
 function letterChip(l) {
   // 单 letter chip 渲染:[图][字母·数量][绑定状态/库存差]
   if (!l.letter) return `<span style="color:var(--text-3);">${(l.qty||0).toLocaleString()}</span>`;
-  const img = l.image_url ? `<img src="${l.image_url}" style="width:28px;height:28px;object-fit:cover;border-radius:4px;vertical-align:middle;margin-right:4px;" alt="${l.letter}">` : '';
+  const img = l.image_url ? `<img src="${BASE_URL}${l.image_url}" style="width:28px;height:28px;object-fit:cover;border-radius:4px;vertical-align:middle;margin-right:4px;" alt="${l.letter}">` : '';
   let status = '';
   if (l.bound_name) {
     if (l.letter_sufficient) {
@@ -1621,7 +1692,7 @@ function renderScheduleResult() {
             </tr></thead>
             <tbody>
               ${rows.map(r => {
-                const img = r.image_url ? `<img src="${r.image_url}" style="width:24px;height:24px;object-fit:cover;border-radius:3px;vertical-align:middle;margin-right:4px;">` : '';
+                const img = r.image_url ? `<img src="${BASE_URL}${r.image_url}" style="width:24px;height:24px;object-fit:cover;border-radius:3px;vertical-align:middle;margin-right:4px;">` : '';
                 const stockTd = r.stock != null
                   ? `<td class="num" style="color:${r.sufficient?'var(--in)':'var(--out)'};font-weight:500;">${r.stock.toLocaleString()}</td>`
                   : `<td class="num" style="color:var(--text-3);">—</td>`;
@@ -1708,7 +1779,7 @@ function renderScheduleResult() {
             </tr></thead>
             <tbody>
               ${rows.map(r => {
-                const img = r.image_url ? `<img src="${r.image_url}" style="width:24px;height:24px;object-fit:cover;border-radius:3px;vertical-align:middle;margin-right:4px;">` : '';
+                const img = r.image_url ? `<img src="${BASE_URL}${r.image_url}" style="width:24px;height:24px;object-fit:cover;border-radius:3px;vertical-align:middle;margin-right:4px;">` : '';
                 const stockTd = r.stock != null
                   ? `<td class="num" style="color:${r.sufficient?'var(--in)':'var(--out)'};font-weight:500;">${r.stock.toLocaleString()}</td>`
                   : `<td class="num" style="color:var(--text-3);">—</td>`;
@@ -2269,7 +2340,7 @@ function openEdit(type, id) {
 
 function exportSku(sku) {
   // 调后端生成多 sheet xlsx(入库 / 出库),矩阵布局:列 = (款式, 布标)
-  window.location.href = '/api/export/sku/' + encodeURIComponent(sku);
+  window.location.href = BASE_URL + '/api/export/sku/' + encodeURIComponent(sku);
 }
 
 function exportAll() {

--- a/apps/PMC跟仓管/华登毛绒仓库/templates/login.html
+++ b/apps/PMC跟仓管/华登毛绒仓库/templates/login.html
@@ -90,6 +90,9 @@
   </div>
 
 <script>
+// 部署前缀：兼容本地直跑 (5009) 和云端 nginx 反代 /huadeng-maorong/
+const BASE_URL = location.pathname.startsWith('/huadeng-maorong') ? '/huadeng-maorong' : '';
+
 const form = document.getElementById('login-form');
 const errorEl = document.getElementById('error');
 const submitBtn = document.getElementById('submit-btn');
@@ -101,7 +104,7 @@ form.addEventListener('submit', async (e) => {
   submitBtn.textContent = '登录中...';
 
   try {
-    const resp = await fetch('/api/login', {
+    const resp = await fetch(BASE_URL + '/api/login', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({
@@ -111,7 +114,7 @@ form.addEventListener('submit', async (e) => {
     });
     const data = await resp.json();
     if (resp.ok && data.success) {
-      window.location.href = '/';
+      window.location.href = BASE_URL + '/';
     } else {
       errorEl.textContent = data.error || '登录失败';
       errorEl.classList.add('show');


### PR DESCRIPTION
## Summary

修 2 类问题 + 沉淀 hotfix 到 git。**App 已在 ECS 上 safe-redeploy 验证全部 OK**，本 PR 只是把代码追认进 git。

### 1. Subpath 路由 bug（4 个症状同根因）
App 跑在 nginx 反代 `/huadeng-maorong/` 下，前端硬编码 `/api/...` 走 nginx `sub_filter` 改写。但 sub_filter 只能改**字面量** `fetch("/...)`,抓不到变量调用 `fetch(path, opts)`。导致：

- 登录后跳到 portal 根（不是 `/huadeng-maorong/`）
- 所有 API 404 → 弹「数据加载失败」
- 字母图片显示 `[?]` 占位
- 登出失败

**修法**：`templates/{app,login}.html` 顶部加：

```js
const BASE_URL = location.pathname.startsWith('/huadeng-maorong') ? '/huadeng-maorong' : '';
```

所有 `fetch()` / `window.location.href` / `<img src>` 加前缀。本地直跑 (5009) 仍工作（BASE_URL 为空）。

### 2. 新增「子货号别名」功能
排期里出现的子货号（如 `157101-S001-MB`），可在「字母绑定」页通过「+ 关联子货号」按钮挂到父货号（如 `15756`）下，自动复用父货号的字母→物料映射 + 库存。

- `database.py`: 新表 `sku_aliases(alias_prefix UNIQUE, primary_prefix)`，4 个 CRUD 函数
- `app.py`: `_resolve_sku_prefix()` 带缓存 + `_invalidate_alias_cache`；3 个新 API (`GET/POST/DELETE /api/sku-aliases`)，防自环 + 防链式；`_enrich_letters_with_binding` 和 `_build_po_view` 改用 `_match_sku_prefix`（字母绑定查询 + 库存查询都自动走别名）
- `templates/app.html`: 字母绑定页 group header 加「+ 关联子货号」按钮 + 已关联子货号 chip 列表

## Verified live
- ✅ ECS safe-redeploy 跑过这版代码，浏览器实测全部 4 症状 + 子货号关联（`157101 → 15756`，4500199988-10 排期里字母 A/B/D/E/G 全部出现海绵宝宝系列 5 角色物料名）
- ✅ Python AST 语法检查
- ✅ Stale-base 检查：本分支 fork 自当前 main HEAD (`401ad46`)，无 regression
- ✅ Closed prior PR #135（base 太旧、误「新增」整目录）

## Out of scope
- `deploy/update-server.sh` 文件级 chmod 防呆 — 已在 main（PR #136 squash 时带上来了）
- CLAUDE.md / docker-compose / nginx 注册 — 已在 main（PR #133）
- 30 行 ratio_rare_text='每款数量的23/24' 数据修正 — 已在 ECS 上手动 SQL 修过，不进 git
- `apps/PMC跟仓管/配色库存管理/app/routes/transactions.py` 一个未提交本地改动 — 跟本 PR 无关，没 staged

## Test plan
- [ ] PR merge 触发 GHA → diff-based deploy 只重 build `huadeng-maorong`
- [ ] 部署后浏览器实测：登录 / 排期对比 4500199988-10 显示海绵宝宝 / 字母绑定页「+ 关联子货号」按钮可用
- [ ] 容器 healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)