### PR TITLE
fix(报价系统): translate-all 自愈丢斜杠的旧翻译

### DIFF
--- a/apps/业务部/报价系统/server/routes/versions.js
+++ b/apps/业务部/报价系统/server/routes/versions.js
@@ -528,18 +528,22 @@ router.post('/:id/translate-all', async (req, res) => {
       return out;
     }
 
-    const EMPTY = "(eng_name IS NULL OR eng_name = '')";
+    // 需要翻译的行：eng 为空，或「中文含 '/' 但 eng 丢了斜杠」——
+    // 后者自愈 PR #160 之前翻译、整串发给 LLM 被合并掉斜杠的旧数据（eng 非空会被永久跳过）。
+    // 含 '/' 的行在下方 per-row 逻辑会走拆分/逐段翻译/重拼，重译后即带回斜杠（幂等：下次不再命中）。
+    const need = (src, eng = 'eng_name') =>
+      `(${eng} IS NULL OR ${eng} = '' OR (${src} LIKE '%/%' AND ${eng} NOT LIKE '%/%'))`;
     const batches = [
-      { table: 'MoldPart',       field: 'description', sql: `SELECT id, description FROM MoldPart       WHERE version_id=? AND ${EMPTY} ORDER BY sort_order` },
-      { table: 'HardwareItem',   field: 'name',        sql: `SELECT id, name        FROM HardwareItem   WHERE version_id=? AND ${EMPTY} ORDER BY sort_order` },
-      { table: 'PackagingItem',  field: 'name',        sql: `SELECT id, name        FROM PackagingItem  WHERE version_id=? AND ${EMPTY} ORDER BY sort_order` },
-      { table: 'PackagingItem',  field: 'remark',      engField: 'remark_eng', sql: `SELECT id, remark FROM PackagingItem WHERE version_id=? AND remark IS NOT NULL AND remark != '' AND (remark_eng IS NULL OR remark_eng = '') ORDER BY sort_order` },
-      { table: 'ElectronicItem', field: 'part_name',   sql: `SELECT id, part_name   FROM ElectronicItem WHERE version_id=? AND ${EMPTY} ORDER BY sort_order` },
-      { table: 'SewingDetail',   field: 'fabric_name', sql: `SELECT id, fabric_name FROM SewingDetail   WHERE version_id=? AND ${EMPTY} ORDER BY sort_order` },
-      { table: 'RawMaterial',    field: 'material_name', sql: `SELECT id, material_name FROM RawMaterial WHERE version_id=? AND ${EMPTY} ORDER BY sort_order` },
-      { table: 'RawMaterial',    field: 'spec',          engField: 'spec_eng', sql: `SELECT id, spec FROM RawMaterial WHERE version_id=? AND category='fabric' AND spec IS NOT NULL AND spec != '' AND (spec_eng IS NULL OR spec_eng = '') ORDER BY sort_order` },
-      { table: 'RotocastItem',   field: 'name',          sql: `SELECT id, name FROM RotocastItem WHERE version_id=? AND ${EMPTY} ORDER BY sort_order` },
-      { table: 'BodyAccessory',  field: 'description',   sql: `SELECT id, description FROM BodyAccessory WHERE version_id=? AND ${EMPTY} ORDER BY sort_order` },
+      { table: 'MoldPart',       field: 'description', sql: `SELECT id, description FROM MoldPart       WHERE version_id=? AND ${need('description')} ORDER BY sort_order` },
+      { table: 'HardwareItem',   field: 'name',        sql: `SELECT id, name        FROM HardwareItem   WHERE version_id=? AND ${need('name')} ORDER BY sort_order` },
+      { table: 'PackagingItem',  field: 'name',        sql: `SELECT id, name        FROM PackagingItem  WHERE version_id=? AND ${need('name')} ORDER BY sort_order` },
+      { table: 'PackagingItem',  field: 'remark',      engField: 'remark_eng', sql: `SELECT id, remark FROM PackagingItem WHERE version_id=? AND remark IS NOT NULL AND remark != '' AND ${need('remark', 'remark_eng')} ORDER BY sort_order` },
+      { table: 'ElectronicItem', field: 'part_name',   sql: `SELECT id, part_name   FROM ElectronicItem WHERE version_id=? AND ${need('part_name')} ORDER BY sort_order` },
+      { table: 'SewingDetail',   field: 'fabric_name', sql: `SELECT id, fabric_name FROM SewingDetail   WHERE version_id=? AND ${need('fabric_name')} ORDER BY sort_order` },
+      { table: 'RawMaterial',    field: 'material_name', sql: `SELECT id, material_name FROM RawMaterial WHERE version_id=? AND ${need('material_name')} ORDER BY sort_order` },
+      { table: 'RawMaterial',    field: 'spec',          engField: 'spec_eng', sql: `SELECT id, spec FROM RawMaterial WHERE version_id=? AND category='fabric' AND spec IS NOT NULL AND spec != '' AND ${need('spec', 'spec_eng')} ORDER BY sort_order` },
+      { table: 'RotocastItem',   field: 'name',          sql: `SELECT id, name FROM RotocastItem WHERE version_id=? AND ${need('name')} ORDER BY sort_order` },
+      { table: 'BodyAccessory',  field: 'description',   sql: `SELECT id, description FROM BodyAccessory WHERE version_id=? AND ${need('description')} ORDER BY sort_order` },
     ];
 
     // Fixed translation overrides (Chinese keyword → fixed English)


### PR DESCRIPTION
## 问题
中文用 `/` 分隔多部件的名称（如「车头盖/车顶盖」「按制左/按制右/沙板」），英文翻译应同样用 `/` 分隔。但报价系统里部分英文丢了斜杠合并成一句（「Front Hood Roof Panel」「Left Hand Mold Right Hand Mold Sand Board」）。

## 根因
PR #160 加了「拆分 → 逐段翻译 → 用 `/` 重拼」的斜杠保留逻辑，但 `translate-all` 只翻译 `eng_name IS NULL OR = ''` 的行。**#160 部署前**已翻译并存入 eng_name 的旧数据（整串发 LLM 被合并掉斜杠）因 eng 非空被永久跳过，无法自愈。云端实测 v113/118/119 共 **18 条**（MoldPart/BodyAccessory/HardwareItem）。

## 改动
仅 `server/routes/versions.js`：翻译筛选条件从「eng 为空」扩展为
```
eng 为空  OR  (中文字段含 '/' AND eng 不含 '/')
```
命中即用已有 #160 拆分逻辑重译，带回斜杠。**幂等**（重译后 eng 含 '/'，下次不命中）；已带斜杠的（含旧的带空格 ` / `）不受影响。用户点「翻译」即自愈。

## 备注
baojia Dockerfile 已用阿里云 alpine 镜像（line 4），部署无 apk 卡顿风险。合并部署后我会在受影响版本跑一次翻译并复核。

🤖 Generated with [Claude Code](https://claude.com/claude-code)