### PR TITLE
fix(deploy): --remove-orphans 清除 internal-quote 孤儿容器 (修全站 OOM)

### DIFF
--- a/deploy/update-server.sh
+++ b/deploy/update-server.sh
@@ -290,7 +290,9 @@ if [[ "$COMPOSE_CHANGED" -eq 1 ]]; then
   # 策略：先 up -d（无 --build），让 docker 用现有 image 只 recreate 容器
   # 这样纯 rename 几乎零成本；如果有新服务或 Dockerfile 变了再用 AFFECTED_SERVICES 做增量 build
   echo "  [COMPOSE] Compose 变动，recreate 容器（不强制 rebuild，避免 OOM 风险）"
-  docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" up -d
+  # --remove-orphans: 删除已从 compose 移除的服务遗留的孤儿容器，
+  # 否则被下线/重命名的服务容器会继续运行（crash-loop 时甚至拖垮内存导致全站 OOM）
+  docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" up -d --remove-orphans
   # 还要 rebuild 那些真的动了源码的服务（incremental）
   for svc in "${AFFECTED_SERVICES[@]}"; do
     echo "  [INCR] Rebuilding $svc (--no-deps)..."

--- a/docker-compose.cloud.yml
+++ b/docker-compose.cloud.yml
@@ -3,6 +3,7 @@
 #
 # Includes: core + db + redis + nginx + rr-production
 # Excludes: 3D打印 (hardware), schedule-system (SMB/Windows), zuru-ma (deferred), indonesia-export (deleted)
+# 2026-06-16: 触发 COMPOSE_CHANGED 走 --remove-orphans 路径，清除 internal-quote (#181) 遗留孤儿容器
 
 services:
   # ──────────────────────────────────────


### PR DESCRIPTION
全站宕机根因：#182 revert 把 internal-quote 从 compose 移除了，但 update-server.sh 的 `docker compose up -d` 缺 `--remove-orphans`，孤儿容器 `rr-portal-internal-quote-1` 仍在 crash-loop，拖垮内存 → nginx 反复被 OOM kill。

本 PR 给 COMPOSE_CHANGED 路径加 `--remove-orphans`，并 touch compose 触发该路径，本次部署即清除孤儿、恢复全站。

🤖 Generated with [Claude Code](https://claude.com/claude-code)