### PR TITLE
fix(hy-schedule): 前端补充「全部清空」按钮

### DIFF
--- a/apps/业务部/ZURU河源排期入单/templates/hy_master.html
+++ b/apps/业务部/ZURU河源排期入单/templates/hy_master.html
@@ -394,6 +394,9 @@
             <button class="btn btn-outline-info btn-sm py-1" style="font-size:0.78rem;white-space:nowrap;" onclick="rescan()">
                 <i class="bi bi-arrow-clockwise"></i> 重建
             </button>
+            <button class="btn btn-outline-danger btn-sm py-1" style="font-size:0.78rem;white-space:nowrap;" onclick="deleteAllSchedules()">
+                <i class="bi bi-trash"></i> 全部清空
+            </button>
         </div>
 
         <div class="card mt-2" id="scheduleDropZone"
@@ -611,8 +614,22 @@ async function deleteSchedule(filename) {
         });
         const data = await r.json();
         if (data.ok) checkStatus();
-        else showError('删除失败: ' + (data.error || ''));
-    } catch (e) { showError('删除失败: ' + e.message); }
+        else { showError('删除失败: ' + (data.error || '')); checkStatus(); }
+    } catch (e) { showError('删除失败: ' + e.message); checkStatus(); }
+}
+
+async function deleteAllSchedules() {
+    if (!confirm('确定清空所有排期文件？此操作不可撤销！')) return;
+    setProcessing(true, '正在清空排期文件...');
+    try {
+        const r = await fetch('api/hy-delete-all-schedules', {
+            method: 'POST', headers: {'X-CSRF-Token': getCsrfToken()}
+        });
+        const data = await r.json();
+        if (data.ok) checkStatus();
+        else showError('清空失败: ' + (data.error || ''));
+    } catch (e) { showError('清空失败: ' + e.message); }
+    finally { setProcessing(false); }
 }
 
 async function rescan() {


### PR DESCRIPTION
## Summary
- PR#177 遗漏了前端模板同步，服务器版缺少「全部清空」按钮
- 添加「全部清空」按钮 HTML + `deleteAllSchedules()` JS 函数
- `deleteSchedule` 失败时也刷新状态（`checkStatus` 回调）

## Test plan
- [ ] 页面显示「全部清空」按钮
- [ ] 点击全部清空后排期文件清零、映射表清零
- [ ] 删除单个文件失败时页面状态正确刷新

🤖 Generated with [Claude Code](https://claude.com/claude-code)