### PR TITLE
fix(figure-mold): apk 用阿里云 alpine 镜像，根治构建卡死

### DIFF
--- a/apps/工程部/模具手办采购订单系统/Dockerfile
+++ b/apps/工程部/模具手办采购订单系统/Dockerfile
@@ -2,6 +2,9 @@ FROM node:20-alpine AS builder
 
 WORKDIR /app
 
+# Use Aliyun alpine mirror — ECS in China; default dl-cdn (fastly/IPv6) throughput is unreliable
+RUN sed -i 's#dl-cdn.alpinelinux.org#mirrors.aliyun.com#g' /etc/apk/repositories
+
 # Build deps for better-sqlite3 native compile
 RUN apk add --no-cache python3 make g++
 
@@ -12,6 +15,9 @@ RUN npm ci --omit=dev
 FROM node:20-alpine
 
 WORKDIR /app
+
+# Use Aliyun alpine mirror — ECS in China; default dl-cdn (fastly/IPv6) throughput is unreliable
+RUN sed -i 's#dl-cdn.alpinelinux.org#mirrors.aliyun.com#g' /etc/apk/repositories
 
 RUN apk add --no-cache tini curl
 


### PR DESCRIPTION
## 背景
PR #165（手办厂/模厂/客户管理 UI）合并后，自动部署的 figure-mold-cost-system 构建**卡死**：默认 alpine 源 `dl-cdn.alpinelinux.org`（fastly/IPv6）从 ECS 出站吞吐严重劣化，`apk add python3 make g++` 每个包 ~3 分钟，29 个包要 ~1.5 小时。两次部署尝试（GHA + safe-redeploy）均超时。生产全程跑旧版无影响（safe-redeploy 失败保护生效）。

## 诊断
- ECS host + 运行容器访问 dl-cdn 也慢；但国内镜像飞快：实测 `mirrors.aliyun.com/alpine` **0.14s**、`mirrors.tencent.com/alpine` 0.27s。
- daemon.json 已配 docker registry mirror（腾讯/daocloud），所以 `FROM node:20-alpine` 能过；但 apk 直连 alpine 源不走该 mirror，故卡。

## 改动
figure-mold Dockerfile 两个 build stage 的 `apk add` 前各加一行 `sed`，把 alpine 仓库 `dl-cdn.alpinelinux.org` 换成 `mirrors.aliyun.com`。ECS 在国内，本就该走国内镜像。

## 影响
- 仅 Dockerfile，6 行新增，无应用代码改动。
- 合并部署后 figure-mold 构建会瞬间变快，#165 的新 CRUD 管理 UI + cache 修复随之上线。
- 上线后仍需做 #165 的 Phase 0 云端基础数据修复（待与 Charles 确认）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)