### PR TITLE
fix(penyou): WorkshopHome 车间列表为空 — subpath baseURL bug

### DIFF
--- a/apps/生产部/喷油部生产管理系统/client/src/pages/WorkshopHome.jsx
+++ b/apps/生产部/喷油部生产管理系统/client/src/pages/WorkshopHome.jsx
@@ -2,10 +2,11 @@ import { useEffect, useState } from 'react';
 import { Card, Button, Spin } from 'antd';
 import { ShopOutlined } from '@ant-design/icons';
 import { useNavigate } from 'react-router-dom';
-import axios from 'axios';
+import api from '../api';
 
-// 不走全局 api(避免被拦截器加 workshop_id;此页本身就是没选 workshop)
-const api = axios.create({ baseURL: '/api' });
+// 注: 原本这里自建一个 axios 实例避开全局 api 的 workshop_id 拦截器，
+// 但 baseURL 写死 '/api' 没带 '/penyou/' 前缀 → 子路径部署下 404 → 车间列表永远是空。
+// 全局 api.js 已经判断 '/workshops' 路径不注入 workshop_id，直接用即可。
 
 export default function WorkshopHome() {
   const [list, setList] = useState([]);


### PR DESCRIPTION
## 现象

访问 `/penyou/` 只见 header「喷油部生产管理系统 · 兴信塑胶制品有限公司 · 请选择车间」，没有车间选择按钮，无法进入任何车间。

## 根因

`WorkshopHome.jsx` line 8 自建 axios 实例：

```js
const api = axios.create({ baseURL: '/api' });  // ❌ 写死 /api 不带 /penyou/ 前缀
```

子路径部署下浏览器请求 `http://server/api/workshops` (nginx root，无此路由) → 404 → catch 静默 → list 永远空。

## 修复

直接用全局 `api`（已正确处理 BASE_URL 前缀 + `/workshops` 路径不注入 workshop_id）：

```js
import api from '../api';
```

## 同类 bug 历史

- PR #131 (pi-outsource) — 全部 fetch 写死 `/api/...`，已修
- 这次 (penyou) — 只 WorkshopHome 一处写死，本 PR 修
- 教训：每次新 React 子路径 app 都要 grep `baseURL: '/` 和 `fetch('/api` 类硬编码

## Test plan

- [x] 本地 grep 确认其他文件不再有硬编码 baseURL
- [ ] Deploy 后访问 `/penyou/` 看到 3 个车间卡片（湖南/兴信/华登）
- [ ] 选车间后 navigate 到 `/penyou/products` 正常

🤖 Generated with Claude Opus 4.7
EOF
)