### PR TITLE
fix(deploy): set -euo pipefail + verify git HEAD == AFTER_COMMIT

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,11 @@ jobs:
           # BEFORE_COMMIT / AFTER_COMMIT 传给 update-server.sh 用于算 diff
           # 脚本自己负责 git pull，不要在这里先 pull（否则 pull 后 HEAD 已经前进，脚本的 BEFORE==AFTER）
           script: |
+            set -euo pipefail
+            # set -e: 任一行 fail 立刻退出。之前没设导致 update-server.sh 退出非零仍
+            # 继续跑 verify，验证又只 grep 一个长寿字符串 → false-positive SUCCESS。
+            # 2026-05-20 review-open-prs 中 PR #144/#141 都因此中招（git pull 静默 abort）。
+
             export BEFORE_COMMIT="${{ github.event.before }}"
             export AFTER_COMMIT="${{ github.event.after }}"
             cd /opt/rr-portal
@@ -37,8 +42,19 @@ jobs:
             grep -c "recreate" deploy/update-server.sh && echo "[OK] update-server.sh contains recreate logic" || echo "[WARN] update-server.sh MISSING recreate logic"
             bash deploy/update-server.sh
             echo ""
-            echo "=== Verify Portal Content (container file) ==="
-            sleep 2
+            echo "=== Verify deploy actually landed ==="
+            # Critical：git HEAD must equal AFTER_COMMIT。任何 git pull 静默 abort
+            # （如 ECS local-mod 文件冲突）都会被这一步 catch，而不是假阳性 SUCCESS。
+            ACTUAL_HEAD=$(git rev-parse HEAD)
+            if [ "$ACTUAL_HEAD" != "$AFTER_COMMIT" ]; then
+              echo "[FAIL] git HEAD ($ACTUAL_HEAD) != expected AFTER_COMMIT ($AFTER_COMMIT)"
+              echo "       update-server.sh 大概率 git pull 静默失败。检查上面日志找 'Aborting' 或 'error:'。"
+              echo "       常见根因：ECS 上有 runtime modified data 文件卡住 pull。"
+              echo "       恢复 sequence：ssh ECS → git stash 那些 M 文件 → git pull → 重 trigger 部署。"
+              exit 1
+            fi
+            echo "[OK] git HEAD = $AFTER_COMMIT"
+            # 长寿字符串 sanity（nginx html 没被破坏）
             if docker exec rr-portal-nginx-1 grep -q "河源排期" /usr/share/nginx/html/index.html; then
               echo "[OK] nginx container index.html contains 河源排期"
             else
@@ -65,7 +81,29 @@ jobs:
             echo "[FAIL] ${ep} (HTTP $status after 3 attempts)"
             return 1
           }
-          for ENDPOINT in /nginx-health /health /hy-schedule/health /rr/health /zouhuo/health /jiangping/health /paiji/health /figure-mold-cost-system/health /baojia/health /liwenjuan/health /huadeng-maorong/health; do
+          # Updated 2026-05-20: 补齐新部署 service (penyou/pi-outsource/production-plan/
+          # tomy-paiqi/zuru-order-system/zuru-master/peise/huadeng) 的 health endpoint，
+          # 之前 missing 这些 → 单 service deploy 挂了也不会被 health-check 抓到。
+          for ENDPOINT in \
+              /nginx-health \
+              /health \
+              /hy-schedule/health \
+              /rr/health \
+              /zouhuo/health \
+              /jiangping/health \
+              /paiji/health \
+              /figure-mold-cost-system/health \
+              /baojia/health \
+              /liwenjuan/health \
+              /huadeng-maorong/health \
+              /huadeng/health \
+              /peise/health \
+              /penyou/health \
+              /pi-outsource/health \
+              /production-plan/health \
+              /tomy-paiqi/health \
+              /zuru-order-system/health \
+              /zuru-master/health; do
             check_endpoint "$ENDPOINT" || FAILED=$((FAILED + 1))
           done
           if [ "$FAILED" -gt 0 ]; then


### PR DESCRIPTION
## Problem

2026-05-20 review-open-prs 中 PR #144 + #141 部署都出现**"GHA SUCCESS 但实际没 deploy"** pattern：

1. \`update-server.sh\` 内的 \`git pull\` 因 ECS 上 runtime-modified 文件卡住 abort
2. update-server.sh 退出非零，但 SSH wrapper script **没 set -e**
3. Wrapper 继续往下跑 verify
4. Verify 只 grep \"河源排期\"（一个早就在 nginx html 里的字符串）→ 总是过
5. GHA 报 ✅ SUCCESS — 但 ECS 的 git HEAD 没动，新 code 没部署

每次都得手动 SSH 进 ECS → stash + pull + 手 rebuild service。

## Fix

\`\`\`yaml
script: |
  set -euo pipefail   # NEW: update-server.sh 失败立刻 propagate

  bash deploy/update-server.sh
  
  # NEW critical check: git HEAD 必须等于 AFTER_COMMIT
  ACTUAL_HEAD=$(git rev-parse HEAD)
  if [ "$ACTUAL_HEAD" != "$AFTER_COMMIT" ]; then
    echo "[FAIL] git pull 静默失败"
    exit 1
  fi
  
  # 旧的 \"河源排期\" grep 保留作 nginx html sanity
\`\`\`

Health Check 端点表也补齐 8 个新部署的 service：penyou / pi-outsource / production-plan / tomy-paiqi / zuru-order-system / zuru-master / peise / huadeng — 之前没列，单 service 挂了不会被 health-check 抓到。

## Defense in depth

3 道防线：

1. **set -e** → update-server.sh 内部 fail 直接退出，不再静默继续
2. **git HEAD == AFTER_COMMIT** → 即使 set -e 漏了某个分支，HEAD 不动就 fail
3. **/health endpoints 大幅扩容** → 即使 1 + 2 都漏，service 跑不起来也会被 curl 抓到

## Test plan

- [x] 本地 diff 检查（41+ 3-）
- [ ] 本 PR 自己会触发新版 deploy（dogfood）：验证 set -e + git HEAD check 都生效
- [ ] 验证 health check 19 个端点都通

🤖 Generated with Claude Opus 4.7