### PR TITLE
feat(报价系统): 翻译批次纳入 PackagingItem.remark -> remark_eng

### DIFF
--- a/apps/业务部/报价系统/server/routes/versions.js
+++ b/apps/业务部/报价系统/server/routes/versions.js
@@ -533,6 +533,7 @@ router.post('/:id/translate-all', async (req, res) => {
       { table: 'MoldPart',       field: 'description', sql: `SELECT id, description FROM MoldPart       WHERE version_id=? AND ${EMPTY} ORDER BY sort_order` },
       { table: 'HardwareItem',   field: 'name',        sql: `SELECT id, name        FROM HardwareItem   WHERE version_id=? AND ${EMPTY} ORDER BY sort_order` },
       { table: 'PackagingItem',  field: 'name',        sql: `SELECT id, name        FROM PackagingItem  WHERE version_id=? AND ${EMPTY} ORDER BY sort_order` },
+      { table: 'PackagingItem',  field: 'remark',      engField: 'remark_eng', sql: `SELECT id, remark FROM PackagingItem WHERE version_id=? AND remark IS NOT NULL AND remark != '' AND (remark_eng IS NULL OR remark_eng = '') ORDER BY sort_order` },
       { table: 'ElectronicItem', field: 'part_name',   sql: `SELECT id, part_name   FROM ElectronicItem WHERE version_id=? AND ${EMPTY} ORDER BY sort_order` },
       { table: 'SewingDetail',   field: 'fabric_name', sql: `SELECT id, fabric_name FROM SewingDetail   WHERE version_id=? AND ${EMPTY} ORDER BY sort_order` },
       { table: 'RawMaterial',    field: 'material_name', sql: `SELECT id, material_name FROM RawMaterial WHERE version_id=? AND ${EMPTY} ORDER BY sort_order` },


### PR DESCRIPTION
补 PR 157 漏的最后一片: PackagingItem.remark 的翻译批次。

PR 157 已上线 db.js (remark_eng 列) + vq-packaging.js (UI 双语) + excel-exporter.js (导出 remark_eng), 但当时为了避免 Bailian/Baidu 回归没动 versions.js, 导致 remark_eng 永远不会被填充。

此 PR 只追加一行批次到 main 的 versions.js (Bailian 实现保持不变), Specifications 列就能自动翻译。