### PR TITLE
fix(nginx): production-plan/api/ body 50m→100m + timeout 300s→600s

### DIFF
--- a/nginx/nginx.cloud.conf
+++ b/nginx/nginx.cloud.conf
@@ -459,9 +459,9 @@ http {
             proxy_set_header Connection "";
             proxy_no_cache 1;
             proxy_cache_bypass 1;
-            client_max_body_size 50m;
-            proxy_read_timeout 300s;
-            proxy_send_timeout 300s;
+            client_max_body_size 100m;
+            proxy_read_timeout 600s;
+            proxy_send_timeout 600s;
         }
         location /production-plan/ {
             set $ups "production-plan:8080";


### PR DESCRIPTION
## Summary

补 PR #118 漏网的最后一项。当时 #118 把 6 项 production-plan 修复打包成一个 PR：

- ✅ CSP `font-src/style-src` 加 at.alicdn.com → 通过 #115
- ✅ CSP `img-src` 加 cdn.jsdelivr.net + at.alicdn.com → 通过 #117/#119
- ✅ `--max-old-space-size=2048` → Dockerfile line 39
- ✅ Parser 6x speedup (22s → 3.5s) → 通过 #120
- ✅ autoheal 优化 + worker-src CSP → 通过 #112/#117
- ❌ **nginx /production-plan/api/ body 50m→100m + timeout 300s→600s** ← 本 PR

回顾 close 但没 merge 的 PR 时发现这项漏网。

## What changed

```diff
location /production-plan/api/ {
    ...
-   client_max_body_size 50m;
-   proxy_read_timeout 300s;
-   proxy_send_timeout 300s;
+   client_max_body_size 100m;
+   proxy_read_timeout 600s;
+   proxy_send_timeout 600s;
}
```

只动 `/production-plan/api/` location 这 3 行。其他 production-plan / api_limit / 其他 location 完全不变。

## Why now

- 用户上传 >50MB Excel 时会被 nginx 拒（即使 parser 现在 6x 更快也救不了）
- 防御性补足：万一异常文件 300s 不够时撑得住

## Test plan
- [x] 本地 diff 干净（3 加 3 减）
- [ ] GHA deploy 后 nginx reload 成功（diff-based deploy 不会触发 force-recreate）
- [ ] curl 验证 production-plan API 仍正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)