### PR TITLE
feat(paiji): 排单延续接最新一份，删除 [结转] 标签

### DIFF
--- a/apps/生产部/注塑啤机排产系统/client/src/index.css
+++ b/apps/生产部/注塑啤机排产系统/client/src/index.css
@@ -1,14 +1,6 @@
 * { box-sizing: border-box; }
 body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
 
-/* 结转行高亮 */
-.carry-over-row td {
-  background-color: #fff7e6 !important;
-}
-.carry-over-row:hover td {
-  background-color: #ffe7ba !important;
-}
-
 /* 白班行（夜班视图中显示白班排单，标橙） */
 .day-shift-row td {
   background-color: #fff3e0 !important;

--- a/apps/生产部/注塑啤机排产系统/client/src/pages/ScheduleResult.jsx
+++ b/apps/生产部/注塑啤机排产系统/client/src/pages/ScheduleResult.jsx
@@ -229,7 +229,7 @@ export default function ScheduleResult({ workshop = 'B' }) {
         {s === 'draft' ? '草稿' : s === 'confirmed' ? '已保存' : s}
       </Tag>
     },
-    { title: '结转说明', dataIndex: 'notes', ellipsis: true,
+    { title: '说明', dataIndex: 'notes', ellipsis: true,
       render: v => v ? <span style={{ color: '#d46b08', fontSize: 12 }}>{v}</span> : ''
     },
     { title: '操作', width: 320,

--- a/apps/生产部/注塑啤机排产系统/client/src/pages/Scheduling.jsx
+++ b/apps/生产部/注塑啤机排产系统/client/src/pages/Scheduling.jsx
@@ -52,7 +52,7 @@ export default function Scheduling({ onDone, workshop = 'B' }) {
       });
       message.success(
         `排机完成！新订单 ${data.itemCount || 0} 条` +
-        (data.carryOverCount > 0 ? `，结转上班次 ${data.carryOverCount} 条` : '')
+        (data.carryOverCount > 0 ? `，延续未完成 ${data.carryOverCount} 条` : '')
       );
       if (onDone) onDone();
     } catch (e) {
@@ -150,7 +150,7 @@ export default function Scheduling({ onDone, workshop = 'B' }) {
               </Radio.Group>
             </div>
 
-            {/* 结转预览 */}
+            {/* 延续上次排单预览 */}
             {carryOverInfo && carryOverInfo.carryOverCount > 0 && (
               <Alert
                 type="warning"
@@ -158,9 +158,9 @@ export default function Scheduling({ onDone, workshop = 'B' }) {
                 showIcon
                 message={
                   <span>
-                    检测到上班次（{carryOverInfo.prevDate} {carryOverInfo.prevShift}）有
+                    最近一份排单（{carryOverInfo.prevDate} {carryOverInfo.prevShift}）有
                     <strong style={{ color: '#d46b08' }}> {carryOverInfo.carryOverCount} </strong>
-                    条订单将自动结转到本班次，排机时会优先延续这些机台的生产
+                    条未完成订单将延续到本班次，排机时会优先延续这些机台的生产
                   </span>
                 }
                 description={
@@ -177,7 +177,7 @@ export default function Scheduling({ onDone, workshop = 'B' }) {
             )}
 
             {carryOverInfo && carryOverInfo.carryOverCount === 0 && (
-              <Alert type="info" showIcon message="无上班次结转记录，将全部安排新订单" />
+              <Alert type="info" showIcon message="无未完成的延续订单，将全部安排新订单" />
             )}
 
             <div>
@@ -198,7 +198,7 @@ export default function Scheduling({ onDone, workshop = 'B' }) {
               <p>日期：<strong>{date.format('YYYY-MM-DD')}</strong>，班次：<strong>{shift}</strong></p>
               <p>新订单：<strong>{selectedIds.length}</strong> 条</p>
               {carryOverInfo && carryOverInfo.carryOverCount > 0 && (
-                <p>结转上班次：<strong style={{ color: '#d46b08' }}>{carryOverInfo.carryOverCount}</strong> 条</p>
+                <p>延续未完成：<strong style={{ color: '#d46b08' }}>{carryOverInfo.carryOverCount}</strong> 条</p>
               )}
             </div>
             <Space>

--- a/apps/生产部/注塑啤机排产系统/server/routes/scheduling.js
+++ b/apps/生产部/注塑啤机排产系统/server/routes/scheduling.js
@@ -9,45 +9,49 @@ router.get('/', (req, res) => {
   res.json(schedules);
 });
 
-// 查询上一班次结转情况（预览用）— 必须在 /:id 之前
+// 查询最近一份排机单的延续项（预览用）— 必须在 /:id 之前
+// 不再要求严格"上一班次"，而是取最新一份（白班=1, 夜班=2 排序）
 router.get('/carry-over', (req, res) => {
   try {
     const { date, shift } = req.query;
     if (!date || !shift) return res.json({ carryOverCount: 0, items: [] });
 
-    let prevDate = date;
-    let prevShift;
-    if (shift === '夜班') {
-      prevShift = '白班';
-    } else {
-      const d = new Date(date);
-      d.setDate(d.getDate() - 1);
-      prevDate = d.toISOString().slice(0, 10);
-      prevShift = '夜班';
-    }
-
     const workshop = req.query.workshop || 'B';
-    const prevSchedule = db.prepare(
-      'SELECT * FROM schedules WHERE schedule_date = ? AND shift = ? AND workshop = ? ORDER BY id DESC LIMIT 1'
-    ).get(prevDate, prevShift, workshop);
+    const curOrder = shift === '夜班' ? 2 : 1;
+
+    const prevSchedule = db.prepare(`
+      SELECT * FROM schedules
+      WHERE workshop = ?
+        AND (
+          schedule_date < ?
+          OR (schedule_date = ? AND CASE shift WHEN '白班' THEN 1 ELSE 2 END < ?)
+        )
+      ORDER BY schedule_date DESC,
+               CASE shift WHEN '白班' THEN 1 ELSE 2 END DESC,
+               id DESC
+      LIMIT 1
+    `).get(workshop, date, date, curOrder);
 
     if (!prevSchedule) {
-      return res.json({ carryOverCount: 0, items: [], prevDate, prevShift });
+      return res.json({ carryOverCount: 0, items: [], prevDate: null, prevShift: null });
     }
 
     const items = db.prepare(
       'SELECT * FROM schedule_items WHERE schedule_id = ? ORDER BY sort_order, id'
     ).all(prevSchedule.id);
 
+    // 仅统计欠数 > 0 的延续项（与 schedulingEngine 行为一致）
+    const pendingItems = items.filter(it => (it.shortage || 0) > 0);
+
     res.json({
-      carryOverCount: items.length,
-      items,
-      prevDate,
-      prevShift,
+      carryOverCount: pendingItems.length,
+      items: pendingItems,
+      prevDate: prevSchedule.schedule_date,
+      prevShift: prevSchedule.shift,
       prevScheduleId: prevSchedule.id,
     });
   } catch (err) {
-    console.error('查询结转失败:', err);
+    console.error('查询延续项失败:', err);
     res.status(500).json({ message: err.message });
   }
 });

--- a/apps/生产部/注塑啤机排产系统/server/services/schedulingEngine.js
+++ b/apps/生产部/注塑啤机排产系统/server/services/schedulingEngine.js
@@ -46,28 +46,25 @@ function tonnageShotWeightRange(tonnage) {
 }
 
 /**
- * 获取上一班次
- * 夜班 → 同日白班
- * 白班 → 前一天夜班
+ * 获取最近一份排机单（不限制是严格的"上一班次"，因为不是每天都排）
+ * 排序：先按日期倒序，同日再按班次倒序（白班=1, 夜班=2）
  */
 function getPreviousShiftSchedule(date, shift, workshop) {
-  let prevDate = date;
-  let prevShift;
-  if (shift === '夜班') {
-    prevShift = '白班';
-    // 同日白班
-  } else {
-    // 白班 → 前一天夜班
-    const d = new Date(date);
-    d.setDate(d.getDate() - 1);
-    prevDate = d.toISOString().slice(0, 10);
-    prevShift = '夜班';
-  }
-
   const ws = workshop || 'B';
-  const schedule = db.prepare(
-    'SELECT * FROM schedules WHERE schedule_date = ? AND shift = ? AND workshop = ? ORDER BY id DESC LIMIT 1'
-  ).get(prevDate, prevShift, ws);
+  const curOrder = shift === '夜班' ? 2 : 1;
+
+  const schedule = db.prepare(`
+    SELECT * FROM schedules
+    WHERE workshop = ?
+      AND (
+        schedule_date < ?
+        OR (schedule_date = ? AND CASE shift WHEN '白班' THEN 1 ELSE 2 END < ?)
+      )
+    ORDER BY schedule_date DESC,
+             CASE shift WHEN '白班' THEN 1 ELSE 2 END DESC,
+             id DESC
+    LIMIT 1
+  `).get(ws, date, date, curOrder);
 
   if (!schedule) return null;
 
@@ -457,7 +454,7 @@ function generateSchedule({ orderIds, date, shift, workshop }) {
   const updateOrderStatus = db.prepare(`UPDATE orders SET status = 'scheduled' WHERE id = ?`);
 
   const carryOverNote = carryOverItems.length > 0
-    ? `结转自${prevShiftData.schedule.schedule_date} ${prevShiftData.schedule.shift}，共${carryOverItems.length}条`
+    ? `延续自${prevShiftData.schedule.schedule_date} ${prevShiftData.schedule.shift}，共${carryOverItems.length}条`
     : null;
 
   const result = db.transaction(() => {
@@ -501,7 +498,7 @@ function generateSchedule({ orderIds, date, shift, workshop }) {
         item.accumulated || 0, item.quantity_needed || 0, shortage,
         item.order_no || '', item.target_24h || 0, item.target_11h || 0,
         item.days_needed || 0, item.packing_qty || 0,
-        `[结转]${(item.notes || '').replace(/^\[结转\]+/, '')}`, sortOrder++,
+        (item.notes || '').replace(/^\[结转\]+/, ''), sortOrder++,
         item.order_id || null, 1, machineArmMap[item.machine_no] || item.robot_arm || '',
         item.serial_no || ''
       );


### PR DESCRIPTION
- 「上一班次」逻辑改为「最新一份排机单」： 原本严格找同日白班/前一天夜班，若中间几天没排就找不到延续来源。 现按 (schedule_date, shift) 倒序取最近一份，跨日也能延续未完成订单。
- 删除 schedule_items.notes 的 [结转] 红字前缀，业务备注保留
- schedule.notes 文案：「结转自…」→「延续自…」
- 前端 Alert / 列名 / 提示文案改为「最近一份排单 / 延续未完成」
- 清理未使用的 .carry-over-row CSS

影响：getPreviousShiftSchedule 与 /carry-over 接口实现同步重写， 对外接口字段名（carryOverCount/items/prevDate/prevShift）保持兼容。