### PR TITLE
fix(peise): OCR 模型 qwen-vl-max-latest -> qwen-vl-max,修复 403 拒绝访问

### DIFF
--- a/apps/PMC跟仓管/配色库存管理/.env.example
+++ b/apps/PMC跟仓管/配色库存管理/.env.example
@@ -10,7 +10,8 @@ BAILIAN_API_KEY=
 BAILIAN_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
 
 # 必填: 通义千问多模态模型
-BAILIAN_MODEL=qwen-vl-max-latest
+# 注意: 不要用 -latest 别名(如 qwen-vl-max-latest), 阿里云已关闭其访问权限, 会报 403
+BAILIAN_MODEL=qwen-vl-max
 
 # 登录(单密码模式)
 # AUTH_USERNAME / AUTH_PASSWORD 必填,否则启动报错

--- a/apps/PMC跟仓管/配色库存管理/app/services/ocr_llm.py
+++ b/apps/PMC跟仓管/配色库存管理/app/services/ocr_llm.py
@@ -5,7 +5,8 @@
 环境变量:
   BAILIAN_API_KEY     必填, 阿里云百炼 API key
                        (https://bailian.console.aliyun.com/?tab=model#/api-key)
-  BAILIAN_MODEL       可选, 默认 qwen-vl-max-latest
+  BAILIAN_MODEL       可选, 默认 qwen-vl-max
+                       (不要用 -latest 别名, 阿里云已对其关闭访问权限, 会报 403)
   BAILIAN_BASE_URL    可选, 默认 https://dashscope.aliyuncs.com/compatible-mode/v1
 """
 from __future__ import annotations
@@ -18,7 +19,7 @@ import re
 import requests
 
 DEFAULT_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
-DEFAULT_MODEL = "qwen-vl-max-latest"
+DEFAULT_MODEL = "qwen-vl-max"
 
 SYSTEM_PROMPT = """你是一个送货单/出入库单识别助手。
 给你一张图片,请只返回 JSON 数组,格式:

--- a/docker-compose.cloud.yml
+++ b/docker-compose.cloud.yml
@@ -526,7 +526,8 @@ services:
       - TZ=Asia/Shanghai
       # OCR 走阿里云百炼 (Bailian) OpenAI 兼容端点 + 通义千问 VL
       - BAILIAN_API_KEY=${PEISE_BAILIAN_API_KEY:-}
-      - BAILIAN_MODEL=${PEISE_BAILIAN_MODEL:-qwen-vl-max-latest}
+      # 注意: 阿里云已关闭 -latest 别名模型的访问权限(403 access_denied), 必须用稳定版模型名
+      - BAILIAN_MODEL=${PEISE_BAILIAN_MODEL:-qwen-vl-max}
       - BAILIAN_BASE_URL=${PEISE_BAILIAN_BASE_URL:-https://dashscope.aliyuncs.com/compatible-mode/v1}
       # 登录凭据(默认 ps/ps123456,改要改 .env.cloud 的 PEISE_AUTH_*)
       # SECRET_KEY 不传,app 会在 instance/.secret_key 自建并持久化


### PR DESCRIPTION
## 问题

配色库存管理的出库/入库拍照识别 (OCR) 功能不可用。

## 根因

阿里云百炼已关闭 `-latest` 别名模型的访问权限,当前配置的 `qwen-vl-max-latest` 调用返回 **HTTP 403 access_denied**。

API key 与账户本身正常:

| 模型 | 状态 |
|------|------|
| qwen-vl-max-latest (当前配置) | 403 拒绝 |
| qwen-vl-max (稳定版) | 正常 |
| qwen3-vl-plus | 正常 |

已用真实图片验证 qwen-vl-max 识别结果正确。

## 改动

- docker-compose.cloud.yml: peise 的 BAILIAN_MODEL 默认值改为 qwen-vl-max (**生产环境生效的关键改动**)
- app/services/ocr_llm.py: DEFAULT_MODEL 改为 qwen-vl-max
- .env.example: 同步文档

## 测试

- peise pytest: 10 passed,5 个 pre-existing 失败 (旧路由测试未适配登录功能,与本改动无关,改动前后失败一致)

🤖 Generated with [Claude Code](https://claude.com/claude-code)