### PR TITLE
feat(paiji): 模具→机台映射 + 拖拽排序 + 其他/吹气机台补齐

### DIFF
--- a/apps/生产部/注塑啤机排产系统/client/package-lock.json
+++ b/apps/生产部/注塑啤机排产系统/client/package-lock.json
@@ -9,6 +9,9 @@
       "version": "0.0.0",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^8.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "antd": "^6.3.1",
         "axios": "^1.13.6",
         "dayjs": "^1.11.19",
@@ -402,6 +405,59 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-8.0.0.tgz",
+      "integrity": "sha512-U3jk5ebVXe1Lr7c2wU7SBZjcWdQP+j7peHJfCspnA81enlu88Mgd7CC8Q+pub9ubP7eKVETzJW+IBAhsqbSu/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.1.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emotion/hash": {
@@ -2910,6 +2966,12 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",

--- a/apps/生产部/注塑啤机排产系统/client/package.json
+++ b/apps/生产部/注塑啤机排产系统/client/package.json
@@ -10,6 +10,9 @@
   },
   "dependencies": {
     "@ant-design/icons": "^6.1.0",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^8.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "antd": "^6.3.1",
     "axios": "^1.13.6",
     "dayjs": "^1.11.19",

--- a/apps/生产部/注塑啤机排产系统/client/src/pages/ScheduleResult.jsx
+++ b/apps/生产部/注塑啤机排产系统/client/src/pages/ScheduleResult.jsx
@@ -1,13 +1,43 @@
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { Table, Button, Card, Space, Tag, message, Popconfirm, Input, InputNumber, Switch, Select, Modal } from 'antd';
-import { DownloadOutlined, DeleteOutlined, CheckCircleOutlined, SaveOutlined, EditOutlined, CopyOutlined, SwapOutlined } from '@ant-design/icons';
+import { DownloadOutlined, DeleteOutlined, CheckCircleOutlined, SaveOutlined, EditOutlined, CopyOutlined, SwapOutlined, HolderOutlined } from '@ant-design/icons';
 import axios from 'axios';
+import { DndContext, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
+import { SortableContext, useSortable, verticalListSortingStrategy, arrayMove } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 
 const API = '/api/scheduling';
 const EXPORT_API = '/api/export';
 
 // 从机台名提取数字用于排序（支持 C-1#、A-12# 等格式）
 const getMachineNum = (mno) => { const m = String(mno).match(/(\d+)/); return m ? parseInt(m[1]) : 99; };
+
+// 拖拽行 —— 整行接收 sortable，但只有手柄列触发拖拽（其它列保留原有点击）
+function DraggableRow({ children, ...props }) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: props['data-row-key'] });
+  const style = {
+    ...props.style,
+    transform: CSS.Transform.toString(transform && { ...transform, scaleY: 1 }),
+    transition,
+    ...(isDragging ? { position: 'relative', zIndex: 9999, background: '#fafafa' } : {}),
+  };
+  return (
+    <tr {...props} ref={setNodeRef} style={style} {...attributes}>
+      {React.Children.map(children, child => {
+        if (child && child.key === 'sort') {
+          return React.cloneElement(child, {
+            children: (
+              <span {...listeners} style={{ cursor: 'grab', color: '#999', display: 'inline-flex', padding: '4px' }}>
+                <HolderOutlined />
+              </span>
+            ),
+          });
+        }
+        return child;
+      })}
+    </tr>
+  );
+}
 
 export default function ScheduleResult({ workshop = 'B' }) {
   const [schedules, setSchedules] = useState([]);
@@ -219,6 +249,41 @@ export default function ScheduleResult({ workshop = 'B' }) {
 
   useEffect(() => { fetchSchedules(); fetchMachines(); }, [workshop]);
 
+  // 拖拽传感器（轻拖才生效，避免点击编辑误触）
+  const dndSensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
+
+  // 表格数据：sort_order 优先，未拖过的按机台号 fallback
+  const tableDataSource = useMemo(() => {
+    let data = showCompleted ? items : items.filter(r => r.shortage > 0);
+    if (showDayShift && dayShiftItems.length > 0) {
+      const dayItems = showCompleted ? dayShiftItems : dayShiftItems.filter(r => r.shortage > 0);
+      data = [...dayItems, ...data];
+    }
+    data.sort((a, b) => {
+      const so = (a.sort_order ?? 0) - (b.sort_order ?? 0);
+      if (so !== 0) return so;
+      return getMachineNum(a.machine_no) - getMachineNum(b.machine_no);
+    });
+    return data;
+  }, [items, dayShiftItems, showCompleted, showDayShift]);
+
+  // 拖完一行的处理：仅对当前 items 生效（day-shift 行不可拖）
+  const handleDragEnd = async ({ active, over }) => {
+    if (!over || active.id === over.id || !selectedSchedule) return;
+    const oldIdx = items.findIndex(it => it.id === active.id);
+    const newIdx = items.findIndex(it => it.id === over.id);
+    if (oldIdx === -1 || newIdx === -1) return;
+    const reordered = arrayMove(items, oldIdx, newIdx).map((it, i) => ({ ...it, sort_order: i }));
+    setItems(reordered);
+    try {
+      await axios.post(`${API}/${selectedSchedule.id}/items/reorder`, {
+        items: reordered.map(it => ({ id: it.id, sort_order: it.sort_order })),
+      });
+    } catch (e) {
+      message.error('保存顺序失败：' + (e.response?.data?.message || e.message));
+    }
+  };
+
   const scheduleColumns = [
     { title: '日期', dataIndex: 'schedule_date', width: 110 },
     { title: '班次', dataIndex: 'shift', width: 80,
@@ -249,6 +314,7 @@ export default function ScheduleResult({ workshop = 'B' }) {
   const isConfirmed = selectedSchedule?.status === 'confirmed';
 
   const itemColumns = [
+    { key: 'sort', title: '', width: 32, fixed: 'left', render: () => null },
     { title: '机台', dataIndex: 'machine_no', width: 90, fixed: 'left',
       render: (v, record) => {
         if (record._isDayShift || isConfirmed) return <strong>{v}</strong>;
@@ -474,24 +540,20 @@ export default function ScheduleResult({ workshop = 'B' }) {
           size="small"
           extra={null}
         >
-          <Table
-            columns={itemColumns}
-            dataSource={(() => {
-              let data = showCompleted ? items : items.filter(r => r.shortage > 0);
-              if (showDayShift && dayShiftItems.length > 0) {
-                const dayItems = showCompleted ? dayShiftItems : dayShiftItems.filter(r => r.shortage > 0);
-                data = [...dayItems, ...data];
-              }
-              // 按机台号排序（支持 C-1#、A-12# 等格式）
-              data.sort((a, b) => getMachineNum(a.machine_no) - getMachineNum(b.machine_no));
-              return data;
-            })()}
-            rowKey={r => r._isDayShift ? `day_${r.id}` : r.id}
-            size="small"
-            pagination={false}
-            scroll={{ x: 2000 }}
-            rowClassName={record => record._isDayShift ? 'day-shift-row' : ''}
-          />
+          <DndContext sensors={dndSensors} onDragEnd={handleDragEnd}>
+            <SortableContext items={items.map(i => i.id)} strategy={verticalListSortingStrategy}>
+              <Table
+                components={{ body: { row: DraggableRow } }}
+                columns={itemColumns}
+                dataSource={tableDataSource}
+                rowKey={r => r._isDayShift ? `day_${r.id}` : r.id}
+                size="small"
+                pagination={false}
+                scroll={{ x: 2000 }}
+                rowClassName={record => record._isDayShift ? 'day-shift-row' : ''}
+              />
+            </SortableContext>
+          </DndContext>
         </Card>
       )}
 

--- a/apps/生产部/注塑啤机排产系统/server/db/init.js
+++ b/apps/生产部/注塑啤机排产系统/server/db/init.js
@@ -213,6 +213,19 @@ function initDatabase() {
     )
   `);
 
+  // ========== 模具→机台映射表（人工改一次永久生效） ==========
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS mold_machine_map (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      mold_code TEXT NOT NULL,
+      workshop TEXT NOT NULL DEFAULT 'B',
+      machine_no TEXT NOT NULL,
+      mold_name TEXT,
+      updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      UNIQUE (mold_code, workshop)
+    )
+  `);
+
   // Migrations
   try { db.prepare("ALTER TABLE orders ADD COLUMN order_notes TEXT DEFAULT ''").run(); } catch(e){}
   try { db.prepare("ALTER TABLE schedule_items ADD COLUMN is_carry_over INTEGER DEFAULT 0").run(); } catch(e){}
@@ -225,6 +238,34 @@ function initDatabase() {
   try { db.prepare("ALTER TABLE mold_targets ADD COLUMN workshop TEXT DEFAULT 'B'").run(); } catch(e){}
   try { db.prepare("ALTER TABLE orders ADD COLUMN serial_no TEXT DEFAULT ''").run(); } catch(e){}
   try { db.prepare("ALTER TABLE schedule_items ADD COLUMN serial_no TEXT DEFAULT ''").run(); } catch(e){}
+
+  // 幂等迁移：确保三个车间都有「其他机台」（用于收纳无明确机台的订单）
+  try {
+    const ensureOtherMachine = db.prepare(`
+      INSERT INTO machines (machine_no, brand, tonnage, arm_type, model_desc, status, workshop)
+      SELECT '其他机台', '-', 0, '-', NULL, 'active', ?
+      WHERE NOT EXISTS (
+        SELECT 1 FROM machines WHERE machine_no = '其他机台' AND workshop = ?
+      )
+    `);
+    for (const ws of ['A', 'B', 'C']) {
+      ensureOtherMachine.run(ws, ws);
+    }
+  } catch(e) { console.log('[其他机台迁移失败]', e.message); }
+
+  // 幂等迁移：确保三个车间都有「吹气机台」（用于收纳吹气类订单）
+  try {
+    const ensureBlowMachine = db.prepare(`
+      INSERT INTO machines (machine_no, brand, tonnage, arm_type, model_desc, status, workshop)
+      SELECT '吹气机台', '-', 0, '-', NULL, 'active', ?
+      WHERE NOT EXISTS (
+        SELECT 1 FROM machines WHERE machine_no = '吹气机台' AND workshop = ?
+      )
+    `);
+    for (const ws of ['A', 'B', 'C']) {
+      ensureBlowMachine.run(ws, ws);
+    }
+  } catch(e) { console.log('[吹气机台迁移失败]', e.message); }
 
   console.log('数据库初始化完成，28台机数据已预置');
 

--- a/apps/生产部/注塑啤机排产系统/server/routes/scheduling.js
+++ b/apps/生产部/注塑啤机排产系统/server/routes/scheduling.js
@@ -162,6 +162,30 @@ router.put('/:id/items/:itemId', (req, res) => {
     }
   }
 
+  // 机台更新时自动学习「模具→机台」映射（人工改一次，下次智能排机自动用）
+  if (req.body.machine_no !== undefined) {
+    try {
+      const currentItem = db.prepare('SELECT * FROM schedule_items WHERE id = ?').get(itemId);
+      if (currentItem && currentItem.mold_name) {
+        const moldCode = currentItem.mold_name.split(' ')[0].replace(/[一-龥].*$/, '').trim();
+        if (moldCode) {
+          const sched = db.prepare('SELECT workshop FROM schedules WHERE id = ?').get(currentItem.schedule_id);
+          const ws = sched?.workshop || 'B';
+          const exists = db.prepare("SELECT id FROM mold_machine_map WHERE mold_code = ? AND workshop = ?").get(moldCode, ws);
+          if (exists) {
+            db.prepare("UPDATE mold_machine_map SET machine_no=?, mold_name=?, updated_at=CURRENT_TIMESTAMP WHERE id=?")
+              .run(req.body.machine_no, currentItem.mold_name, exists.id);
+          } else {
+            db.prepare("INSERT INTO mold_machine_map (mold_code, workshop, machine_no, mold_name) VALUES (?, ?, ?, ?)")
+              .run(moldCode, ws, req.body.machine_no, currentItem.mold_name);
+          }
+        }
+      }
+    } catch (e) {
+      console.log('[同步mold_machine_map失败]', e.message);
+    }
+  }
+
   if (updates.length === 0) return res.status(400).json({ message: '没有要更新的字段' });
 
   values.push(itemId);
@@ -200,6 +224,29 @@ router.post('/:id/items/:itemId/copy', (req, res) => {
 
   const newItem = db.prepare('SELECT * FROM schedule_items WHERE id = ?').get(result.lastInsertRowid);
   res.json({ message: `已复制到 ${machine_no}`, item: newItem });
+});
+
+// 批量更新 sort_order（拖拽排序）
+router.post('/:id/items/reorder', (req, res) => {
+  const { id } = req.params;
+  const { items } = req.body;
+  if (!Array.isArray(items)) return res.status(400).json({ message: '请传入 items 数组' });
+
+  try {
+    const upd = db.prepare('UPDATE schedule_items SET sort_order = ? WHERE id = ? AND schedule_id = ?');
+    const tx = db.transaction((list) => {
+      for (const it of list) {
+        if (it && Number.isInteger(it.id) && Number.isInteger(it.sort_order)) {
+          upd.run(it.sort_order, it.id, id);
+        }
+      }
+    });
+    tx(items);
+    res.json({ message: '已更新顺序', count: items.length });
+  } catch (e) {
+    console.error('reorder 失败:', e);
+    res.status(500).json({ message: e.message });
+  }
 });
 
 // 确认排机单 → 写入历史数据库

--- a/apps/生产部/注塑啤机排产系统/server/seed/machines.json
+++ b/apps/生产部/注塑啤机排产系统/server/seed/machines.json
@@ -1006,5 +1006,32 @@
     "model_desc": "伊之密120T",
     "status": "active",
     "workshop": "B"
+  },
+  {
+    "machine_no": "吹气机台",
+    "brand": "-",
+    "tonnage": 0,
+    "arm_type": "-",
+    "model_desc": null,
+    "status": "active",
+    "workshop": "A"
+  },
+  {
+    "machine_no": "吹气机台",
+    "brand": "-",
+    "tonnage": 0,
+    "arm_type": "-",
+    "model_desc": null,
+    "status": "active",
+    "workshop": "B"
+  },
+  {
+    "machine_no": "吹气机台",
+    "brand": "-",
+    "tonnage": 0,
+    "arm_type": "-",
+    "model_desc": null,
+    "status": "active",
+    "workshop": "C"
   }
 ]

--- a/apps/生产部/注塑啤机排产系统/server/services/schedulingEngine.js
+++ b/apps/生产部/注塑啤机排产系统/server/services/schedulingEngine.js
@@ -150,6 +150,17 @@ function generateSchedule({ orderIds, date, shift, workshop }) {
     ? prevShiftData.items.filter(item => (item.shortage || 0) > 0)
     : [];
 
+  // 模具→机台映射（人工改过一次的永久记住）
+  // 仅当该机台仍 active 时才生效
+  const activeMachineSet = new Set(machines.map(m => m.machine_no));
+  const moldMachineMap = {};  // mold_code → machine_no
+  const allMoldMachineMaps = db.prepare('SELECT mold_code, machine_no FROM mold_machine_map WHERE workshop = ?').all(ws);
+  for (const m of allMoldMachineMaps) {
+    if (activeMachineSet.has(m.machine_no)) {
+      moldMachineMap[m.mold_code] = m.machine_no;
+    }
+  }
+
   // 4. 获取机台历史统计
   const machineStats = {};
   for (const m of machines) {
@@ -247,6 +258,24 @@ function generateSchedule({ orderIds, date, shift, workshop }) {
   });
 
   for (const order of newOrders) {
+    // 0) 最高优先级：查「模具→机台」映射（人工指定过的）
+    const orderMoldCode = (order.mold_no || '').replace(/[一-龥].*$/, '').trim();
+    if (orderMoldCode && moldMachineMap[orderMoldCode]) {
+      const mappedMachine = moldMachineMap[orderMoldCode];
+      newAssignments.push({
+        order,
+        machine_no: mappedMachine,
+        score: 1000,
+        reasons: ['模具→机台映射（人工指定）'],
+        is_carry_over: false,
+      });
+      machineLoad[mappedMachine] = (machineLoad[mappedMachine] || 0) + 1;
+      // 同步登记到 moldGroupMachine，让同套模其他订单也走同一台
+      const orderMoldKey0 = moldBase(order.mold_no || order.mold_name || '');
+      if (orderMoldKey0) moldGroupMachine[orderMoldKey0] = mappedMachine;
+      continue;
+    }
+
     // 若同模号已分配过机台，直接强制分到同一台机
     const orderMoldKey = moldBase(order.mold_no || order.mold_name || '');
     if (orderMoldKey && moldGroupMachine[orderMoldKey]) {


### PR DESCRIPTION
三个独立改动：

1. 其他机台 / 吹气机台幂等迁移
   - init.js 启动时确保 A/B/C 三个车间各有「其他机台」和「吹气机台」各一台
   - 仅当不存在时插入（INSERT WHERE NOT EXISTS），重启不会重复
   - 修云端缺「其他机台」的问题：seed/machines.json 已经包含但 seed 只在表为空时跑， 云端非空 → 这些条目永远不会插入。改用幂等迁移即可
   - seed/machines.json 同步追加 3 条吹气机台

2. 模具→机台映射（人工改一次永久生效）
   - 新表 mold_machine_map (mold_code, workshop, machine_no)
   - PUT /api/scheduling/:id/items/:itemId 更新 machine_no 时自动 UPSERT 映射
   - generateSchedule 分配新订单时，最高优先级查映射（score=1000）
   - 仅当映射的机台仍 active 时才生效

3. 排机明细拖拽排序
   - 新增 POST /api/scheduling/:id/items/reorder 批量更新 sort_order
   - 前端引入 @dnd-kit（core + sortable + utilities）
   - ScheduleResult 表格首列加拖拽手柄，按住 ⋮⋮ 即可拖动整行
   - 排序优先按 sort_order，未拖过的 fallback 按机台号
   - day-shift 行（橙色）不可拖