### PR TITLE
feat(figure-mold): 手办厂/模厂/客户 管理 UI + API cache bugfix

### DIFF
--- a/apps/工程部/模具手办采购订单系统/db.js
+++ b/apps/工程部/模具手办采购订单系统/db.js
@@ -300,6 +300,121 @@ function getMoldFactories() {
 function getFigureFactories() {
   return db.prepare('SELECT name FROM figure_factories ORDER BY name').all().map(r => r.name);
 }
+
+// ─── Figure Factory CRUD ─────────────────────────────────────────────────
+function getFigureFactoriesWithCount() {
+  return db.prepare(`
+    SELECT f.name, COUNT(o.id) AS ref_count
+    FROM figure_factories f
+    LEFT JOIN figure_orders o ON o.figure_factory = f.name
+    GROUP BY f.name
+    ORDER BY f.name
+  `).all();
+}
+function addFigureFactory(name) {
+  name = String(name || '').trim();
+  if (!name) { const e = new Error('EMPTY'); e.code = 'EMPTY'; throw e; }
+  const exists = db.prepare('SELECT 1 FROM figure_factories WHERE name = ?').get(name);
+  if (exists) { const e = new Error('CONFLICT'); e.code = 'CONFLICT'; throw e; }
+  db.prepare('INSERT INTO figure_factories (name) VALUES (?)').run(name);
+}
+const renameFigureFactory = db.transaction((oldName, newName) => {
+  newName = String(newName || '').trim();
+  if (!newName) { const e = new Error('EMPTY'); e.code = 'EMPTY'; throw e; }
+  if (oldName === newName) return;
+  const exists = db.prepare('SELECT 1 FROM figure_factories WHERE name = ?').get(newName);
+  if (exists) { const e = new Error('CONFLICT'); e.code = 'CONFLICT'; throw e; }
+  const found = db.prepare('SELECT 1 FROM figure_factories WHERE name = ?').get(oldName);
+  if (!found) { const e = new Error('NOT_FOUND'); e.code = 'NOT_FOUND'; throw e; }
+  db.prepare('UPDATE figure_factories SET name = ? WHERE name = ?').run(newName, oldName);
+  db.prepare('UPDATE figure_orders SET figure_factory = ? WHERE figure_factory = ?').run(newName, oldName);
+});
+const deleteFigureFactory = db.transaction((name, force) => {
+  const refCount = db.prepare('SELECT COUNT(*) AS c FROM figure_orders WHERE figure_factory = ?').get(name).c;
+  if (refCount > 0 && !force) {
+    const e = new Error('IN_USE'); e.code = 'IN_USE'; e.ref_count = refCount; throw e;
+  }
+  if (refCount > 0 && force) {
+    db.prepare("UPDATE figure_orders SET figure_factory = '' WHERE figure_factory = ?").run(name);
+  }
+  db.prepare('DELETE FROM figure_factories WHERE name = ?').run(name);
+});
+
+// ─── Mold Factory CRUD ───────────────────────────────────────────────────
+function getMoldFactoriesWithCount() {
+  return db.prepare(`
+    SELECT f.name, COUNT(o.id) AS ref_count
+    FROM mold_factories f
+    LEFT JOIN mold_orders o ON o.mold_factory = f.name
+    GROUP BY f.name
+    ORDER BY f.name
+  `).all();
+}
+function addMoldFactory(name) {
+  name = String(name || '').trim();
+  if (!name) { const e = new Error('EMPTY'); e.code = 'EMPTY'; throw e; }
+  const exists = db.prepare('SELECT 1 FROM mold_factories WHERE name = ?').get(name);
+  if (exists) { const e = new Error('CONFLICT'); e.code = 'CONFLICT'; throw e; }
+  db.prepare('INSERT INTO mold_factories (name) VALUES (?)').run(name);
+}
+const renameMoldFactory = db.transaction((oldName, newName) => {
+  newName = String(newName || '').trim();
+  if (!newName) { const e = new Error('EMPTY'); e.code = 'EMPTY'; throw e; }
+  if (oldName === newName) return;
+  const exists = db.prepare('SELECT 1 FROM mold_factories WHERE name = ?').get(newName);
+  if (exists) { const e = new Error('CONFLICT'); e.code = 'CONFLICT'; throw e; }
+  const found = db.prepare('SELECT 1 FROM mold_factories WHERE name = ?').get(oldName);
+  if (!found) { const e = new Error('NOT_FOUND'); e.code = 'NOT_FOUND'; throw e; }
+  db.prepare('UPDATE mold_factories SET name = ? WHERE name = ?').run(newName, oldName);
+  db.prepare('UPDATE mold_orders SET mold_factory = ? WHERE mold_factory = ?').run(newName, oldName);
+});
+const deleteMoldFactory = db.transaction((name, force) => {
+  const refCount = db.prepare('SELECT COUNT(*) AS c FROM mold_orders WHERE mold_factory = ?').get(name).c;
+  if (refCount > 0 && !force) {
+    const e = new Error('IN_USE'); e.code = 'IN_USE'; e.ref_count = refCount; throw e;
+  }
+  if (refCount > 0 && force) {
+    db.prepare("UPDATE mold_orders SET mold_factory = '' WHERE mold_factory = ?").run(name);
+  }
+  db.prepare('DELETE FROM mold_factories WHERE name = ?').run(name);
+});
+
+// ─── Customer CRUD (dual cascade: figure_orders + mold_orders) ──────────
+function getCustomersWithCount() {
+  return db.prepare(`
+    SELECT c.name,
+           (SELECT COUNT(*) FROM figure_orders WHERE customer = c.name)
+         + (SELECT COUNT(*) FROM mold_orders   WHERE customer = c.name) AS ref_count
+    FROM customers c
+    ORDER BY c.name
+  `).all();
+}
+const renameCustomer = db.transaction((oldName, newName) => {
+  newName = String(newName || '').trim();
+  if (!newName) { const e = new Error('EMPTY'); e.code = 'EMPTY'; throw e; }
+  if (oldName === newName) return;
+  const exists = db.prepare('SELECT 1 FROM customers WHERE name = ?').get(newName);
+  if (exists) { const e = new Error('CONFLICT'); e.code = 'CONFLICT'; throw e; }
+  const found = db.prepare('SELECT 1 FROM customers WHERE name = ?').get(oldName);
+  if (!found) { const e = new Error('NOT_FOUND'); e.code = 'NOT_FOUND'; throw e; }
+  db.prepare('UPDATE customers SET name = ? WHERE name = ?').run(newName, oldName);
+  db.prepare('UPDATE figure_orders SET customer = ? WHERE customer = ?').run(newName, oldName);
+  db.prepare('UPDATE mold_orders   SET customer = ? WHERE customer = ?').run(newName, oldName);
+});
+const deleteCustomer = db.transaction((name, force) => {
+  const f = db.prepare('SELECT COUNT(*) AS c FROM figure_orders WHERE customer = ?').get(name).c;
+  const m = db.prepare('SELECT COUNT(*) AS c FROM mold_orders   WHERE customer = ?').get(name).c;
+  const refCount = f + m;
+  if (refCount > 0 && !force) {
+    const e = new Error('IN_USE'); e.code = 'IN_USE'; e.ref_count = refCount; throw e;
+  }
+  if (refCount > 0 && force) {
+    db.prepare("UPDATE figure_orders SET customer = '' WHERE customer = ?").run(name);
+    db.prepare("UPDATE mold_orders   SET customer = '' WHERE customer = ?").run(name);
+  }
+  db.prepare('DELETE FROM customers WHERE name = ?').run(name);
+});
+
 function getUser(name) {
   return db.prepare('SELECT name, pin FROM eng_users WHERE name = ?').get(name);
 }
@@ -314,6 +429,9 @@ module.exports = {
   listFigureOrders, getFigureOrder, createFigureOrder, updateFigureOrder, deleteFigureOrder,
   listPurchaseOrders, getPurchaseOrder, createPurchaseOrder, updatePurchaseOrder, deletePurchaseOrder,
   getCustomers, addCustomer,
+  getCustomersWithCount, renameCustomer, deleteCustomer,
   getMoldFactories, getFigureFactories,
+  getFigureFactoriesWithCount, addFigureFactory, renameFigureFactory, deleteFigureFactory,
+  getMoldFactoriesWithCount, addMoldFactory, renameMoldFactory, deleteMoldFactory,
   getUser, updateUserPin,
 };

--- a/apps/工程部/模具手办采购订单系统/public/figure.html
+++ b/apps/工程部/模具手办采购订单系统/public/figure.html
@@ -176,11 +176,23 @@
           </div>
           <div class="col-md-4">
             <label class="form-label">客户 *</label>
-            <select class="form-select" id="m-customer"><option value="">请选择客户</option></select>
+            <div class="input-group">
+              <select class="form-select" id="m-customer"><option value="">请选择客户</option></select>
+              <button class="btn btn-outline-secondary" type="button"
+                      onclick="openListManager('customer')" title="管理客户">
+                <i class="bi bi-gear"></i>
+              </button>
+            </div>
           </div>
           <div class="col-md-4">
             <label class="form-label">手办厂 *</label>
-            <select class="form-select" id="m-figure_factory"><option value="">请选择</option></select>
+            <div class="input-group">
+              <select class="form-select" id="m-figure_factory"><option value="">请选择</option></select>
+              <button class="btn btn-outline-secondary" type="button"
+                      onclick="openListManager('figure-factory')" title="管理手办厂">
+                <i class="bi bi-gear"></i>
+              </button>
+            </div>
           </div>
           <div class="col-md-4">
             <label class="form-label">产品名称/编号</label>
@@ -211,6 +223,27 @@
       <div class="modal-footer">
         <button class="btn btn-secondary" data-bs-dismiss="modal">取消</button>
         <button class="btn btn-primary" onclick="saveOrder()">保存</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ─── Shared List Manager Modal (figure-factory / customer) ──────── -->
+<div class="modal fade" id="listMgrModal" tabindex="-1">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="listMgrTitle">管理</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <div class="input-group mb-3">
+          <input type="text" class="form-control" id="listMgrNewName" placeholder="新名称">
+          <button class="btn btn-success" onclick="listMgrAdd()">
+            <i class="bi bi-plus-lg"></i> 添加
+          </button>
+        </div>
+        <div id="listMgrItems"></div>
       </div>
     </div>
   </div>
@@ -485,6 +518,132 @@ function switchTab(tab) {
   document.getElementById('tabList').style.display = tab === 'list' ? '' : 'none';
   document.getElementById('tabStats').style.display = tab === 'stats' ? '' : 'none';
   if (tab === 'stats') loadStats();
+}
+
+// ─── List Manager (shared modal for figure-factory + customer) ──────
+var LIST_MGR_CONFIG = {
+  'figure-factory': { title: '管理手办厂', api: 'api/figure-factories' },
+  'customer':       { title: '管理客户',   api: 'api/customers'        }
+};
+var listMgrType = null;
+
+function openListManager(type) {
+  listMgrType = type;
+  var cfg = LIST_MGR_CONFIG[type];
+  if (!cfg) return;
+  document.getElementById('listMgrTitle').textContent = cfg.title;
+  document.getElementById('listMgrNewName').value = '';
+  listMgrReload();
+  new bootstrap.Modal(document.getElementById('listMgrModal')).show();
+}
+
+function listMgrReload() {
+  var cfg = LIST_MGR_CONFIG[listMgrType];
+  authFetch(cfg.api + '?with_count=1')
+    .then(function(r) { return r.json(); })
+    .then(function(items) {
+      var html = items.map(function(item) {
+        var refBadge = item.ref_count > 0
+          ? '<span class="badge bg-warning text-dark ms-2">' + item.ref_count + ' 引用</span>'
+          : '<span class="badge bg-light text-muted ms-2">0 引用</span>';
+        return '<div class="d-flex justify-content-between align-items-center border rounded p-2 mb-2" data-name="' + esc(item.name) + '">' +
+          '<div class="lm-name">' + esc(item.name) + refBadge + '</div>' +
+          '<div>' +
+            '<button class="btn btn-sm btn-outline-primary me-1" onclick="listMgrStartRename(this)"><i class="bi bi-pencil"></i></button>' +
+            '<button class="btn btn-sm btn-outline-danger" onclick="listMgrDelete(this)"><i class="bi bi-trash"></i></button>' +
+          '</div>' +
+        '</div>';
+      }).join('');
+      document.getElementById('listMgrItems').innerHTML = html || '<div class="text-muted text-center py-3">暂无数据</div>';
+    });
+}
+
+function listMgrAdd() {
+  var name = document.getElementById('listMgrNewName').value.trim();
+  if (!name) { showToast('请输入名称', 'danger'); return; }
+  var cfg = LIST_MGR_CONFIG[listMgrType];
+  authFetch(cfg.api, { method: 'POST', headers: authHeaders(), body: JSON.stringify({ name: name }) })
+    .then(function(r) { return r.json().then(function(d) { return { ok: r.ok, data: d }; }); })
+    .then(function(res) {
+      if (!res.ok) { showToast(res.data.error || '添加失败', 'danger'); return; }
+      document.getElementById('listMgrNewName').value = '';
+      showToast('已添加');
+      listMgrReload();
+    });
+}
+
+function listMgrStartRename(btn) {
+  var row = btn.closest('[data-name]');
+  var oldName = row.getAttribute('data-name');
+  var nameDiv = row.querySelector('.lm-name');
+  nameDiv.innerHTML = '<input type="text" class="form-control form-control-sm" value="' + esc(oldName) + '">';
+  var input = nameDiv.querySelector('input');
+  input.focus();
+  input.select();
+  var actionDiv = btn.parentElement;
+  actionDiv.innerHTML =
+    '<button class="btn btn-sm btn-success me-1" onclick="listMgrConfirmRename(this, \'' + esc(oldName).replace(/'/g, "\\'") + '\')"><i class="bi bi-check-lg"></i></button>' +
+    '<button class="btn btn-sm btn-secondary" onclick="listMgrReload()"><i class="bi bi-x-lg"></i></button>';
+}
+
+function listMgrConfirmRename(btn, oldName) {
+  var row = btn.closest('[data-name]');
+  var newName = row.querySelector('input').value.trim();
+  if (!newName) { showToast('新名称不能为空', 'danger'); return; }
+  if (newName === oldName) { listMgrReload(); return; }
+  var cfg = LIST_MGR_CONFIG[listMgrType];
+  authFetch(cfg.api + '/' + encodeURIComponent(oldName), {
+    method: 'PUT', headers: authHeaders(), body: JSON.stringify({ name: newName })
+  }).then(function(r) { return r.json().then(function(d) { return { ok: r.ok, data: d }; }); })
+    .then(function(res) {
+      if (!res.ok) { showToast(res.data.error || '改名失败', 'danger'); return; }
+      showToast('已改名');
+      listMgrReload();
+    });
+}
+
+function listMgrDelete(btn) {
+  var row = btn.closest('[data-name]');
+  var name = row.getAttribute('data-name');
+  var cfg = LIST_MGR_CONFIG[listMgrType];
+  authFetch(cfg.api + '/' + encodeURIComponent(name), { method: 'DELETE', headers: authHeaders() })
+    .then(function(r) { return r.json().then(function(d) { return { ok: r.ok, status: r.status, data: d }; }); })
+    .then(function(res) {
+      if (res.ok) { showToast('已删除'); listMgrReload(); return; }
+      if (res.status === 409 && res.data.ref_count > 0) {
+        if (!confirm('「' + name + '」已被 ' + res.data.ref_count + ' 条订单引用。\n确定要强制删除吗？这些订单对应字段将被清空（订单本身保留）。')) return;
+        return authFetch(cfg.api + '/' + encodeURIComponent(name) + '?force=1', { method: 'DELETE', headers: authHeaders() })
+          .then(function(r2) { return r2.json().then(function(d2) { return { ok: r2.ok, data: d2 }; }); })
+          .then(function(res2) {
+            if (res2.ok) { showToast('已强制删除'); listMgrReload(); }
+            else showToast(res2.data.error || '删除失败', 'danger');
+          });
+      }
+      showToast(res.data.error || '删除失败', 'danger');
+    });
+}
+
+// 关 modal 时刷新主页面下拉
+document.addEventListener('DOMContentLoaded', function() {
+  var mgr = document.getElementById('listMgrModal');
+  if (mgr) {
+    mgr.addEventListener('hidden.bs.modal', function() {
+      loadFactoriesAndCustomers();
+      loadOrders();
+    });
+  }
+});
+
+function loadFactoriesAndCustomers() {
+  authFetch('api/factories').then(function(r) { return r.json(); }).then(function(d) {
+    factoryOrder = d.figure_factories || [];
+    var mSel = document.getElementById('m-figure_factory');
+    var current = mSel.value;
+    mSel.innerHTML = '<option value="">请选择</option>' + factoryOrder.map(function(f) {
+      return '<option' + (f === current ? ' selected' : '') + '>' + esc(f) + '</option>';
+    }).join('');
+  });
+  loadCustomers();
 }
 
 // ─── Order List (grouped by factory) ─────────────────────────────────

--- a/apps/工程部/模具手办采购订单系统/public/mold.html
+++ b/apps/工程部/模具手办采购订单系统/public/mold.html
@@ -179,11 +179,23 @@
           </div>
           <div class="col-md-4">
             <label class="form-label">客户 *</label>
-            <select class="form-select" id="m-customer"><option value="">请选择客户</option></select>
+            <div class="input-group">
+              <select class="form-select" id="m-customer"><option value="">请选择客户</option></select>
+              <button class="btn btn-outline-secondary" type="button"
+                      onclick="openListManager('customer')" title="管理客户">
+                <i class="bi bi-gear"></i>
+              </button>
+            </div>
           </div>
           <div class="col-md-4">
             <label class="form-label">模厂 *</label>
-            <select class="form-select" id="m-mold_factory"><option value="">请选择</option></select>
+            <div class="input-group">
+              <select class="form-select" id="m-mold_factory"><option value="">请选择</option></select>
+              <button class="btn btn-outline-secondary" type="button"
+                      onclick="openListManager('mold-factory')" title="管理模厂">
+                <i class="bi bi-gear"></i>
+              </button>
+            </div>
           </div>
           <div class="col-12"><hr class="my-1"><small class="text-muted">模具详情</small></div>
           <div class="col-md-4">
@@ -243,6 +255,27 @@
       <div class="modal-footer">
         <button class="btn btn-secondary" data-bs-dismiss="modal">取消</button>
         <button class="btn btn-primary" onclick="saveOrder()">保存</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ─── Shared List Manager Modal (mold-factory / customer) ────────── -->
+<div class="modal fade" id="listMgrModal" tabindex="-1">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="listMgrTitle">管理</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <div class="input-group mb-3">
+          <input type="text" class="form-control" id="listMgrNewName" placeholder="新名称">
+          <button class="btn btn-success" onclick="listMgrAdd()">
+            <i class="bi bi-plus-lg"></i> 添加
+          </button>
+        </div>
+        <div id="listMgrItems"></div>
       </div>
     </div>
   </div>
@@ -531,6 +564,131 @@ function switchTab(tab) {
   document.getElementById('tabList').style.display = tab === 'list' ? '' : 'none';
   document.getElementById('tabStats').style.display = tab === 'stats' ? '' : 'none';
   if (tab === 'stats') loadStats();
+}
+
+// ─── List Manager (shared modal for mold-factory + customer) ────────
+var LIST_MGR_CONFIG = {
+  'mold-factory': { title: '管理模厂',   api: 'api/mold-factories' },
+  'customer':     { title: '管理客户',   api: 'api/customers'      }
+};
+var listMgrType = null;
+
+function openListManager(type) {
+  listMgrType = type;
+  var cfg = LIST_MGR_CONFIG[type];
+  if (!cfg) return;
+  document.getElementById('listMgrTitle').textContent = cfg.title;
+  document.getElementById('listMgrNewName').value = '';
+  listMgrReload();
+  new bootstrap.Modal(document.getElementById('listMgrModal')).show();
+}
+
+function listMgrReload() {
+  var cfg = LIST_MGR_CONFIG[listMgrType];
+  authFetch(cfg.api + '?with_count=1')
+    .then(function(r) { return r.json(); })
+    .then(function(items) {
+      var html = items.map(function(item) {
+        var refBadge = item.ref_count > 0
+          ? '<span class="badge bg-warning text-dark ms-2">' + item.ref_count + ' 引用</span>'
+          : '<span class="badge bg-light text-muted ms-2">0 引用</span>';
+        return '<div class="d-flex justify-content-between align-items-center border rounded p-2 mb-2" data-name="' + esc(item.name) + '">' +
+          '<div class="lm-name">' + esc(item.name) + refBadge + '</div>' +
+          '<div>' +
+            '<button class="btn btn-sm btn-outline-primary me-1" onclick="listMgrStartRename(this)"><i class="bi bi-pencil"></i></button>' +
+            '<button class="btn btn-sm btn-outline-danger" onclick="listMgrDelete(this)"><i class="bi bi-trash"></i></button>' +
+          '</div>' +
+        '</div>';
+      }).join('');
+      document.getElementById('listMgrItems').innerHTML = html || '<div class="text-muted text-center py-3">暂无数据</div>';
+    });
+}
+
+function listMgrAdd() {
+  var name = document.getElementById('listMgrNewName').value.trim();
+  if (!name) { showToast('请输入名称', 'danger'); return; }
+  var cfg = LIST_MGR_CONFIG[listMgrType];
+  authFetch(cfg.api, { method: 'POST', headers: authHeaders(), body: JSON.stringify({ name: name }) })
+    .then(function(r) { return r.json().then(function(d) { return { ok: r.ok, data: d }; }); })
+    .then(function(res) {
+      if (!res.ok) { showToast(res.data.error || '添加失败', 'danger'); return; }
+      document.getElementById('listMgrNewName').value = '';
+      showToast('已添加');
+      listMgrReload();
+    });
+}
+
+function listMgrStartRename(btn) {
+  var row = btn.closest('[data-name]');
+  var oldName = row.getAttribute('data-name');
+  var nameDiv = row.querySelector('.lm-name');
+  nameDiv.innerHTML = '<input type="text" class="form-control form-control-sm" value="' + esc(oldName) + '">';
+  var input = nameDiv.querySelector('input');
+  input.focus();
+  input.select();
+  var actionDiv = btn.parentElement;
+  actionDiv.innerHTML =
+    '<button class="btn btn-sm btn-success me-1" onclick="listMgrConfirmRename(this, \'' + esc(oldName).replace(/'/g, "\\'") + '\')"><i class="bi bi-check-lg"></i></button>' +
+    '<button class="btn btn-sm btn-secondary" onclick="listMgrReload()"><i class="bi bi-x-lg"></i></button>';
+}
+
+function listMgrConfirmRename(btn, oldName) {
+  var row = btn.closest('[data-name]');
+  var newName = row.querySelector('input').value.trim();
+  if (!newName) { showToast('新名称不能为空', 'danger'); return; }
+  if (newName === oldName) { listMgrReload(); return; }
+  var cfg = LIST_MGR_CONFIG[listMgrType];
+  authFetch(cfg.api + '/' + encodeURIComponent(oldName), {
+    method: 'PUT', headers: authHeaders(), body: JSON.stringify({ name: newName })
+  }).then(function(r) { return r.json().then(function(d) { return { ok: r.ok, data: d }; }); })
+    .then(function(res) {
+      if (!res.ok) { showToast(res.data.error || '改名失败', 'danger'); return; }
+      showToast('已改名');
+      listMgrReload();
+    });
+}
+
+function listMgrDelete(btn) {
+  var row = btn.closest('[data-name]');
+  var name = row.getAttribute('data-name');
+  var cfg = LIST_MGR_CONFIG[listMgrType];
+  authFetch(cfg.api + '/' + encodeURIComponent(name), { method: 'DELETE', headers: authHeaders() })
+    .then(function(r) { return r.json().then(function(d) { return { ok: r.ok, status: r.status, data: d }; }); })
+    .then(function(res) {
+      if (res.ok) { showToast('已删除'); listMgrReload(); return; }
+      if (res.status === 409 && res.data.ref_count > 0) {
+        if (!confirm('「' + name + '」已被 ' + res.data.ref_count + ' 条订单引用。\n确定要强制删除吗？这些订单对应字段将被清空（订单本身保留）。')) return;
+        return authFetch(cfg.api + '/' + encodeURIComponent(name) + '?force=1', { method: 'DELETE', headers: authHeaders() })
+          .then(function(r2) { return r2.json().then(function(d2) { return { ok: r2.ok, data: d2 }; }); })
+          .then(function(res2) {
+            if (res2.ok) { showToast('已强制删除'); listMgrReload(); }
+            else showToast(res2.data.error || '删除失败', 'danger');
+          });
+      }
+      showToast(res.data.error || '删除失败', 'danger');
+    });
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+  var mgr = document.getElementById('listMgrModal');
+  if (mgr) {
+    mgr.addEventListener('hidden.bs.modal', function() {
+      loadFactoriesAndCustomers();
+      loadOrders();
+    });
+  }
+});
+
+function loadFactoriesAndCustomers() {
+  authFetch('api/factories').then(function(r) { return r.json(); }).then(function(d) {
+    factoryOrder = d.mold_factories || [];
+    var mSel = document.getElementById('m-mold_factory');
+    var current = mSel.value;
+    mSel.innerHTML = '<option value="">请选择</option>' + factoryOrder.map(function(f) {
+      return '<option' + (f === current ? ' selected' : '') + '>' + esc(f) + '</option>';
+    }).join('');
+  });
+  loadCustomers();
 }
 
 // ─── Order List (grouped by factory) ─────────────────────────────────

--- a/apps/工程部/模具手办采购订单系统/server.js
+++ b/apps/工程部/模具手办采购订单系统/server.js
@@ -118,8 +118,124 @@ app.get('/api/factories', (req, res) => {
   res.json({ mold_factories: d.getMoldFactories(), figure_factories: d.getFigureFactories() });
 });
 
+// ─── Figure Factory management ─────────────────────────────────────────
+app.get('/api/figure-factories', (req, res) => {
+  if (req.query.with_count === '1') {
+    res.json(d.getFigureFactoriesWithCount());
+  } else {
+    res.json(d.getFigureFactories().map(name => ({ name })));
+  }
+});
+app.post('/api/figure-factories', (req, res) => {
+  try {
+    d.addFigureFactory(req.body.name);
+    res.json({ success: true });
+  } catch (e) {
+    if (e.code === 'EMPTY') return res.status(400).json({ error: '名称不能为空' });
+    if (e.code === 'CONFLICT') return res.status(409).json({ error: '名称已存在' });
+    res.status(500).json({ error: e.message });
+  }
+});
+app.put('/api/figure-factories/:oldName', (req, res) => {
+  try {
+    d.renameFigureFactory(req.params.oldName, req.body.name);
+    res.json({ success: true });
+  } catch (e) {
+    if (e.code === 'EMPTY') return res.status(400).json({ error: '新名称不能为空' });
+    if (e.code === 'CONFLICT') return res.status(409).json({ error: '新名称已存在' });
+    if (e.code === 'NOT_FOUND') return res.status(404).json({ error: '原名称不存在' });
+    res.status(500).json({ error: e.message });
+  }
+});
+app.delete('/api/figure-factories/:name', (req, res) => {
+  try {
+    d.deleteFigureFactory(req.params.name, req.query.force === '1');
+    res.json({ success: true });
+  } catch (e) {
+    if (e.code === 'IN_USE') return res.status(409).json({ error: '有订单引用', ref_count: e.ref_count });
+    res.status(500).json({ error: e.message });
+  }
+});
+
+// ─── Mold Factory management ───────────────────────────────────────────
+app.get('/api/mold-factories', (req, res) => {
+  if (req.query.with_count === '1') {
+    res.json(d.getMoldFactoriesWithCount());
+  } else {
+    res.json(d.getMoldFactories().map(name => ({ name })));
+  }
+});
+app.post('/api/mold-factories', (req, res) => {
+  try {
+    d.addMoldFactory(req.body.name);
+    res.json({ success: true });
+  } catch (e) {
+    if (e.code === 'EMPTY') return res.status(400).json({ error: '名称不能为空' });
+    if (e.code === 'CONFLICT') return res.status(409).json({ error: '名称已存在' });
+    res.status(500).json({ error: e.message });
+  }
+});
+app.put('/api/mold-factories/:oldName', (req, res) => {
+  try {
+    d.renameMoldFactory(req.params.oldName, req.body.name);
+    res.json({ success: true });
+  } catch (e) {
+    if (e.code === 'EMPTY') return res.status(400).json({ error: '新名称不能为空' });
+    if (e.code === 'CONFLICT') return res.status(409).json({ error: '新名称已存在' });
+    if (e.code === 'NOT_FOUND') return res.status(404).json({ error: '原名称不存在' });
+    res.status(500).json({ error: e.message });
+  }
+});
+app.delete('/api/mold-factories/:name', (req, res) => {
+  try {
+    d.deleteMoldFactory(req.params.name, req.query.force === '1');
+    res.json({ success: true });
+  } catch (e) {
+    if (e.code === 'IN_USE') return res.status(409).json({ error: '有订单引用', ref_count: e.ref_count });
+    res.status(500).json({ error: e.message });
+  }
+});
+
+// ─── Customer management ───────────────────────────────────────────────
 app.get('/api/customers', (req, res) => {
-  res.json(d.getCustomers());
+  if (req.query.with_count === '1') {
+    res.json(d.getCustomersWithCount());
+  } else {
+    // 保持向后兼容：默认返回字符串数组
+    res.json(d.getCustomers());
+  }
+});
+app.post('/api/customers', (req, res) => {
+  try {
+    const name = String(req.body.name || '').trim();
+    if (!name) return res.status(400).json({ error: '名称不能为空' });
+    const exists = d.getCustomers().includes(name);
+    if (exists) return res.status(409).json({ error: '名称已存在' });
+    d.addCustomer(name);
+    res.json({ success: true });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+app.put('/api/customers/:oldName', (req, res) => {
+  try {
+    d.renameCustomer(req.params.oldName, req.body.name);
+    res.json({ success: true });
+  } catch (e) {
+    if (e.code === 'EMPTY') return res.status(400).json({ error: '新名称不能为空' });
+    if (e.code === 'CONFLICT') return res.status(409).json({ error: '新名称已存在' });
+    if (e.code === 'NOT_FOUND') return res.status(404).json({ error: '原名称不存在' });
+    res.status(500).json({ error: e.message });
+  }
+});
+app.delete('/api/customers/:name', (req, res) => {
+  try {
+    d.deleteCustomer(req.params.name, req.query.force === '1');
+    res.json({ success: true });
+  } catch (e) {
+    if (e.code === 'IN_USE') return res.status(409).json({ error: '有订单引用', ref_count: e.ref_count });
+    res.status(500).json({ error: e.message });
+  }
 });
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/apps/工程部/模具手办采购订单系统/server.js
+++ b/apps/工程部/模具手办采购订单系统/server.js
@@ -84,6 +84,7 @@ function verifyToken(req) {
 
 // Auth middleware: optional — allow all requests, populate req.user when token present
 app.use('/api', (req, res, next) => {
+  res.setHeader('Cache-Control', 'no-store');
   if (req.path === '/login') return next();
   const payload = verifyToken(req);
   req.user = payload ? payload.name : '管理员';


### PR DESCRIPTION
## Summary

实现 [docs/superpowers/specs/2026-05-26-factory-customer-management-design.md](https://github.com/charlesskl/RR-Portal/pull/164) 的设计：

- **管理 UI**：三张基础数据表（figure_factories / mold_factories / customers）加 CRUD，从下拉旁齿轮按钮进入
- **级联**：改名/删除走事务级联同步 orders 表；customer 改名/删除同时级联 figure_orders + mold_orders 双表
- **删除安全**：默认有引用项返回 409 + 引用数；二次确认后 `?force=1` 强删，把订单字段清空（订单本身保留）
- **附带修 bug**：API 响应加 `Cache-Control: no-store` header，根治 CRUD 后页面延迟刷新

## Commits (5)

1. `fix`: API 加 Cache-Control: no-store（1 行）
2. `feat`: db.js 加 9 个 mutation 函数 + 3 个 with_count 查询（118 行）
3. `feat`: server.js 加 12 个 endpoint（117 行）
4. `feat`: figure.html 加齿轮 + modal + JS（161 行）
5. `feat`: mold.html 同上（160 行）

## ⚠️ 部署前要做的事 (Phase 0)

**云端 SQLite 里的 figure_factories / mold_factories 数据是错的**（含"东莞兴信手办厂"/"兴信"/"华登"等历史脏数据），需手动 SSH 修：

\`\`\`bash
ssh root@8.148.146.194

# 备份
cp '/opt/rr-portal/apps/工程部/模具手办采购订单系统/data/app.db' \
   ~/rr-backups/figure-mold-app.db.\$(date +%Y%m%d-%H%M%S)

# 看现状
sqlite3 '/opt/rr-portal/apps/工程部/模具手办采购订单系统/data/app.db' \
  'SELECT name FROM figure_factories; SELECT "---"; SELECT name FROM mold_factories;'

# 修
sqlite3 '/opt/rr-portal/apps/工程部/模具手办采购订单系统/data/app.db' <<'SQL'
BEGIN;
DELETE FROM figure_factories;
INSERT INTO figure_factories(name) VALUES ('力图'),('海洋'),('广祥'),('伟盟');

DELETE FROM mold_factories;
INSERT INTO mold_factories(name) VALUES ('力众'),('亚细亚'),('龙之联'),('亿隆泰'),('范仕达');
COMMIT;
SQL
\`\`\`

不动 orders 表里的历史厂名字符串，那些会照原样保留显示。

## Test plan

**本地**：因 better-sqlite3 需要 Visual Studio Build Tools 编译原生模块，本机没装，本地 smoke test 已跳过。所有改动语法已 \`node --check\` 验证。

**云端**（合并部署后）：

- [ ] Phase 0 数据修复执行成功
- [ ] safe-redeploy figure-mold-cost-system 后健康检查通过
- [ ] DevTools Network 看 \`/api/figure-orders\` 响应头有 \`Cache-Control: no-store\`
- [ ] 新建/删除订单后列表立即刷新（不再延迟）
- [ ] figure.html 手办厂 ⚙：CRUD + 强删全验
- [ ] figure.html 客户 ⚙：CRUD 全验
- [ ] mold.html 模厂 ⚙：CRUD + 强删全验
- [ ] mold.html 客户 ⚙：CRUD 全验
- [ ] 客户改名级联：在 figure 改某客户名，mold 那边该客户订单同步更新
- [ ] 老接口向后兼容：\`GET /api/factories\` 和 \`GET /api/customers\`（不带 query）格式不变

🤖 Generated with [Claude Code](https://claude.com/claude-code)