### PR TITLE
fix(deploy): correct /api/health paths for penyou + pi-outsource health check

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -98,8 +98,8 @@ jobs:
               /huadeng-maorong/health \
               /huadeng/health \
               /peise/health \
-              /penyou/health \
-              /pi-outsource/health \
+              /penyou/api/health \
+              /pi-outsource/api/health \
               /production-plan/health \
               /tomy-paiqi/health \
               /zuru-order-system/health \


### PR DESCRIPTION
## 跟进 #148

PR #148 把 penyou 和 pi-outsource 加进 GHA Health Check endpoint 列表，但路径错了：

```yaml
- /penyou/health           # ❌ 401 (有 basic auth)
- /pi-outsource/health     # ❌ 401 (有 basic auth)
```

nginx 上实际配 `auth_basic off` 的是 `/penyou/api/health` 和 `/pi-outsource/api/health`（`grep 'auth_basic off' nginx/nginx.cloud.conf` 一目了然）。

本 PR 修正这两个路径。

## 旁注：deploy hardening 工作正常

#148 deploy 步骤通过了（新 git HEAD == AFTER_COMMIT check 正确工作），失败仅在 Health Check 步骤。这其实证明新 logic 是好的 —— 把 latent bug 暴露出来了。