### PR TITLE
feat(业务部): 内部报价系统 (internal-quote) 重新上线 — 启动加固版

### DIFF
--- a/.env.cloud
+++ b/.env.cloud
@@ -35,6 +35,8 @@ ALLOWED_ORIGINS=                # REQUIRED: actual domain, e.g. https://portal.e
 FIGURE_MOLD_JWT_SECRET=         # REQUIRED: figure-mold-cost-system JWT signing key
 ZOUHUO_JWT_SECRET=              # REQUIRED: zouhuo JWT signing key
 JIANGPING_SECRET_KEY=           # REQUIRED: jiangping Flask session secret key
+INTERNAL_QUOTE_SESSION_SECRET=  # REQUIRED: internal-quote 会话密钥 (cookie-session)
+INTERNAL_QUOTE_ADMIN_PASSWORD=  # OPTIONAL: 首次启动 admin 初始密码；留空则随机生成(见容器日志)
 
 # ─── Per-Service CORS ───
 ZOUHUO_CORS_ORIGIN=             # REQUIRED: e.g. https://portal.example.com (never use *)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,8 @@ RR-Portal/
 │   │   ├── ZURU接单表入单系统/      — zuru-order-system (Flask)
 │   │   ├── ZURU总排期入单/          — zuru-master-schedule (Flask)
 │   │   ├── 报价系统/                — baojia (Node.js, SPIN/TOMY 供应商报价)
-│   │   └── TOMY排期核对系统/        — tomy-paiqi (Node.js + React)
+│   │   ├── TOMY排期核对系统/        — tomy-paiqi (Node.js + React)
+│   │   └── 内部报价系统/            — internal-quote (Node.js + node:sqlite, 多部门分工报价)
 │   ├── QA部/
 │   │   └── QA测试报告周结系统/      — qa-weekly-report (Node.js + React + exceljs)
 │   └── task-api/                  — 任务 API (Node.js，仅本地 compose，无部门)
@@ -209,6 +210,7 @@ curl http://localhost:<port>/health
 | hy-schedule-system ZURU河源排期入单 | Flask | 5008 | /hy-schedule/ |
 | baojia 报价系统 | Node.js | 3007 | /baojia/ |
 | qa-weekly-report QA测试报告周结系统 | Node.js/React | 3210 | /qa-weekly-report/ |
+| internal-quote 内部报价系统 | Node.js | 3211 | /internal-quote/ |
 
 ## 插件类型
 
@@ -460,6 +462,7 @@ const data = JSON.parse(fs.readFileSync('data/data.json'));
 | hy-schedule-system | ZURU河源排期入单 | 业务部 | Standalone (Python/Flask) | /hy-schedule/ | https://github.com/hanson678/hy-schedule-system |
 | baojia | 报价系统 | 业务部 | Standalone (Node.js) | /baojia/ | — |
 | qa-weekly-report | QA测试报告周结系统 | QA部 | Standalone (Node.js/React + exceljs) | /qa-weekly-report/ | — |
+| internal-quote | 内部报价系统 | 业务部 | Standalone (Node.js + node:sqlite) | /internal-quote/ | — |
 
 ### 旧插件（已删除）
 

--- a/apps/业务部/内部报价系统/.dockerignore
+++ b/apps/业务部/内部报价系统/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+npm-debug.log
+.git
+.gitignore
+backend/data
+backend/data.db
+backend/data.db-shm
+backend/data.db-wal
+backend/uploads
+README.md

--- a/apps/业务部/内部报价系统/.gitignore
+++ b/apps/业务部/内部报价系统/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+backend/data/
+backend/data.db
+backend/data.db-shm
+backend/data.db-wal
+backend/uploads/
+*.log
+.env

--- a/apps/业务部/内部报价系统/Dockerfile
+++ b/apps/业务部/内部报价系统/Dockerfile
@@ -1,0 +1,27 @@
+# 内部报价系统 — RR-Portal app
+# Node/Express + node:sqlite（内置，需 Node 22.5+；无需 better-sqlite3 编译）
+FROM node:22-alpine
+
+# 阿里云 Alpine + npm 镜像（国内 ECS 加速）
+RUN sed -i 's|https\?://dl-cdn.alpinelinux.org|https://mirrors.aliyun.com|g' /etc/apk/repositories
+RUN npm config set registry https://registry.npmmirror.com
+
+WORKDIR /app
+
+ENV NODE_ENV=production \
+    PORT=3210 \
+    DB_FILE=/app/backend/data/data.db \
+    TZ=Asia/Shanghai
+
+# 先装依赖利用 layer cache（依赖全是纯 JS，无需编译工具）
+COPY package.json ./
+RUN npm install --omit=dev --no-audit --no-fund
+
+COPY backend ./backend
+COPY frontend ./frontend
+
+# 数据库目录 + 上传目录（部署时 bind-mount 持久化这两个目录）
+RUN mkdir -p /app/backend/data /app/backend/uploads
+
+EXPOSE 3210
+CMD ["node", "backend/server.js"]

--- a/apps/业务部/内部报价系统/Dockerfile
+++ b/apps/业务部/内部报价系统/Dockerfile
@@ -1,6 +1,8 @@
 # 内部报价系统 — RR-Portal app
-# Node/Express + node:sqlite（内置，需 Node 22.5+；无需 better-sqlite3 编译）
-FROM node:22-alpine
+# Node/Express + node:sqlite（内置，无需 better-sqlite3 编译）
+# 用 node:24-alpine（现行 LTS）：node:sqlite 已转正、无需 --experimental-sqlite flag，
+# 与本地验证通过的环境一致。22.x 上 node:sqlite 行为有差异，曾导致容器启动崩溃。
+FROM node:24-alpine
 
 # 阿里云 Alpine + npm 镜像（国内 ECS 加速）
 RUN sed -i 's|https\?://dl-cdn.alpinelinux.org|https://mirrors.aliyun.com|g' /etc/apk/repositories

--- a/apps/业务部/内部报价系统/Dockerfile
+++ b/apps/业务部/内部报价系统/Dockerfile
@@ -9,7 +9,7 @@ RUN npm config set registry https://registry.npmmirror.com
 WORKDIR /app
 
 ENV NODE_ENV=production \
-    PORT=3210 \
+    PORT=3211 \
     DB_FILE=/app/backend/data/data.db \
     TZ=Asia/Shanghai
 
@@ -23,5 +23,5 @@ COPY frontend ./frontend
 # 数据库目录 + 上传目录（部署时 bind-mount 持久化这两个目录）
 RUN mkdir -p /app/backend/data /app/backend/uploads
 
-EXPOSE 3210
+EXPOSE 3211
 CMD ["node", "backend/server.js"]

--- a/apps/业务部/内部报价系统/README.md
+++ b/apps/业务部/内部报价系统/README.md
@@ -5,12 +5,16 @@
 - **技术栈**: Node.js + Express，`node:sqlite`（内置，需 Node 22.5+），cookie-session 鉴权，ExcelJS 导出
 - **自包含**: 不依赖 core/FastAPI，自带 SQLite 库与登录（与 `报价系统/baojia` 同类自包含 Node 应用）
 
-## 本 PR 范围
-仅新增本 app 文件夹。**未**接入 `docker-compose.cloud.yml` / nginx / 门户入口，需后续接线 PR 完成上线。
+## 接线状态（本 PR 已完成）
+- ✅ `docker-compose.cloud.yml`: service `internal-quote`（bind-mount `backend/data` + `backend/uploads`，healthcheck `/health`）
+- ✅ `nginx/nginx.cloud.conf`: 路由 `/internal-quote/`（api/静态/health，子路径前缀重写）
+- ✅ `frontend/index.cloud.html`: 门户磁贴 + 详情卡 + 状态点
+- ✅ `.env.cloud`: `INTERNAL_QUOTE_SESSION_SECRET`（必填）/ `INTERNAL_QUOTE_ADMIN_PASSWORD`（可选）
+- ✅ 前端已做子路径适配（fetch 前缀 shim + 图片相对路径），`/internal-quote/` 与根路径都能跑
 
-## 接线建议（给后续 PR / 维护者）
+## 关键参数
 - **service 名**: `internal-quote`（容器/DNS/nginx upstream 用，保持不变）
-- **URL 路径**: 建议 `/internal-quote/`
+- **URL 路径**: `/internal-quote/`
 - **端口**: 容器内 `3210`（`PORT` 可改）
 - **持久化（bind-mount 两个目录）**:
   - `backend/data/`  — SQLite 数据库（`DB_FILE=/app/backend/data/data.db`）

--- a/apps/业务部/内部报价系统/README.md
+++ b/apps/业务部/内部报价系统/README.md
@@ -15,7 +15,7 @@
 ## 关键参数
 - **service 名**: `internal-quote`（容器/DNS/nginx upstream 用，保持不变）
 - **URL 路径**: `/internal-quote/`
-- **端口**: 容器内 `3210`（`PORT` 可改）
+- **端口**: 容器内 `3211`（`PORT` 可改）
 - **持久化（bind-mount 两个目录）**:
   - `backend/data/`  — SQLite 数据库（`DB_FILE=/app/backend/data/data.db`）
   - `backend/uploads/` — 上传的模具图
@@ -28,5 +28,5 @@
 ## 本地运行
 ```bash
 npm install
-npm run dev   # node --watch backend/server.js → http://localhost:3210
+npm run dev   # node --watch backend/server.js → http://localhost:3211
 ```

--- a/apps/业务部/内部报价系统/README.md
+++ b/apps/业务部/内部报价系统/README.md
@@ -1,0 +1,28 @@
+# 内部报价系统 (internal-quote)
+
+公司内部报价明细系统 — 多部门分工填写（业务/工程/电子/啤机/喷油/搪胶/车缝/装配）+ 主管审核 + 受控导出 xlsx。
+
+- **技术栈**: Node.js + Express，`node:sqlite`（内置，需 Node 22.5+），cookie-session 鉴权，ExcelJS 导出
+- **自包含**: 不依赖 core/FastAPI，自带 SQLite 库与登录（与 `报价系统/baojia` 同类自包含 Node 应用）
+
+## 本 PR 范围
+仅新增本 app 文件夹。**未**接入 `docker-compose.cloud.yml` / nginx / 门户入口，需后续接线 PR 完成上线。
+
+## 接线建议（给后续 PR / 维护者）
+- **service 名**: `internal-quote`（容器/DNS/nginx upstream 用，保持不变）
+- **URL 路径**: 建议 `/internal-quote/`
+- **端口**: 容器内 `3210`（`PORT` 可改）
+- **持久化（bind-mount 两个目录）**:
+  - `backend/data/`  — SQLite 数据库（`DB_FILE=/app/backend/data/data.db`）
+  - `backend/uploads/` — 上传的模具图
+- **环境变量**:
+  - `SESSION_SECRET`（必填，生产随机长串）
+  - `ADMIN_INITIAL_PASSWORD`（可选；不设则首启随机生成并打印在日志）
+  - `NODE_ENV=production`（已在 Dockerfile 设置，启用 secure cookie；app 已 `trust proxy`）
+- 首次启动自动建库种子：创建 `admin` 账号 + 各部门初始 PIN（见容器日志），登录后请立即改密。
+
+## 本地运行
+```bash
+npm install
+npm run dev   # node --watch backend/server.js → http://localhost:3210
+```

--- a/apps/业务部/内部报价系统/backend/db/index.js
+++ b/apps/业务部/内部报价系统/backend/db/index.js
@@ -1,0 +1,152 @@
+// 使用 Node 22+ 内置的 node:sqlite，零原生编译。
+const { DatabaseSync } = require('node:sqlite');
+const path = require('path');
+const fs = require('fs');
+const bcrypt = require('bcryptjs');
+
+const DB_PATH = process.env.DB_FILE || path.join(__dirname, '..', 'data.db');
+const SCHEMA_PATH = path.join(__dirname, 'schema.sql');
+
+const db = new DatabaseSync(DB_PATH);
+db.exec('PRAGMA journal_mode = WAL');
+db.exec('PRAGMA foreign_keys = ON');
+
+db.exec(fs.readFileSync(SCHEMA_PATH, 'utf8'));
+
+// 迁移：给已有库的 quotes 补 version 列（幂等）
+const _quoteCols = db.prepare('PRAGMA table_info(quotes)').all().map(c => c.name);
+if (!_quoteCols.includes('version')) {
+  db.exec('ALTER TABLE quotes ADD COLUMN version TEXT');
+  console.log('[migrate] quotes.version 列已添加');
+}
+
+const count = db.prepare('SELECT COUNT(*) AS n FROM departments').get().n;
+if (count === 0) {
+  const seeds = [
+    { code: 'sales',       name_cn: '业务',   sort_order: 1 },
+    { code: 'engineering', name_cn: '工程',   sort_order: 2 },
+    { code: 'electronic',  name_cn: '电子部', sort_order: 3 },
+    { code: 'molding',     name_cn: '啤机部', sort_order: 4 },
+    { code: 'painting',    name_cn: '喷油部', sort_order: 5 },
+    { code: 'slush',       name_cn: '搪胶',   sort_order: 6 },
+    { code: 'sewing',      name_cn: '车缝',   sort_order: 7 },
+    { code: 'assembly',    name_cn: '装配部', sort_order: 8 },
+  ];
+  const insert = db.prepare(`
+    INSERT INTO departments (code, name_cn, sort_order, pin_staff, pin_supervisor)
+    VALUES (?, ?, ?, ?, ?)
+  `);
+  console.log('[seed] 部门初始 PIN（请抄下并修改）:');
+  for (const d of seeds) {
+    const staffPin = String(1000 + Math.floor(Math.random() * 9000));
+    const supPin   = String(1000 + Math.floor(Math.random() * 9000));
+    insert.run(d.code, d.name_cn, d.sort_order, bcrypt.hashSync(staffPin, 8), bcrypt.hashSync(supPin, 8));
+    console.log(`  ${d.name_cn.padEnd(4)} 员工 PIN=${staffPin}   主管 PIN=${supPin}`);
+  }
+}
+
+// 后续新增部门：补 row（不影响已 seed 部门）
+const upgradeDepts = [
+  { code: 'electronic', name_cn: '电子部', sort_order: 3 },
+];
+for (const d of upgradeDepts) {
+  const exists = db.prepare('SELECT 1 FROM departments WHERE code = ?').get(d.code);
+  if (!exists) {
+    const dummy = bcrypt.hashSync(String(1000 + Math.floor(Math.random() * 9000)), 8);
+    db.prepare('INSERT INTO departments (code, name_cn, sort_order, pin_staff, pin_supervisor) VALUES (?, ?, ?, ?, ?)')
+      .run(d.code, d.name_cn, d.sort_order, dummy, dummy);
+    console.log('[upgrade] 新增部门:', d.name_cn);
+  }
+}
+
+// 给所有现有报价单补缺失的 section（电子部）
+const allDeptCodes = db.prepare('SELECT code FROM departments').all().map(r => r.code);
+const quotesAll = db.prepare('SELECT id FROM quotes').all();
+for (const q of quotesAll) {
+  const have = new Set(db.prepare('SELECT dept FROM quote_sections WHERE quote_id = ?').all(q.id).map(r => r.dept));
+  for (const d of allDeptCodes) {
+    if (!have.has(d)) {
+      db.prepare('INSERT INTO quote_sections (quote_id, dept) VALUES (?, ?)').run(q.id, d);
+    }
+  }
+}
+
+// 全局参考表种入默认数据（仅首次/空时）
+const refSeeds = {
+  material_prices: [
+    { name: 'ABS', model: '750SW', price: 8.50 },
+    { name: 'C-ABS', model: 'TR558/920', price: 12.50 },
+    { name: 'HIPS', model: 'HI425', price: 7.80 },
+    { name: 'GP', model: 'MW-1', price: 7.80 },
+    { name: 'PP#JM350/K8009', model: 'JM350/K8009', price: 6.80 },
+    { name: 'PP#7032 E3', model: '7032 E3', price: 6.80 },
+    { name: 'C-PP', model: '5090T', price: 7.80 },
+    { name: 'POM', model: 'F3003/M9044', price: 16.50 },
+    { name: 'POM', model: 'PM820/DM220', price: 21.50 },
+    { name: 'C-PVC', model: '普通透明', price: 9.00 },
+    { name: 'PVC', model: '普通本白', price: 8.00 },
+    { name: 'LDPE', model: 'G812', price: 7.80 },
+    { name: 'HDPE', model: 'HMA016', price: 8.00 },
+    { name: 'TPR', model: '本白橡胶料', price: 15.00 },
+    { name: 'C-TPR', model: '透明橡胶料', price: 17.00 },
+    { name: 'K料', model: 'KR-03NW', price: 15.00 },
+    { name: 'PC料', model: '2605', price: 12.50 },
+  ],
+  machine_prices: [
+    { model: '4A-6A', normal: '80T', price: 940 },
+    { model: '7A-9A', normal: '60-80T', price: 1050 },
+    { model: '10A-12A', normal: '120T', price: 1160 },
+    { model: '14A-16A', normal: '150T', price: 1490 },
+    { model: '20A', normal: '200T', price: 1920 },
+    { model: '24A', normal: '260T', price: 1920 },
+    { model: '32A', normal: '', price: 2220 },
+    { model: '44A', normal: '490T', price: 2500 },
+    { model: '46A-49.9A', normal: '', price: 2800 },
+    { model: '60A', normal: '', price: 3090 },
+    { model: '80A', normal: '', price: 3590 },
+    { model: '81.3A', normal: '', price: 3600 },
+    { model: '105A', normal: '800T', price: 4500 },
+  ],
+};
+for (const [key, data] of Object.entries(refSeeds)) {
+  const exists = db.prepare('SELECT 1 FROM ref_tables WHERE key = ?').get(key);
+  if (!exists) {
+    db.prepare('INSERT INTO ref_tables (key, data_json, updated_by) VALUES (?, ?, ?)').run(key, JSON.stringify(data), '[seed]');
+    console.log('[seed] 全局参考表 ' + key + ' 已种入 ' + data.length + ' 条');
+  }
+}
+
+// seed 初始 admin 账号（仅 users 表为空时）
+const userCount = db.prepare('SELECT COUNT(*) AS n FROM users').get().n;
+if (userCount === 0) {
+  const { templateFor } = require('../permissions/role_templates');
+  const adminPass = process.env.ADMIN_INITIAL_PASSWORD || String(100000 + Math.floor(Math.random() * 900000));
+  const info = db.prepare(`
+    INSERT INTO users (username, password_hash, display_name, dept, role)
+    VALUES (?, ?, ?, ?, 'admin')
+  `).run('admin', bcrypt.hashSync(adminPass, 8), '超级管理员', 'sales');
+  const adminId = info.lastInsertRowid;
+  const tpl = templateFor('sales', 'admin');
+  const insertPerm = db.prepare(`
+    INSERT INTO user_perms (user_id, menu, can_view, can_edit, can_review, can_admin)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `);
+  for (const p of tpl) insertPerm.run(adminId, p.menu, p.can_view, p.can_edit, p.can_review, p.can_admin);
+  console.log('\n========================================');
+  console.log('[seed] 初始管理员账号已创建:');
+  console.log('  用户名: admin');
+  console.log('  密码:   ' + adminPass);
+  console.log('  ⚠️ 请立即登录并修改密码');
+  console.log('========================================\n');
+}
+
+// 包装：transaction(fn) 在 BEGIN/COMMIT/ROLLBACK 中运行 fn
+db.transaction = function (fn) {
+  return (...args) => {
+    db.exec('BEGIN');
+    try { const r = fn(...args); db.exec('COMMIT'); return r; }
+    catch (e) { db.exec('ROLLBACK'); throw e; }
+  };
+};
+
+module.exports = db;

--- a/apps/业务部/内部报价系统/backend/db/index.js
+++ b/apps/业务部/内部报价系统/backend/db/index.js
@@ -7,11 +7,20 @@ const bcrypt = require('bcryptjs');
 const DB_PATH = process.env.DB_FILE || path.join(__dirname, '..', 'data.db');
 const SCHEMA_PATH = path.join(__dirname, 'schema.sql');
 
-const db = new DatabaseSync(DB_PATH);
-db.exec('PRAGMA journal_mode = WAL');
-db.exec('PRAGMA foreign_keys = ON');
-
-db.exec(fs.readFileSync(SCHEMA_PATH, 'utf8'));
+// 打开 DB + schema 是最容易因环境（node:sqlite 版本 / WAL 文件系统不支持 / bind-mount 不可写）
+// 而抛错的一段。包 try/catch 打清晰 [FATAL] 日志再退出，避免静默 crash-loop 让人无从排查。
+let db;
+try {
+  db = new DatabaseSync(DB_PATH);
+  db.exec('PRAGMA journal_mode = WAL');
+  db.exec('PRAGMA foreign_keys = ON');
+  db.exec(fs.readFileSync(SCHEMA_PATH, 'utf8'));
+} catch (e) {
+  console.error('[FATAL][db-init] SQLite 初始化失败 (DB_PATH=' + DB_PATH + ')。'
+    + '排查方向：node:sqlite 版本、WAL 是否被该文件系统支持、bind-mount 目录是否可写。');
+  console.error('[FATAL][db-init]', (e && e.stack) || e);
+  process.exit(1);
+}
 
 // 迁移：给已有库的 quotes 补 version 列（幂等）
 const _quoteCols = db.prepare('PRAGMA table_info(quotes)').all().map(c => c.name);

--- a/apps/业务部/内部报价系统/backend/db/schema.sql
+++ b/apps/业务部/内部报价系统/backend/db/schema.sql
@@ -1,0 +1,99 @@
+-- 公司内部报价明细系统 schema v1
+-- 字段细节 (payload_json) 待用户提供导出模板后在 P2 阶段扩展
+
+PRAGMA foreign_keys = ON;
+
+-- 部门表：固定 5 行，启动时若空则种入默认数据
+CREATE TABLE IF NOT EXISTS departments (
+  code           TEXT PRIMARY KEY,           -- sales / engineering / molding / painting / assembly
+  name_cn        TEXT NOT NULL,
+  sort_order     INTEGER NOT NULL DEFAULT 0,
+  pin_staff      TEXT NOT NULL,              -- bcrypt hash
+  pin_supervisor TEXT NOT NULL               -- bcrypt hash
+);
+
+-- 报价单
+CREATE TABLE IF NOT EXISTS quotes (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  quote_no         TEXT UNIQUE NOT NULL,
+  product_name     TEXT NOT NULL,
+  customer         TEXT,
+  qty              INTEGER,
+  created_by_dept  TEXT NOT NULL DEFAULT 'sales',
+  created_by_name  TEXT,
+  created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+  status           TEXT NOT NULL DEFAULT 'drafting',  -- drafting / fully_approved / exported
+  version          TEXT  -- 版本标签：同一产品的不同报价版本（如 V1 / 改色版）
+);
+
+-- 每报价单 × 每部门 = 一行 section（创建报价时自动 5 行）
+CREATE TABLE IF NOT EXISTS quote_sections (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  quote_id        INTEGER NOT NULL REFERENCES quotes(id) ON DELETE CASCADE,
+  dept            TEXT    NOT NULL REFERENCES departments(code),
+  payload_json    TEXT    NOT NULL DEFAULT '{}',
+  status          TEXT    NOT NULL DEFAULT 'empty',  -- empty / filled / approved / rejected
+  filled_by       TEXT,
+  filled_at       TEXT,
+  reviewed_by     TEXT,
+  reviewed_at     TEXT,
+  review_comment  TEXT,
+  UNIQUE(quote_id, dept)
+);
+
+CREATE INDEX IF NOT EXISTS idx_sections_quote ON quote_sections(quote_id);
+CREATE INDEX IF NOT EXISTS idx_sections_dept_status ON quote_sections(dept, status);
+
+CREATE TABLE IF NOT EXISTS audit_log (
+  id        INTEGER PRIMARY KEY AUTOINCREMENT,
+  quote_id  INTEGER,
+  dept      TEXT,
+  actor     TEXT,
+  action    TEXT NOT NULL,    -- login / fill / submit / approve / reject / export
+  detail    TEXT,
+  at        TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_quote ON audit_log(quote_id);
+
+-- 全局参考表 — 单行 JSON，新报价单从这里读默认数据，编辑后写回
+CREATE TABLE IF NOT EXISTS ref_tables (
+  key        TEXT PRIMARY KEY,           -- 'material_prices' / 'machine_prices'
+  data_json  TEXT NOT NULL DEFAULT '[]',
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_by TEXT
+);
+
+-- 用户账号（替代旧的部门 PIN 登录）
+CREATE TABLE IF NOT EXISTS users (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  username      TEXT UNIQUE NOT NULL,
+  password_hash TEXT NOT NULL,
+  display_name  TEXT NOT NULL,
+  dept          TEXT NOT NULL REFERENCES departments(code),
+  role          TEXT NOT NULL DEFAULT 'staff',   -- staff / supervisor / admin
+  locked_until  TEXT,
+  login_fails   INTEGER NOT NULL DEFAULT 0,
+  last_login    TEXT,
+  created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_users_dept ON users(dept);
+
+-- 用户 × 可见客户（多对多；空表 = 看不到任何报价单；admin 不受限）
+CREATE TABLE IF NOT EXISTS user_customers (
+  user_id  INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  customer TEXT    NOT NULL,
+  PRIMARY KEY (user_id, customer)
+);
+
+-- 用户 × 菜单 × 4 位权限
+CREATE TABLE IF NOT EXISTS user_perms (
+  user_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  menu       TEXT    NOT NULL,
+  can_view   INTEGER NOT NULL DEFAULT 0,
+  can_edit   INTEGER NOT NULL DEFAULT 0,
+  can_review INTEGER NOT NULL DEFAULT 0,
+  can_admin  INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (user_id, menu)
+);

--- a/apps/业务部/内部报价系统/backend/middleware/auth.js
+++ b/apps/业务部/内部报价系统/backend/middleware/auth.js
@@ -32,4 +32,16 @@ function requireAuth(req, res, next) {
   next();
 }
 
-module.exports = { requireAuth, loadUserAndPerms };
+// 客户可见范围校验：返回 { status: 200|403|404 }
+// admin 跳过；无客户(customer 空)的单仅 admin 可访问；否则该单 customer 必须在用户 user_customers 内
+function quoteAccess(user, quoteId) {
+  const q = db.prepare('SELECT customer FROM quotes WHERE id = ?').get(quoteId);
+  if (!q) return { status: 404 };
+  const isAdmin = user.perms && user.perms['账号管理'] && user.perms['账号管理'].can_admin;
+  if (isAdmin) return { status: 200 };
+  if (!q.customer) return { status: 403 };
+  const ok = db.prepare('SELECT 1 FROM user_customers WHERE user_id = ? AND customer = ?').get(user.id, q.customer);
+  return { status: ok ? 200 : 403 };
+}
+
+module.exports = { requireAuth, loadUserAndPerms, quoteAccess };

--- a/apps/业务部/内部报价系统/backend/middleware/auth.js
+++ b/apps/业务部/内部报价系统/backend/middleware/auth.js
@@ -1,0 +1,35 @@
+const db = require('../db');
+
+// 缓存权限 1 次/请求；session 存 user_id
+function loadUserAndPerms(userId) {
+  const u = db.prepare('SELECT id, username, display_name, dept, role, locked_until FROM users WHERE id = ?').get(userId);
+  if (!u) return null;
+  const rows = db.prepare('SELECT menu, can_view, can_edit, can_review, can_admin FROM user_perms WHERE user_id = ?').all(userId);
+  const perms = {};
+  for (const r of rows) {
+    perms[r.menu] = { can_view: r.can_view, can_edit: r.can_edit, can_review: r.can_review, can_admin: r.can_admin };
+  }
+  return {
+    id: u.id, username: u.username, display_name: u.display_name,
+    dept: u.dept, role: u.role,
+    locked_until: u.locked_until, perms,
+    // 向后兼容字段（旧代码用到 name 的地方）
+    name: u.display_name || u.username,
+  };
+}
+
+function requireAuth(req, res, next) {
+  const s = req.session;
+  if (!s || !s.user_id) return res.status(401).json({ error: '未登录' });
+  const user = loadUserAndPerms(s.user_id);
+  if (!user) { req.session = null; return res.status(401).json({ error: '账号失效' }); }
+  // 锁定检查
+  if (user.locked_until && new Date(user.locked_until) > new Date()) {
+    req.session = null;
+    return res.status(403).json({ error: '账号已锁定' });
+  }
+  req.user = user;
+  next();
+}
+
+module.exports = { requireAuth, loadUserAndPerms };

--- a/apps/业务部/内部报价系统/backend/middleware/perms.js
+++ b/apps/业务部/内部报价系统/backend/middleware/perms.js
@@ -1,0 +1,21 @@
+// 权限检查中间件 / 工具
+// req.user.perms 形如 { '业务部': {can_view:1, can_edit:1, ...}, ... }
+
+function hasPerm(user, menu, action) {
+  if (!user || !user.perms) return false;
+  const p = user.perms[menu];
+  if (!p) return false;
+  return !!p['can_' + action];
+}
+
+function requirePerm(menu, action) {
+  return (req, res, next) => {
+    if (!req.user) return res.status(401).json({ error: '未登录' });
+    if (!hasPerm(req.user, menu, action)) {
+      return res.status(403).json({ error: `无 ${menu}·${action} 权限` });
+    }
+    next();
+  };
+}
+
+module.exports = { hasPerm, requirePerm };

--- a/apps/业务部/内部报价系统/backend/permissions/menu_catalog.js
+++ b/apps/业务部/内部报价系统/backend/permissions/menu_catalog.js
@@ -1,0 +1,32 @@
+// 菜单目录 — 集中维护
+// 任何新增功能/页面，对应权限菜单需在此登记
+module.exports = {
+  MENUS: [
+    { key: '报价单列表', group: '报价' },
+    { key: '报价单详情', group: '报价' },
+    { key: '业务部', group: '部门' },
+    { key: '工程部', group: '部门' },
+    { key: '电子部', group: '部门' },
+    { key: '啤机部', group: '部门' },
+    { key: '喷油部', group: '部门' },
+    { key: '搪胶', group: '部门' },
+    { key: '车缝', group: '部门' },
+    { key: '装配部', group: '部门' },
+    { key: '汇总分析', group: '高级' },
+    { key: '减税明细', group: '高级' },
+    { key: '参考表', group: '维护' },
+    { key: '出口', group: '维护' },
+    { key: '账号管理', group: '系统' },
+  ],
+  // 部门 code → 部门菜单 key
+  DEPT_TO_MENU: {
+    sales: '业务部',
+    engineering: '工程部',
+    electronic: '电子部',
+    molding: '啤机部',
+    painting: '喷油部',
+    slush: '搪胶',
+    sewing: '车缝',
+    assembly: '装配部',
+  },
+};

--- a/apps/业务部/内部报价系统/backend/permissions/role_templates.js
+++ b/apps/业务部/内部报价系统/backend/permissions/role_templates.js
@@ -1,0 +1,58 @@
+// 角色 → 默认权限模板
+// staff / supervisor / admin
+// 4 位：view / edit / review / admin
+const { MENUS, DEPT_TO_MENU } = require('./menu_catalog');
+
+// 工具：生成一条权限
+const perm = (view = 0, edit = 0, review = 0, admin = 0) => ({
+  can_view: view, can_edit: edit, can_review: review, can_admin: admin,
+});
+
+// 给定 dept、role，返回 [{menu, can_view, can_edit, can_review, can_admin}, ...]
+function templateFor(dept, role) {
+  const myDeptMenu = DEPT_TO_MENU[dept];
+  const out = [];
+  for (const m of MENUS) {
+    let p;
+    if (role === 'admin') {
+      // admin 全权
+      p = perm(1, 1, 1, 1);
+    } else if (m.key === '账号管理') {
+      // 非 admin 不能进账号管理
+      p = perm(0, 0, 0, 0);
+    } else if (m.key === '报价单列表' || m.key === '报价单详情') {
+      // 报价主页：业务/工程能 view+edit；其他部门 view+edit 自己 section
+      p = perm(1, 1, 0, 0);
+    } else if (m.key === '汇总分析' || m.key === '减税明细') {
+      // 高级：只有业务/工程能看
+      p = (dept === 'sales' || dept === 'engineering')
+        ? perm(1, role === 'supervisor' ? 1 : 1, 0, 0)
+        : perm(0, 0, 0, 0);
+    } else if (m.key === '参考表') {
+      // 参考表：业务/工程/啤机能 view+edit；其他只读
+      const canEdit = ['sales', 'engineering', 'molding'].includes(dept);
+      p = perm(1, canEdit ? 1 : 0, 0, 0);
+    } else if (m.key === '出口') {
+      // 出口（导出）：所有人 view（=能导出）
+      p = perm(1, 0, 0, 0);
+    } else if (m.group === '部门') {
+      // 部门菜单：只本部门 view+edit；本部门主管多 review
+      const isOwn = m.key === myDeptMenu;
+      const isCrossDept = (dept === 'sales' || dept === 'engineering');
+      if (isOwn) {
+        p = perm(1, 1, role === 'supervisor' ? 1 : 0, 0);
+      } else if (isCrossDept) {
+        // 业务/工程能看全部门 + 编辑全部门 + 审核全部门（主管）
+        p = perm(1, 1, role === 'supervisor' ? 1 : 0, 0);
+      } else {
+        p = perm(0, 0, 0, 0);
+      }
+    } else {
+      p = perm(0, 0, 0, 0);
+    }
+    out.push({ menu: m.key, ...p });
+  }
+  return out;
+}
+
+module.exports = { templateFor };

--- a/apps/业务部/内部报价系统/backend/routes/admin.js
+++ b/apps/业务部/内部报价系统/backend/routes/admin.js
@@ -1,0 +1,230 @@
+const express = require('express');
+const bcrypt = require('bcryptjs');
+const db = require('../db');
+const { requireAuth } = require('../middleware/auth');
+const { requirePerm } = require('../middleware/perms');
+const { MENUS } = require('../permissions/menu_catalog');
+const { templateFor } = require('../permissions/role_templates');
+
+const router = express.Router();
+router.use(requireAuth);
+router.use(requirePerm('账号管理', 'admin'));
+
+// 工具：把角色模板写入 user_perms（覆盖）
+function applyTemplate(userId, dept, role) {
+  const tpl = templateFor(dept, role);
+  db.prepare('DELETE FROM user_perms WHERE user_id = ?').run(userId);
+  const ins = db.prepare(`
+    INSERT INTO user_perms (user_id, menu, can_view, can_edit, can_review, can_admin)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `);
+  for (const p of tpl) {
+    ins.run(userId, p.menu, p.can_view, p.can_edit, p.can_review, p.can_admin);
+  }
+}
+
+// GET /api/admin/users
+router.get('/users', (req, res) => {
+  const rows = db.prepare(`
+    SELECT u.id, u.username, u.display_name, u.dept, d.name_cn AS dept_name,
+           u.role, u.locked_until, u.login_fails, u.last_login, u.created_at
+    FROM users u LEFT JOIN departments d ON d.code = u.dept
+    ORDER BY u.id
+  `).all();
+  const now = new Date();
+  const out = rows.map(r => ({ ...r, is_locked: !!(r.locked_until && new Date(r.locked_until) > now) }));
+  res.json(out);
+});
+
+// POST /api/admin/users  { username, password, display_name, dept, role }
+router.post('/users', (req, res) => {
+  const { username, password, display_name, dept, role } = req.body || {};
+  if (!username || !password || !display_name || !dept || !role) {
+    return res.status(400).json({ error: '字段缺失' });
+  }
+  if (!['staff', 'supervisor', 'admin'].includes(role)) return res.status(400).json({ error: 'role 非法' });
+  if (String(password).length < 6) return res.status(400).json({ error: '密码至少 6 位' });
+  const dept_ok = db.prepare('SELECT 1 FROM departments WHERE code = ?').get(dept);
+  if (!dept_ok) return res.status(400).json({ error: '部门不存在' });
+  const exists = db.prepare('SELECT 1 FROM users WHERE username = ?').get(String(username).trim());
+  if (exists) return res.status(409).json({ error: '用户名已存在' });
+  try {
+    const info = db.prepare(`
+      INSERT INTO users (username, password_hash, display_name, dept, role)
+      VALUES (?, ?, ?, ?, ?)
+    `).run(String(username).trim(), bcrypt.hashSync(String(password), 8),
+           String(display_name).trim().slice(0, 32), dept, role);
+    applyTemplate(info.lastInsertRowid, dept, role);
+    db.prepare(`INSERT INTO audit_log (dept, actor, action, detail) VALUES (?, ?, 'register_user', ?)`)
+      .run(dept, req.user.username, username);
+    res.json({ id: info.lastInsertRowid });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+// POST /api/admin/users/:id/reset-password  { password }
+router.post('/users/:id/reset-password', (req, res) => {
+  const id = Number(req.params.id);
+  const { password } = req.body || {};
+  if (!password || String(password).length < 6) return res.status(400).json({ error: '密码至少 6 位' });
+  const u = db.prepare('SELECT username FROM users WHERE id = ?').get(id);
+  if (!u) return res.status(404).json({ error: '不存在' });
+  db.prepare('UPDATE users SET password_hash = ?, login_fails = 0, locked_until = NULL WHERE id = ?')
+    .run(bcrypt.hashSync(String(password), 8), id);
+  db.prepare(`INSERT INTO audit_log (actor, action, detail) VALUES (?, 'reset_password', ?)`)
+    .run(req.user.username, u.username);
+  res.json({ ok: true });
+});
+
+// POST /api/admin/users/:id/lock
+router.post('/users/:id/lock', (req, res) => {
+  const id = Number(req.params.id);
+  if (id === req.user.id) return res.status(400).json({ error: '不能锁定自己' });
+  const u = db.prepare('SELECT username FROM users WHERE id = ?').get(id);
+  if (!u) return res.status(404).json({ error: '不存在' });
+  db.prepare('UPDATE users SET locked_until = ? WHERE id = ?').run('2999-12-31T00:00:00.000Z', id);
+  db.prepare(`INSERT INTO audit_log (actor, action, detail) VALUES (?, 'lock_user', ?)`)
+    .run(req.user.username, u.username);
+  res.json({ ok: true });
+});
+
+// POST /api/admin/users/:id/unlock
+router.post('/users/:id/unlock', (req, res) => {
+  const id = Number(req.params.id);
+  const u = db.prepare('SELECT username FROM users WHERE id = ?').get(id);
+  if (!u) return res.status(404).json({ error: '不存在' });
+  db.prepare('UPDATE users SET locked_until = NULL, login_fails = 0 WHERE id = ?').run(id);
+  db.prepare(`INSERT INTO audit_log (actor, action, detail) VALUES (?, 'unlock_user', ?)`)
+    .run(req.user.username, u.username);
+  res.json({ ok: true });
+});
+
+// DELETE /api/admin/users/:id
+router.delete('/users/:id', (req, res) => {
+  const id = Number(req.params.id);
+  if (id === req.user.id) return res.status(400).json({ error: '不能删除自己' });
+  const u = db.prepare('SELECT username FROM users WHERE id = ?').get(id);
+  if (!u) return res.status(404).json({ error: '不存在' });
+  db.prepare('DELETE FROM users WHERE id = ?').run(id); // user_perms 级联
+  db.prepare(`INSERT INTO audit_log (actor, action, detail) VALUES (?, 'delete_user', ?)`)
+    .run(req.user.username, u.username);
+  res.json({ ok: true });
+});
+
+// GET /api/admin/customers — 现有所有 distinct 客户
+router.get('/customers', (req, res) => {
+  const rows = db.prepare('SELECT DISTINCT customer FROM quotes WHERE customer IS NOT NULL AND customer != \'\' ORDER BY customer').all();
+  res.json({ customers: rows.map(r => r.customer) });
+});
+
+// GET /api/admin/users/:id/customers — 该用户可见客户
+router.get('/users/:id/customers', (req, res) => {
+  const id = Number(req.params.id);
+  const u = db.prepare('SELECT 1 FROM users WHERE id = ?').get(id);
+  if (!u) return res.status(404).json({ error: '不存在' });
+  const rows = db.prepare('SELECT customer FROM user_customers WHERE user_id = ? ORDER BY customer').all(id);
+  res.json({ customers: rows.map(r => r.customer) });
+});
+
+// PUT /api/admin/users/:id/customers  { customers: [...] }
+router.put('/users/:id/customers', (req, res) => {
+  const id = Number(req.params.id);
+  const u = db.prepare('SELECT username FROM users WHERE id = ?').get(id);
+  if (!u) return res.status(404).json({ error: '不存在' });
+  const list = Array.isArray(req.body && req.body.customers) ? req.body.customers : [];
+  const clean = [...new Set(list.map(x => String(x || '').trim()).filter(Boolean))];
+  db.exec('BEGIN');
+  try {
+    db.prepare('DELETE FROM user_customers WHERE user_id = ?').run(id);
+    const ins = db.prepare('INSERT INTO user_customers (user_id, customer) VALUES (?, ?)');
+    for (const c of clean) ins.run(id, c);
+    db.exec('COMMIT');
+  } catch (e) {
+    db.exec('ROLLBACK');
+    return res.status(500).json({ error: e.message });
+  }
+  db.prepare(`INSERT INTO audit_log (actor, action, detail) VALUES (?, 'save_user_customers', ?)`)
+    .run(req.user.username, u.username + ' → ' + clean.length + ' 客户');
+  res.json({ ok: true });
+});
+
+// GET /api/admin/menus  — 菜单目录（前端权限矩阵渲染用，下期）
+router.get('/menus', (req, res) => {
+  res.json({ menus: MENUS });
+});
+
+// GET /api/admin/users/:id/perms  — 当前权限矩阵（14 个菜单全列出）
+router.get('/users/:id/perms', (req, res) => {
+  const id = Number(req.params.id);
+  const u = db.prepare('SELECT username FROM users WHERE id = ?').get(id);
+  if (!u) return res.status(404).json({ error: '不存在' });
+  const rows = db.prepare('SELECT menu, can_view, can_edit, can_review, can_admin FROM user_perms WHERE user_id = ?').all(id);
+  const map = {};
+  for (const r of rows) map[r.menu] = r;
+  const out = MENUS.map(m => ({
+    menu: m.key,
+    group: m.group,
+    can_view:   map[m.key] ? map[m.key].can_view   : 0,
+    can_edit:   map[m.key] ? map[m.key].can_edit   : 0,
+    can_review: map[m.key] ? map[m.key].can_review : 0,
+    can_admin:  map[m.key] ? map[m.key].can_admin  : 0,
+  }));
+  res.json({ user_id: id, username: u.username, perms: out });
+});
+
+// PUT /api/admin/users/:id/perms  { perms: [{menu, can_view, can_edit, can_review, can_admin}] }
+router.put('/users/:id/perms', (req, res) => {
+  const id = Number(req.params.id);
+  const u = db.prepare('SELECT username FROM users WHERE id = ?').get(id);
+  if (!u) return res.status(404).json({ error: '不存在' });
+  const list = (req.body && req.body.perms) || [];
+  if (!Array.isArray(list)) return res.status(400).json({ error: 'perms 必须是数组' });
+
+  // 自我保护：不能去掉自己「账号管理·管理」位
+  if (id === req.user.id) {
+    const adminRow = list.find(r => r.menu === '账号管理');
+    if (!adminRow || !adminRow.can_admin) {
+      return res.status(400).json({ error: '不能去掉自己「账号管理·管理」权限' });
+    }
+  }
+
+  const valid = new Set(MENUS.map(m => m.key));
+  db.exec('BEGIN');
+  try {
+    db.prepare('DELETE FROM user_perms WHERE user_id = ?').run(id);
+    const ins = db.prepare(`
+      INSERT INTO user_perms (user_id, menu, can_view, can_edit, can_review, can_admin)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `);
+    for (const r of list) {
+      if (!valid.has(r.menu)) continue;
+      const v = r.can_view ? 1 : 0;
+      const e = r.can_edit ? 1 : 0;
+      const rv = r.can_review ? 1 : 0;
+      const ad = r.can_admin ? 1 : 0;
+      if (v || e || rv || ad) ins.run(id, r.menu, v, e, rv, ad);
+    }
+    db.exec('COMMIT');
+  } catch (err) {
+    db.exec('ROLLBACK');
+    return res.status(500).json({ error: err.message });
+  }
+  db.prepare(`INSERT INTO audit_log (actor, action, detail) VALUES (?, 'save_user_perms', ?)`)
+    .run(req.user.username, u.username);
+  res.json({ ok: true });
+});
+
+// 重新套角色模板（部门/角色变了之后）
+// POST /api/admin/users/:id/apply-template
+router.post('/users/:id/apply-template', (req, res) => {
+  const id = Number(req.params.id);
+  const u = db.prepare('SELECT dept, role, username FROM users WHERE id = ?').get(id);
+  if (!u) return res.status(404).json({ error: '不存在' });
+  applyTemplate(id, u.dept, u.role);
+  db.prepare(`INSERT INTO audit_log (actor, action, detail) VALUES (?, 'apply_template', ?)`)
+    .run(req.user.username, u.username);
+  res.json({ ok: true });
+});
+
+module.exports = router;

--- a/apps/业务部/内部报价系统/backend/routes/auth.js
+++ b/apps/业务部/内部报价系统/backend/routes/auth.js
@@ -1,0 +1,88 @@
+const express = require('express');
+const bcrypt = require('bcryptjs');
+const db = require('../db');
+const { loadUserAndPerms } = require('../middleware/auth');
+
+const router = express.Router();
+
+const MAX_FAILS = 5;
+const LOCK_MIN = 15;
+
+// POST /api/auth/login  { username, password }
+router.post('/login', (req, res) => {
+  const { username, password } = req.body || {};
+  if (!username || !password) return res.status(400).json({ error: '缺少用户名或密码' });
+  const u = db.prepare('SELECT * FROM users WHERE username = ?').get(String(username).trim());
+  if (!u) return res.status(401).json({ error: '用户名或密码错误' });
+
+  // 锁定检查
+  if (u.locked_until && new Date(u.locked_until) > new Date()) {
+    return res.status(403).json({ error: '账号已锁定，请联系管理员或稍后重试' });
+  }
+  if (!bcrypt.compareSync(String(password), u.password_hash)) {
+    const fails = (u.login_fails || 0) + 1;
+    let lockUntil = null;
+    if (fails >= MAX_FAILS) {
+      lockUntil = new Date(Date.now() + LOCK_MIN * 60 * 1000).toISOString();
+    }
+    db.prepare('UPDATE users SET login_fails = ?, locked_until = ? WHERE id = ?')
+      .run(fails, lockUntil, u.id);
+    return res.status(401).json({ error: '用户名或密码错误' });
+  }
+
+  // 成功
+  db.prepare('UPDATE users SET login_fails = 0, last_login = datetime(\'now\') WHERE id = ?').run(u.id);
+  req.session.user_id = u.id;
+
+  db.prepare(`INSERT INTO audit_log (dept, actor, action, detail) VALUES (?, ?, 'login', ?)`)
+    .run(u.dept, u.username, u.role);
+
+  const me = loadUserAndPerms(u.id);
+  const deptRow = db.prepare('SELECT name_cn FROM departments WHERE code = ?').get(u.dept);
+  res.json({
+    id: me.id, username: me.username, display_name: me.display_name,
+    dept: me.dept, dept_name: deptRow ? deptRow.name_cn : me.dept,
+    role: me.role, perms: me.perms,
+  });
+});
+
+router.post('/logout', (req, res) => {
+  req.session = null;
+  res.json({ ok: true });
+});
+
+router.get('/me', (req, res) => {
+  const s = req.session;
+  if (!s || !s.user_id) return res.status(401).json({ error: '未登录' });
+  const me = loadUserAndPerms(s.user_id);
+  if (!me) { req.session = null; return res.status(401).json({ error: '账号失效' }); }
+  if (me.locked_until && new Date(me.locked_until) > new Date()) {
+    req.session = null;
+    return res.status(403).json({ error: '账号已锁定' });
+  }
+  const deptRow = db.prepare('SELECT name_cn FROM departments WHERE code = ?').get(me.dept);
+  res.json({
+    id: me.id, username: me.username, display_name: me.display_name,
+    dept: me.dept, dept_name: deptRow ? deptRow.name_cn : me.dept,
+    role: me.role, perms: me.perms,
+  });
+});
+
+// POST /api/auth/change-password  { current, new }
+router.post('/change-password', (req, res) => {
+  const s = req.session;
+  if (!s || !s.user_id) return res.status(401).json({ error: '未登录' });
+  const { current, new: newPwd } = req.body || {};
+  if (!current || !newPwd) return res.status(400).json({ error: '缺少 current 或 new' });
+  if (String(newPwd).length < 6) return res.status(400).json({ error: '新密码至少 6 位' });
+  const u = db.prepare('SELECT * FROM users WHERE id = ?').get(s.user_id);
+  if (!u) return res.status(404).json({ error: '账号不存在' });
+  if (!bcrypt.compareSync(String(current), u.password_hash)) {
+    return res.status(401).json({ error: '当前密码错误' });
+  }
+  db.prepare('UPDATE users SET password_hash = ? WHERE id = ?')
+    .run(bcrypt.hashSync(String(newPwd), 8), u.id);
+  res.json({ ok: true });
+});
+
+module.exports = router;

--- a/apps/业务部/内部报价系统/backend/routes/export.js
+++ b/apps/业务部/内部报价系统/backend/routes/export.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const db = require('../db');
-const { requireAuth } = require('../middleware/auth');
+const { requireAuth, quoteAccess } = require('../middleware/auth');
 const { buildWorkbook } = require('../services/exportXlsx');
 
 const router = express.Router();
@@ -11,6 +11,9 @@ router.get('/:id/export', async (req, res) => {
   const id = Number(req.params.id);
   const quote = db.prepare('SELECT * FROM quotes WHERE id = ?').get(id);
   if (!quote) return res.status(404).json({ error: '不存在' });
+  // 客户可见范围校验
+  const acc = quoteAccess(req.user, id);
+  if (acc.status !== 200) return res.status(acc.status).json({ error: acc.status === 404 ? '不存在' : '无权导出该客户的报价单' });
 
   const approvedCount = db.prepare(
     `SELECT COUNT(*) AS n FROM quote_sections WHERE quote_id = ? AND status = 'approved'`

--- a/apps/业务部/内部报价系统/backend/routes/export.js
+++ b/apps/业务部/内部报价系统/backend/routes/export.js
@@ -1,0 +1,45 @@
+const express = require('express');
+const db = require('../db');
+const { requireAuth } = require('../middleware/auth');
+const { buildWorkbook } = require('../services/exportXlsx');
+
+const router = express.Router();
+router.use(requireAuth);
+
+// GET /api/quotes/:id/export  — 5/5 通过才放行；返回 xlsx 文件
+router.get('/:id/export', async (req, res) => {
+  const id = Number(req.params.id);
+  const quote = db.prepare('SELECT * FROM quotes WHERE id = ?').get(id);
+  if (!quote) return res.status(404).json({ error: '不存在' });
+
+  const approvedCount = db.prepare(
+    `SELECT COUNT(*) AS n FROM quote_sections WHERE quote_id = ? AND status = 'approved'`
+  ).get(id).n;
+  const totalDepts = db.prepare('SELECT COUNT(*) AS n FROM departments').get().n;
+  if (approvedCount < totalDepts) {
+    return res.status(409).json({ error: `尚有 ${totalDepts - approvedCount} 个部门未审核通过` });
+  }
+
+  const sections = db.prepare(
+    `SELECT s.dept, d.name_cn, s.payload_json, s.reviewed_by, s.reviewed_at
+     FROM quote_sections s JOIN departments d ON d.code = s.dept
+     WHERE s.quote_id = ? ORDER BY d.sort_order`
+  ).all(id);
+
+  db.prepare(`INSERT INTO audit_log (quote_id, actor, action) VALUES (?, ?, 'export')`)
+    .run(id, req.user.name);
+
+  try {
+    const wb = await buildWorkbook({ quote, sections });
+    const buf = await wb.xlsx.writeBuffer();
+    const filename = encodeURIComponent(`${quote.quote_no || quote.id}_内部报价明细.xlsx`);
+    res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"; filename*=UTF-8''${filename}`);
+    res.send(Buffer.from(buf));
+  } catch (e) {
+    console.error('[export]', e);
+    res.status(500).json({ error: '导出失败: ' + e.message });
+  }
+});
+
+module.exports = router;

--- a/apps/业务部/内部报价系统/backend/routes/quotes.js
+++ b/apps/业务部/内部报价系统/backend/routes/quotes.js
@@ -1,0 +1,205 @@
+const express = require('express');
+const db = require('../db');
+const { requireAuth } = require('../middleware/auth');
+
+const router = express.Router();
+router.use(requireAuth);
+
+const DEPT_CODES = ['sales', 'engineering', 'electronic', 'molding', 'painting', 'slush', 'sewing', 'assembly'];
+
+// GET /api/quotes  报价单列表（按 user_customers 过滤；admin 看全部）
+router.get('/', (req, res) => {
+  const isAdmin = req.user.perms && req.user.perms['账号管理'] && req.user.perms['账号管理'].can_admin;
+  const totalDepts = db.prepare('SELECT COUNT(*) AS n FROM departments').get().n;
+
+  let rows;
+  if (isAdmin) {
+    rows = db.prepare(`
+      SELECT q.*,
+        (SELECT COUNT(*) FROM quote_sections s WHERE s.quote_id=q.id AND s.status='approved') AS approved_count
+      FROM quotes q
+      ORDER BY q.id DESC
+    `).all();
+  } else {
+    const customers = db.prepare('SELECT customer FROM user_customers WHERE user_id = ?').all(req.user.id).map(r => r.customer);
+    if (customers.length === 0) {
+      return res.status(403).json({ error: '请联系管理员配置可见客户' });
+    }
+    const placeholders = customers.map(() => '?').join(',');
+    rows = db.prepare(`
+      SELECT q.*,
+        (SELECT COUNT(*) FROM quote_sections s WHERE s.quote_id=q.id AND s.status='approved') AS approved_count
+      FROM quotes q
+      WHERE q.customer IN (${placeholders})
+      ORDER BY q.id DESC
+    `).all(...customers);
+  }
+  res.json(rows.map(r => ({ ...r, total_depts: totalDepts })));
+});
+
+// POST /api/quotes  仅业务可建
+router.post('/', (req, res) => {
+  if (req.user.dept !== 'sales') return res.status(403).json({ error: '只有业务可以创建报价单' });
+  const { quote_no, product_name, customer, qty, version } = req.body || {};
+  if (!quote_no || !product_name) return res.status(400).json({ error: '缺少 quote_no 或 product_name' });
+
+  const tx = db.transaction(() => {
+    const info = db.prepare(`
+      INSERT INTO quotes (quote_no, product_name, customer, qty, version, created_by_dept, created_by_name)
+      VALUES (?, ?, ?, ?, ?, 'sales', ?)
+    `).run(quote_no, product_name, customer || null, qty || null, version || null, req.user.name);
+    const id = info.lastInsertRowid;
+    const ins = db.prepare(`INSERT INTO quote_sections (quote_id, dept) VALUES (?, ?)`);
+    for (const d of DEPT_CODES) ins.run(id, d);
+    db.prepare(`INSERT INTO audit_log (quote_id, dept, actor, action) VALUES (?, 'sales', ?, 'create')`)
+      .run(id, req.user.name);
+    return id;
+  });
+
+  try {
+    const id = tx();
+    res.json({ id });
+  } catch (e) {
+    if (String(e.message).includes('UNIQUE')) return res.status(409).json({ error: '报价单号已存在' });
+    throw e;
+  }
+});
+
+// POST /api/quotes/:id/clone  复制一张报价单（含 payload，状态全 empty）
+router.post('/:id/clone', (req, res) => {
+  if (req.user.dept !== 'sales') return res.status(403).json({ error: '只有业务可以复制报价单' });
+  const srcId = Number(req.params.id);
+  const { quote_no, product_name, customer, qty, version } = req.body || {};
+  if (!quote_no) return res.status(400).json({ error: '缺少 quote_no' });
+  const src = db.prepare('SELECT * FROM quotes WHERE id = ?').get(srcId);
+  if (!src) return res.status(404).json({ error: '源报价单不存在' });
+
+  const tx = db.transaction(() => {
+    const info = db.prepare(`
+      INSERT INTO quotes (quote_no, product_name, customer, qty, version, created_by_dept, created_by_name)
+      VALUES (?, ?, ?, ?, ?, 'sales', ?)
+    `).run(
+      quote_no,
+      product_name || src.product_name,
+      customer != null ? customer : src.customer,
+      qty != null ? qty : src.qty,
+      version != null ? version : src.version,
+      req.user.name,
+    );
+    const newId = info.lastInsertRowid;
+    // 复制 7 个 section 的 payload_json，状态 empty
+    const srcSecs = db.prepare('SELECT dept, payload_json FROM quote_sections WHERE quote_id = ?').all(srcId);
+    const ins = db.prepare(`INSERT INTO quote_sections (quote_id, dept, payload_json, status) VALUES (?, ?, ?, 'empty')`);
+    for (const s of srcSecs) ins.run(newId, s.dept, s.payload_json || '{}');
+    db.prepare(`INSERT INTO audit_log (quote_id, dept, actor, action, detail) VALUES (?, 'sales', ?, 'clone', ?)`)
+      .run(newId, req.user.name, `from #${srcId} (${src.quote_no})`);
+    return newId;
+  });
+
+  try {
+    const id = tx();
+    res.json({ id });
+  } catch (e) {
+    if (String(e.message).includes('UNIQUE')) return res.status(409).json({ error: '报价单号已存在' });
+    throw e;
+  }
+});
+
+// PUT /api/quotes/:id/header  修改表头（产品名/客户/数量）— 业务+工程可改
+router.put('/:id/header', (req, res) => {
+  if (!['sales', 'engineering'].includes(req.user.dept)) {
+    return res.status(403).json({ error: '只有业务或工程可改表头' });
+  }
+  const id = Number(req.params.id);
+  const { product_name, customer, qty, version } = req.body || {};
+  const fields = []; const vals = [];
+  if (product_name !== undefined) { fields.push('product_name = ?'); vals.push(product_name); }
+  if (customer !== undefined)     { fields.push('customer = ?');     vals.push(customer); }
+  if (qty !== undefined)          { fields.push('qty = ?');          vals.push(qty); }
+  if (version !== undefined)      { fields.push('version = ?');      vals.push(version); }
+  if (!fields.length) return res.json({ ok: true });
+  vals.push(id);
+  db.prepare(`UPDATE quotes SET ${fields.join(', ')} WHERE id = ?`).run(...vals);
+  db.prepare(`INSERT INTO audit_log (quote_id, dept, actor, action, detail) VALUES (?, ?, ?, 'edit_header', ?)`)
+    .run(id, req.user.dept, req.user.name, JSON.stringify(req.body || {}));
+  res.json({ ok: true });
+});
+
+// GET /api/quotes/:id  报价单详情 + 所有 section（按可见性过滤）
+router.get('/:id', (req, res) => {
+  const id = Number(req.params.id);
+  const quote = db.prepare('SELECT * FROM quotes WHERE id = ?').get(id);
+  if (!quote) return res.status(404).json({ error: '不存在' });
+  // 客户范围检查（admin 跳过）
+  const isAdminQ = req.user.perms && req.user.perms['账号管理'] && req.user.perms['账号管理'].can_admin;
+  if (!isAdminQ) {
+    const ok = db.prepare('SELECT 1 FROM user_customers WHERE user_id = ? AND customer = ?').get(req.user.id, quote.customer || '');
+    if (!ok) return res.status(403).json({ error: '无权查看该客户的报价单' });
+  }
+
+  // 浏览记录：同一用户 5 分钟内重复打开 不重复记
+  const last = db.prepare(`
+    SELECT at FROM audit_log
+    WHERE quote_id = ? AND action = 'view' AND actor = ?
+    ORDER BY id DESC LIMIT 1
+  `).get(id, req.user.username || req.user.name);
+  const fiveMinAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString().replace('T', ' ').slice(0, 19);
+  if (!last || (last.at && last.at < fiveMinAgo)) {
+    db.prepare(`INSERT INTO audit_log (quote_id, dept, actor, action, detail) VALUES (?, ?, ?, 'view', ?)`)
+      .run(id, req.user.dept, req.user.username || req.user.name, req.user.display_name || null);
+  }
+
+  const sections = db.prepare(`
+    SELECT s.*, d.name_cn AS dept_name, d.sort_order
+    FROM quote_sections s JOIN departments d ON d.code = s.dept
+    WHERE s.quote_id = ?
+    ORDER BY d.sort_order
+  `).all(id);
+
+  // 业务/工程：可看所有部门 section（包括未审核的），因为他们可以操作所有
+  // 其他部门：只能看自己 section
+  const canSeeAll = req.user.dept === 'sales' || req.user.dept === 'engineering';
+  const filtered = sections.map(s => {
+    const own = s.dept === req.user.dept;
+    const visible = own || canSeeAll;
+    if (visible) return s;
+    // 其他部门未授予查看 → 仅暴露状态字段
+    return {
+      id: s.id, quote_id: s.quote_id, dept: s.dept, dept_name: s.dept_name, sort_order: s.sort_order,
+      status: s.status, reviewed_at: s.reviewed_at, filled_at: s.filled_at,
+      payload_json: null,
+    };
+  });
+
+  // 工程模具摘要：露给所有部门（用于啤机/喷油/装配等做参考行，即使工程尚未审核）
+  let engineering_molds = [];
+  const engSection = sections.find(s => s.dept === 'engineering');
+  if (engSection && engSection.payload_json) {
+    try {
+      const p = JSON.parse(engSection.payload_json);
+      engineering_molds = (p.molds || []).map(m => ({
+        mold_no: m.mold_no || '', name: m.name || '', cavity: m.cavity || '',
+        sets: m.sets ?? 1, material: m.material || '', color: m.color || '',
+        weight_g: m.weight_g ?? null, cycle_sec: m.cycle_sec ?? null,
+      }));
+    } catch {}
+  }
+
+  res.json({ quote, sections: filtered, engineering_molds });
+});
+
+// GET /api/quotes/:id/audit-log  返回该报价单全部动作时间线（最新在前）
+router.get('/:id/audit-log', (req, res) => {
+  const id = Number(req.params.id);
+  const rows = db.prepare(`
+    SELECT al.*, d.name_cn AS dept_name
+    FROM audit_log al
+    LEFT JOIN departments d ON d.code = al.dept
+    WHERE al.quote_id = ?
+    ORDER BY al.id DESC
+    LIMIT 500
+  `).all(id);
+  res.json(rows);
+});
+
+module.exports = router;

--- a/apps/业务部/内部报价系统/backend/routes/quotes.js
+++ b/apps/业务部/内部报价系统/backend/routes/quotes.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const db = require('../db');
-const { requireAuth } = require('../middleware/auth');
+const { requireAuth, quoteAccess } = require('../middleware/auth');
 
 const router = express.Router();
 router.use(requireAuth);
@@ -111,6 +111,8 @@ router.put('/:id/header', (req, res) => {
     return res.status(403).json({ error: '只有业务或工程可改表头' });
   }
   const id = Number(req.params.id);
+  const acc = quoteAccess(req.user, id);
+  if (acc.status !== 200) return res.status(acc.status).json({ error: acc.status === 404 ? '不存在' : '无权修改该客户的报价单' });
   const { product_name, customer, qty, version } = req.body || {};
   const fields = []; const vals = [];
   if (product_name !== undefined) { fields.push('product_name = ?'); vals.push(product_name); }
@@ -130,12 +132,9 @@ router.get('/:id', (req, res) => {
   const id = Number(req.params.id);
   const quote = db.prepare('SELECT * FROM quotes WHERE id = ?').get(id);
   if (!quote) return res.status(404).json({ error: '不存在' });
-  // 客户范围检查（admin 跳过）
-  const isAdminQ = req.user.perms && req.user.perms['账号管理'] && req.user.perms['账号管理'].can_admin;
-  if (!isAdminQ) {
-    const ok = db.prepare('SELECT 1 FROM user_customers WHERE user_id = ? AND customer = ?').get(req.user.id, quote.customer || '');
-    if (!ok) return res.status(403).json({ error: '无权查看该客户的报价单' });
-  }
+  // 客户范围检查（admin 跳过；无客户单仅 admin）
+  const acc = quoteAccess(req.user, id);
+  if (acc.status !== 200) return res.status(acc.status).json({ error: acc.status === 404 ? '不存在' : '无权查看该客户的报价单' });
 
   // 浏览记录：同一用户 5 分钟内重复打开 不重复记
   const last = db.prepare(`
@@ -191,6 +190,8 @@ router.get('/:id', (req, res) => {
 // GET /api/quotes/:id/audit-log  返回该报价单全部动作时间线（最新在前）
 router.get('/:id/audit-log', (req, res) => {
   const id = Number(req.params.id);
+  const acc = quoteAccess(req.user, id);
+  if (acc.status !== 200) return res.status(acc.status).json({ error: acc.status === 404 ? '不存在' : '无权查看该客户的报价单' });
   const rows = db.prepare(`
     SELECT al.*, d.name_cn AS dept_name
     FROM audit_log al

--- a/apps/业务部/内部报价系统/backend/routes/refs.js
+++ b/apps/业务部/内部报价系统/backend/routes/refs.js
@@ -1,0 +1,36 @@
+const express = require('express');
+const db = require('../db');
+const { requireAuth } = require('../middleware/auth');
+
+const router = express.Router();
+router.use(requireAuth);
+
+const ALLOWED = new Set(['material_prices', 'machine_prices']);
+
+// GET /api/refs/:key — 拉全局参考表
+router.get('/:key', (req, res) => {
+  const key = req.params.key;
+  if (!ALLOWED.has(key)) return res.status(400).json({ error: 'invalid key' });
+  const row = db.prepare('SELECT data_json, updated_at, updated_by FROM ref_tables WHERE key = ?').get(key);
+  if (!row) return res.json({ data: [], updated_at: null, updated_by: null });
+  let data = [];
+  try { data = JSON.parse(row.data_json); } catch {}
+  res.json({ data, updated_at: row.updated_at, updated_by: row.updated_by });
+});
+
+// PUT /api/refs/:key — 覆盖全局参考表（业务/工程可改）
+router.put('/:key', (req, res) => {
+  const key = req.params.key;
+  if (!ALLOWED.has(key)) return res.status(400).json({ error: 'invalid key' });
+  if (!['sales', 'engineering', 'molding'].includes(req.user.dept)) {
+    return res.status(403).json({ error: '没有权限修改参考表' });
+  }
+  const data = Array.isArray(req.body && req.body.data) ? req.body.data : [];
+  db.prepare(`
+    INSERT INTO ref_tables (key, data_json, updated_at, updated_by) VALUES (?, ?, datetime('now'), ?)
+    ON CONFLICT(key) DO UPDATE SET data_json = excluded.data_json, updated_at = excluded.updated_at, updated_by = excluded.updated_by
+  `).run(key, JSON.stringify(data), `[${req.user.dept}] ${req.user.name}`);
+  res.json({ ok: true });
+});
+
+module.exports = router;

--- a/apps/业务部/内部报价系统/backend/routes/reviews.js
+++ b/apps/业务部/内部报价系统/backend/routes/reviews.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const db = require('../db');
-const { requireAuth } = require('../middleware/auth');
+const { requireAuth, quoteAccess } = require('../middleware/auth');
 
 const router = express.Router();
 router.use(requireAuth);
@@ -14,6 +14,8 @@ router.post('/:section_id', (req, res) => {
 
   const sec = db.prepare('SELECT * FROM quote_sections WHERE id = ?').get(id);
   if (!sec) return res.status(404).json({ error: '不存在' });
+  const acc = quoteAccess(req.user, sec.quote_id);
+  if (acc.status !== 200) return res.status(acc.status).json({ error: acc.status === 404 ? '不存在' : '无权审核该客户的报价单' });
   if (sec.dept !== req.user.dept && !['sales', 'engineering'].includes(req.user.dept)) {
     return res.status(403).json({ error: '只能审核本部门' });
   }
@@ -52,6 +54,8 @@ router.post('/:section_id/reopen', (req, res) => {
 
   const sec = db.prepare('SELECT * FROM quote_sections WHERE id = ?').get(id);
   if (!sec) return res.status(404).json({ error: '不存在' });
+  const acc = quoteAccess(req.user, sec.quote_id);
+  if (acc.status !== 200) return res.status(acc.status).json({ error: acc.status === 404 ? '不存在' : '无权操作该客户的报价单' });
   if (sec.dept !== req.user.dept && !['sales', 'engineering'].includes(req.user.dept)) {
     return res.status(403).json({ error: '只能操作本部门' });
   }

--- a/apps/业务部/内部报价系统/backend/routes/reviews.js
+++ b/apps/业务部/内部报价系统/backend/routes/reviews.js
@@ -1,0 +1,77 @@
+const express = require('express');
+const db = require('../db');
+const { requireAuth } = require('../middleware/auth');
+
+const router = express.Router();
+router.use(requireAuth);
+
+// POST /api/reviews/:section_id   { action: 'approve'|'reject', comment? }
+router.post('/:section_id', (req, res) => {
+  if (!['supervisor', 'admin'].includes(req.user.role)) return res.status(403).json({ error: '仅主管可审核' });
+  const id = Number(req.params.section_id);
+  const { action, comment } = req.body || {};
+  if (!['approve', 'reject'].includes(action)) return res.status(400).json({ error: 'action 非法' });
+
+  const sec = db.prepare('SELECT * FROM quote_sections WHERE id = ?').get(id);
+  if (!sec) return res.status(404).json({ error: '不存在' });
+  if (sec.dept !== req.user.dept && !['sales', 'engineering'].includes(req.user.dept)) {
+    return res.status(403).json({ error: '只能审核本部门' });
+  }
+  if (sec.status !== 'filled' && action === 'approve') {
+    return res.status(409).json({ error: '该 section 尚未填写完毕' });
+  }
+
+  const newStatus = action === 'approve' ? 'approved' : 'rejected';
+  db.prepare(`
+    UPDATE quote_sections
+    SET status = ?, reviewed_by = ?, reviewed_at = datetime('now'), review_comment = ?
+    WHERE id = ?
+  `).run(newStatus, req.user.name, comment || null, id);
+
+  // 若 5/5 通过 → 报价单整体状态升级
+  const approvedAll = db.prepare(
+    `SELECT COUNT(*) AS n FROM quote_sections WHERE quote_id = ? AND status = 'approved'`
+  ).get(sec.quote_id).n >= db.prepare('SELECT COUNT(*) AS n FROM departments').get().n;
+  if (approvedAll) {
+    db.prepare(`UPDATE quotes SET status = 'fully_approved' WHERE id = ? AND status = 'drafting'`)
+      .run(sec.quote_id);
+  }
+
+  const actor = `[${req.user.dept}] ${req.user.name}`;
+  db.prepare(`INSERT INTO audit_log (quote_id, dept, actor, action, detail) VALUES (?, ?, ?, ?, ?)`)
+    .run(sec.quote_id, sec.dept, actor, action, comment || null);
+
+  res.json({ ok: true, all_approved: approvedAll });
+});
+
+// POST /api/reviews/:section_id/reopen  { reason? }
+// 主管把已审 section 退回到"已填"以便修改；同时若报价单已 fully_approved 则回退到 drafting
+router.post('/:section_id/reopen', (req, res) => {
+  const id = Number(req.params.section_id);
+  const reason = (req.body && req.body.reason) || null;
+
+  const sec = db.prepare('SELECT * FROM quote_sections WHERE id = ?').get(id);
+  if (!sec) return res.status(404).json({ error: '不存在' });
+  if (sec.dept !== req.user.dept && !['sales', 'engineering'].includes(req.user.dept)) {
+    return res.status(403).json({ error: '只能操作本部门' });
+  }
+  if (sec.status !== 'approved') return res.status(409).json({ error: '只能解除已审核通过的 section' });
+
+  db.prepare(`
+    UPDATE quote_sections
+    SET status = 'filled', review_comment = ?
+    WHERE id = ?
+  `).run(reason ? '【解除审核】' + reason : '【解除审核】', id);
+
+  // 整张报价单若已 fully_approved → 回退 drafting
+  db.prepare(`UPDATE quotes SET status = 'drafting' WHERE id = ? AND status = 'fully_approved'`)
+    .run(sec.quote_id);
+
+  const reopenActor = `[${req.user.dept}] ${req.user.name}`;
+  db.prepare(`INSERT INTO audit_log (quote_id, dept, actor, action, detail) VALUES (?, ?, ?, 'reopen', ?)`)
+    .run(sec.quote_id, sec.dept, reopenActor, reason || null);
+
+  res.json({ ok: true });
+});
+
+module.exports = router;

--- a/apps/业务部/内部报价系统/backend/routes/sections.js
+++ b/apps/业务部/内部报价系统/backend/routes/sections.js
@@ -1,0 +1,41 @@
+const express = require('express');
+const db = require('../db');
+const { requireAuth } = require('../middleware/auth');
+
+const router = express.Router();
+router.use(requireAuth);
+
+// PUT /api/sections/:id  填写本部门 section
+router.put('/:id', (req, res) => {
+  const id = Number(req.params.id);
+  const sec = db.prepare('SELECT * FROM quote_sections WHERE id = ?').get(id);
+  if (!sec) return res.status(404).json({ error: '不存在' });
+  // 业务 / 工程 可操作所有 section；其他部门只能操作自己
+  if (sec.dept !== req.user.dept && !['sales', 'engineering'].includes(req.user.dept)) {
+    return res.status(403).json({ error: '只能填写本部门部分' });
+  }
+  if (sec.status === 'approved') return res.status(409).json({ error: '已审核通过，无法修改' });
+
+  const payload = req.body && typeof req.body.payload === 'object' ? req.body.payload : {};
+  const submit = !!(req.body && req.body.submit);
+
+  const nextStatus = submit ? 'filled' : (sec.status === 'rejected' ? 'rejected' : 'empty');
+
+  db.prepare(`
+    UPDATE quote_sections
+    SET payload_json = ?, status = CASE WHEN ? = 1 THEN 'filled' ELSE status END,
+        filled_by = ?, filled_at = datetime('now')
+    WHERE id = ?
+  `).run(JSON.stringify(payload), submit ? 1 : 0, req.user.name, id);
+
+  // 仅记录"提交审核"，保存草稿不写入修改记录
+  if (submit) {
+    const actor = `[${req.user.dept}] ${req.user.name}`;
+    db.prepare(`INSERT INTO audit_log (quote_id, dept, actor, action, detail) VALUES (?, ?, ?, 'submit', ?)`)
+      .run(sec.quote_id, sec.dept, actor, null);
+  }
+
+  res.json({ ok: true });
+});
+
+module.exports = router;

--- a/apps/业务部/内部报价系统/backend/routes/sections.js
+++ b/apps/业务部/内部报价系统/backend/routes/sections.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const db = require('../db');
-const { requireAuth } = require('../middleware/auth');
+const { requireAuth, quoteAccess } = require('../middleware/auth');
 
 const router = express.Router();
 router.use(requireAuth);
@@ -10,6 +10,9 @@ router.put('/:id', (req, res) => {
   const id = Number(req.params.id);
   const sec = db.prepare('SELECT * FROM quote_sections WHERE id = ?').get(id);
   if (!sec) return res.status(404).json({ error: '不存在' });
+  // 客户可见范围校验（防跨客户越权写）
+  const acc = quoteAccess(req.user, sec.quote_id);
+  if (acc.status !== 200) return res.status(acc.status).json({ error: acc.status === 404 ? '不存在' : '无权操作该客户的报价单' });
   // 业务 / 工程 可操作所有 section；其他部门只能操作自己
   if (sec.dept !== req.user.dept && !['sales', 'engineering'].includes(req.user.dept)) {
     return res.status(403).json({ error: '只能填写本部门部分' });
@@ -19,7 +22,10 @@ router.put('/:id', (req, res) => {
   const payload = req.body && typeof req.body.payload === 'object' ? req.body.payload : {};
   const submit = !!(req.body && req.body.submit);
 
-  const nextStatus = submit ? 'filled' : (sec.status === 'rejected' ? 'rejected' : 'empty');
+  // 轻量并发提醒：你打开后这段是否已被「别人」改过（不挡保存，仅提示）
+  const baseFilledAt = req.body && req.body.base_filled_at;
+  const conflict = !!(baseFilledAt && sec.filled_at && sec.filled_at !== baseFilledAt
+    && sec.filled_by && sec.filled_by !== req.user.name);
 
   db.prepare(`
     UPDATE quote_sections
@@ -35,7 +41,8 @@ router.put('/:id', (req, res) => {
       .run(sec.quote_id, sec.dept, actor, null);
   }
 
-  res.json({ ok: true });
+  const after = db.prepare('SELECT filled_at FROM quote_sections WHERE id = ?').get(id);
+  res.json({ ok: true, filled_at: after && after.filled_at, conflict, last_by: conflict ? sec.filled_by : null, last_at: conflict ? sec.filled_at : null });
 });
 
 module.exports = router;

--- a/apps/业务部/内部报价系统/backend/routes/uploads.js
+++ b/apps/业务部/内部报价系统/backend/routes/uploads.js
@@ -30,12 +30,32 @@ const upload = multer({
   },
 });
 
+// 按文件头(magic bytes)校验真实类型：防止伪造 Content-Type 上传非图片
+function isRealImage(buf) {
+  if (!buf || buf.length < 12) return false;
+  if (buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4E && buf[3] === 0x47) return true;            // PNG
+  if (buf[0] === 0xFF && buf[1] === 0xD8 && buf[2] === 0xFF) return true;                                // JPEG
+  if (buf.toString('ascii', 0, 4) === 'RIFF' && buf.toString('ascii', 8, 12) === 'WEBP') return true;   // WEBP
+  return false;
+}
+
 // POST /api/uploads/mold-image  multipart field "file" — 工程上传模具图（同时被喷油/装配复用）
 router.post('/mold-image', requireAuth, upload.single('file'), (req, res) => {
   if (!['engineering', 'painting', 'assembly', 'molding', 'sales'].includes(req.user.dept) && req.user.role !== 'admin') {
+    if (req.file) { try { fs.unlinkSync(req.file.path); } catch {} }
     return res.status(403).json({ error: '无权上传' });
   }
   if (!req.file) return res.status(400).json({ error: '缺少文件' });
+  // 文件头校验：不是真图片就删掉并拒绝（伪造 mimetype 防线）
+  try {
+    const head = fs.readFileSync(req.file.path).subarray(0, 12);
+    if (!isRealImage(head)) {
+      try { fs.unlinkSync(req.file.path); } catch {}
+      return res.status(400).json({ error: '文件不是有效图片(png/jpg/webp)' });
+    }
+  } catch {
+    return res.status(400).json({ error: '文件读取失败' });
+  }
   res.json({ url: 'uploads/mold/' + req.file.filename });
 });
 

--- a/apps/业务部/内部报价系统/backend/routes/uploads.js
+++ b/apps/业务部/内部报价系统/backend/routes/uploads.js
@@ -1,0 +1,149 @@
+const express = require('express');
+const multer = require('multer');
+const fs = require('fs');
+const path = require('path');
+const { requireAuth } = require('../middleware/auth');
+
+const router = express.Router();
+
+const UPLOAD_ROOT = path.join(__dirname, '..', 'uploads');
+fs.mkdirSync(path.join(UPLOAD_ROOT, 'mold'), { recursive: true });
+
+const storage = multer.diskStorage({
+  destination: (req, _file, cb) => {
+    const dir = path.join(UPLOAD_ROOT, 'mold');
+    cb(null, dir);
+  },
+  filename: (_req, file, cb) => {
+    const ext = path.extname(file.originalname).toLowerCase().replace(/[^.\w]/g, '');
+    const safeExt = ['.png', '.jpg', '.jpeg', '.webp'].includes(ext) ? ext : '.png';
+    const ts = Date.now() + '-' + Math.random().toString(36).slice(2, 8);
+    cb(null, ts + safeExt);
+  },
+});
+const upload = multer({
+  storage,
+  limits: { fileSize: 3 * 1024 * 1024 },
+  fileFilter: (_req, file, cb) => {
+    const ok = /^image\/(png|jpe?g|webp)$/.test(file.mimetype);
+    cb(ok ? null : new Error('仅支持 png/jpg/webp'), ok);
+  },
+});
+
+// POST /api/uploads/mold-image  multipart field "file" — 工程上传模具图（同时被喷油/装配复用）
+router.post('/mold-image', requireAuth, upload.single('file'), (req, res) => {
+  if (!['engineering', 'painting', 'assembly', 'molding', 'sales'].includes(req.user.dept) && req.user.role !== 'admin') {
+    return res.status(403).json({ error: '无权上传' });
+  }
+  if (!req.file) return res.status(400).json({ error: '缺少文件' });
+  res.json({ url: 'uploads/mold/' + req.file.filename });
+});
+
+// POST /api/uploads/mold-sheet  解析"模具报价单&合同"型 xlsx → 返回 molds[]
+// 不持久化 — 前端预览后由用户决定是否合并入 payload.molds
+const memUpload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 10 * 1024 * 1024 },
+});
+const { parseWorkbook } = require('../services/parseMoldSheet');
+const { extractImagesByRow } = require('../services/extractXlsxImages');
+router.post('/mold-sheet', requireAuth, memUpload.single('file'), async (req, res) => {
+  if (req.user.dept !== 'engineering' && req.user.role !== 'admin') return res.status(403).json({ error: '仅工程或超级管理员可上传' });
+  if (!req.file) return res.status(400).json({ error: '缺少文件' });
+  if (!/\.(xls|xlsx)$/i.test(req.file.originalname)) {
+    return res.status(400).json({ error: '当前只支持 .xls/.xlsx（PDF/图片待后续支持）' });
+  }
+  try {
+    const result = parseWorkbook(req.file.buffer);
+    if (result.error) return res.status(422).json(result);
+
+    // xlsx 才尝试抽图（.xls 二进制不支持嵌入图提取）
+    if (/\.xlsx$/i.test(req.file.originalname)) {
+      try {
+        const moldImgDir = path.join(UPLOAD_ROOT, 'mold');
+        const anchored = await extractImagesByRow(req.file.buffer, moldImgDir);
+        // anchored[].row = xlsx 0-based 行号；解析器已为每副模具记录 _rows=[起始,结束] 0-based 行范围
+        // 直接按行范围归属（适用于有/无"模号"列两种表格）
+        let assigned = 0;
+        for (const img of anchored) {
+          for (let mi = 0; mi < result.molds.length; mi++) {
+            const range = result.molds[mi]._rows;
+            if (!range) continue;
+            if (img.row >= range[0] && img.row <= range[1]) {
+              result.molds[mi].images = result.molds[mi].images || [];
+              result.molds[mi].images.push('uploads/mold/' + img.file);
+              assigned++;
+              break;
+            }
+          }
+        }
+        result.images_extracted = anchored.length;
+        if (anchored.length && !assigned) result.images_hint = `抽取到 ${anchored.length} 张图片但未能按行归位（图片锚点行=${anchored.map(a => a.row).join(',')}）。`;
+      } catch (e) {
+        result.images_extract_error = e.message;
+      }
+    } else {
+      result.images_hint = '当前文件是 .xls 旧二进制格式，图片无法自动抽取。请在 WPS/Excel 里"另存为 → .xlsx"后重新上传即可自动识图。';
+    }
+    res.json(result);
+  } catch (e) {
+    res.status(500).json({ error: '解析失败: ' + e.message });
+  }
+});
+
+// POST /api/uploads/sewing-sheet  车缝报价单 xlsx → 返回 groups[]
+const { parseWorkbook: parseSewingWorkbook } = require('../services/parseSewingSheet');
+router.post('/sewing-sheet', requireAuth, memUpload.single('file'), async (req, res) => {
+  if (!['sewing', 'sales', 'engineering'].includes(req.user.dept) && req.user.role !== 'admin') {
+    return res.status(403).json({ error: '仅 车缝/业务/工程/超级管理员 可上传' });
+  }
+  if (!req.file) return res.status(400).json({ error: '缺少文件' });
+  if (!/\.(xls|xlsx)$/i.test(req.file.originalname)) {
+    return res.status(400).json({ error: '当前只支持 .xls/.xlsx' });
+  }
+  try {
+    const result = await parseSewingWorkbook(req.file.buffer);
+    if (result.error) return res.status(422).json(result);
+    res.json(result);
+  } catch (e) {
+    res.status(500).json({ error: '解析失败: ' + e.message });
+  }
+});
+
+// POST /api/uploads/electronic-sheet  电子报价单 xlsx → 返回 parts + extras
+const { parseWorkbook: parseElectronicWorkbook } = require('../services/parseElectronicSheet');
+router.post('/electronic-sheet', requireAuth, memUpload.single('file'), async (req, res) => {
+  if (!['electronic', 'sales', 'engineering'].includes(req.user.dept) && req.user.role !== 'admin') {
+    return res.status(403).json({ error: '仅 电子部/业务/工程/超级管理员 可上传' });
+  }
+  if (!req.file) return res.status(400).json({ error: '缺少文件' });
+  if (!/\.(xls|xlsx)$/i.test(req.file.originalname)) {
+    return res.status(400).json({ error: '当前只支持 .xls/.xlsx' });
+  }
+  try {
+    const result = await parseElectronicWorkbook(req.file.buffer);
+    if (result.error) return res.status(422).json(result);
+    res.json(result);
+  } catch (e) {
+    res.status(500).json({ error: '解析失败: ' + e.message });
+  }
+});
+
+// POST /api/uploads/assembly-sheet  生产排拉工序表 xlsx → 返回 { meta, steps }
+const { parseWorkbook: parseAssemblyWorkbook } = require('../services/parseAssemblySheet');
+router.post('/assembly-sheet', requireAuth, memUpload.single('file'), async (req, res) => {
+  if (!['assembly', 'sales', 'engineering'].includes(req.user.dept) && req.user.role !== 'admin') {
+    return res.status(403).json({ error: '仅 装配部/业务/工程/超级管理员 可上传' });
+  }
+  if (!req.file) return res.status(400).json({ error: '缺少文件' });
+  if (!/\.(xls|xlsx)$/i.test(req.file.originalname)) return res.status(400).json({ error: '只支持 .xls/.xlsx' });
+  try {
+    const result = await parseAssemblyWorkbook(req.file.buffer);
+    if (result.error) return res.status(422).json(result);
+    res.json(result);
+  } catch (e) {
+    res.status(500).json({ error: '解析失败: ' + e.message });
+  }
+});
+
+module.exports = router;

--- a/apps/业务部/内部报价系统/backend/server.js
+++ b/apps/业务部/内部报价系统/backend/server.js
@@ -32,5 +32,5 @@ app.use('/api/admin', require('./routes/admin'));
 app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
 app.use(express.static(path.join(__dirname, '..', 'frontend')));
 
-const PORT = process.env.PORT || 3210;
+const PORT = process.env.PORT || 3211;
 app.listen(PORT, () => console.log(`内部报价系统 listening on http://localhost:${PORT}`));

--- a/apps/业务部/内部报价系统/backend/server.js
+++ b/apps/业务部/内部报价系统/backend/server.js
@@ -17,6 +17,9 @@ app.use(cookieSession({
   secure: process.env.NODE_ENV === 'production',  // 生产(HTTPS)下仅经加密连接发送；本地 http 开发不受影响
 }));
 
+// 健康检查（门户状态点 + 容器 healthcheck 用；无需鉴权）
+app.get('/health', (_req, res) => res.json({ status: 'ok' }));
+
 app.use('/api/auth', require('./routes/auth'));
 app.use('/api/quotes', require('./routes/quotes'));
 app.use('/api/quotes', require('./routes/export')); // GET /:id/export

--- a/apps/业务部/内部报价系统/backend/server.js
+++ b/apps/业务部/内部报价系统/backend/server.js
@@ -2,6 +2,12 @@ const path = require('path');
 const express = require('express');
 const cookieSession = require('cookie-session');
 
+// 生产环境必须显式设置 SESSION_SECRET：否则会用默认密钥，任何人可伪造登录
+if (process.env.NODE_ENV === 'production' && !process.env.SESSION_SECRET) {
+  console.error('[fatal] 生产环境必须设置 SESSION_SECRET（生成：openssl rand -hex 32）；缺失会用默认密钥导致可伪造登录，拒绝启动。');
+  process.exit(1);
+}
+
 require('./db'); // ensure schema + seed
 
 const app = express();
@@ -29,8 +35,26 @@ app.use('/api/uploads', require('./routes/uploads'));
 app.use('/api/refs', require('./routes/refs'));
 app.use('/api/admin', require('./routes/admin'));
 
-app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
+// nosniff：即使有人上传内容为 HTML/SVG 但扩展名被强制成图片，浏览器也不会嗅探成可执行类型
+app.use('/uploads', express.static(path.join(__dirname, 'uploads'), {
+  setHeaders: (res) => res.setHeader('X-Content-Type-Options', 'nosniff'),
+}));
 app.use(express.static(path.join(__dirname, '..', 'frontend')));
+
+// 全局错误处理：路由内抛出的同步异常(含 DB 错误)在此兜底，避免拖垮进程
+// eslint-disable-next-line no-unused-vars
+app.use((err, req, res, next) => {
+  console.error('[error]', req.method, req.originalUrl, err);
+  if (res.headersSent) return;
+  const msg = String(err.message || '');
+  if (msg.includes('UNIQUE')) return res.status(409).json({ error: '数据已存在（唯一约束冲突）' });
+  res.status(500).json({ error: '服务器内部错误' });
+});
+
+// 进程级兜底：未处理的 Promise rejection 不应静默/崩溃
+process.on('unhandledRejection', (reason) => {
+  console.error('[unhandledRejection]', reason);
+});
 
 const PORT = process.env.PORT || 3211;
 app.listen(PORT, () => console.log(`内部报价系统 listening on http://localhost:${PORT}`));

--- a/apps/业务部/内部报价系统/backend/server.js
+++ b/apps/业务部/内部报价系统/backend/server.js
@@ -1,0 +1,33 @@
+const path = require('path');
+const express = require('express');
+const cookieSession = require('cookie-session');
+
+require('./db'); // ensure schema + seed
+
+const app = express();
+// 反代(Caddy/nginx)在前面终止 TLS，按 X-Forwarded-Proto 识别 https，secure cookie 才生效
+app.set('trust proxy', 1);
+app.use(express.json({ limit: '2mb' }));
+app.use(cookieSession({
+  name: 'iq_sess',
+  keys: [process.env.SESSION_SECRET || 'change-me-in-prod'],
+  maxAge: 12 * 60 * 60 * 1000,
+  httpOnly: true,
+  sameSite: 'lax',
+  secure: process.env.NODE_ENV === 'production',  // 生产(HTTPS)下仅经加密连接发送；本地 http 开发不受影响
+}));
+
+app.use('/api/auth', require('./routes/auth'));
+app.use('/api/quotes', require('./routes/quotes'));
+app.use('/api/quotes', require('./routes/export')); // GET /:id/export
+app.use('/api/sections', require('./routes/sections'));
+app.use('/api/reviews', require('./routes/reviews'));
+app.use('/api/uploads', require('./routes/uploads'));
+app.use('/api/refs', require('./routes/refs'));
+app.use('/api/admin', require('./routes/admin'));
+
+app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
+app.use(express.static(path.join(__dirname, '..', 'frontend')));
+
+const PORT = process.env.PORT || 3210;
+app.listen(PORT, () => console.log(`内部报价系统 listening on http://localhost:${PORT}`));

--- a/apps/业务部/内部报价系统/backend/services/exportXlsx.js
+++ b/apps/业务部/内部报价系统/backend/services/exportXlsx.js
@@ -120,8 +120,10 @@ async function buildWorkbook({ quote, sections }) {
 
   const get = (dept) => {
     const s = sections.find(x => x.dept === dept);
-    if (!s) return {};
-    return s.payload_json ? JSON.parse(s.payload_json) : {};
+    if (!s || !s.payload_json) return {};
+    // 单个 section 的 payload 若损坏，当空处理，避免整单导出 500
+    try { return JSON.parse(s.payload_json); }
+    catch (e) { console.error(`[export] ${dept} payload_json 解析失败，按空处理:`, e.message); return {}; }
   };
   const eng = get('engineering');
   const mold = get('molding');

--- a/apps/业务部/内部报价系统/backend/services/exportXlsx.js
+++ b/apps/业务部/内部报价系统/backend/services/exportXlsx.js
@@ -1,0 +1,1976 @@
+// 把报价单 + 各部门 section 导出成 xlsx，布局对齐 47765A_产品报价清单 sheet1
+// 9 章节 + 模具行图片嵌入
+const ExcelJS = require('exceljs');
+const path = require('path');
+const fs = require('fs');
+
+const RMB = '￥#,##0.00';
+const HKD = '"HK$"#,##0.00';
+const HKD4 = '"HK$"#,##0.0000';
+const PCT = '0.00%';
+const FONT = 'Microsoft YaHei';  // 全表统一字体
+// 辅助/包装材料 类别 — 减税明细各外购项按此类别统计（须与前端 workbench.js MAT_CATEGORIES 一致）
+const MAT_CATEGORIES = ['吸塑', '彩盒/内咭', '电池', '利宝', '电镀', '其他外购'];
+
+// 工具
+const num = (v) => Number(v) || 0;
+const sum = (arr, fn) => arr.reduce((a, r) => a + (fn(r) || 0), 0);
+
+// 暖灰系单色调
+function styleHeader(cell) {
+  cell.font = { bold: true, color: { argb: 'FF1F2937' }, size: 11, name: 'Microsoft YaHei' };
+  cell.alignment = { horizontal: 'center', vertical: 'middle', wrapText: true };
+  cell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFF0DBA1' } };  // 合计同色 暖米
+  cell.border = thinBorder();
+  if (cell.worksheet && cell.worksheet.getRow(cell.row).height < 30) {
+    cell.worksheet.getRow(cell.row).height = 30;
+  }
+}
+function styleData(cell) {
+  cell.font = cell.font || { size: 11, color: { argb: 'FF44403C' }, name: 'Microsoft YaHei' };
+  cell.alignment = { horizontal: 'center', vertical: 'middle', wrapText: true };
+  cell.border = thinBorder();
+  if (cell.worksheet) {
+    const r = cell.worksheet.getRow(cell.row);
+    if (!r.height || r.height < 26) r.height = 26;
+  }
+}
+function styleSection(cell) {
+  // 章节标题：白底 + 加粗深色文字，不填充
+  cell.font = { bold: true, size: 14, color: { argb: 'FF704917' }, name: 'Microsoft YaHei' };
+  cell.alignment = { horizontal: 'left', vertical: 'middle', indent: 1 };
+  cell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFFFFFFF' } };
+  cell.border = { bottom: { style: 'medium', color: { argb: 'FFF0DBA1' } } };
+  if (cell.worksheet) cell.worksheet.getRow(cell.row).height = 30;
+}
+function styleSubtotal(cell, level) {
+  // 奶油拿铁 配色
+  const palette = {
+    sub:   'FFFDF8E7',  // 极浅奶
+    total: 'FFF0DBA1',  // 暖米（合计）
+    hkd:   'FFF0DBA1',  // 同合计
+    loss:  'FFFBF5E0',  // 米色
+  };
+  const color = palette[level] || palette.sub;
+  cell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: color } };
+  cell.border = thinBorder();
+  if (cell.worksheet) {
+    const r = cell.worksheet.getRow(cell.row);
+    if (!r.height || r.height < 24) r.height = 24;
+  }
+}
+function thinBorder() {
+  const s = { style: 'thin', color: { argb: 'FFEFE7D2' } };  // 米色边框
+  return { top: s, bottom: s, left: s, right: s };
+}
+function mediumBorder() {
+  const s = { style: 'medium', color: { argb: 'FF1E40AF' } };
+  return { top: s, bottom: s, left: s, right: s };
+}
+
+async function buildWorkbook({ quote, sections }) {
+  const wb = new ExcelJS.Workbook();
+  wb.creator = '内部报价系统';
+  wb.created = new Date();
+  const ws = wb.addWorksheet('报价明细');
+
+  // 列宽（13 列）— 整体加宽
+  ws.columns = [
+    { width: 18 },  // A 序号 / 注塑 / 出货底价 HK$ 标签等
+    { width: 28 },  // B 主名称
+    { width: 18 },  // C 模号 / 规格
+    { width: 16 },  // D 模胚类型
+    { width: 14 },  // E 模具结构
+    { width: 12 },  // F 材质
+    { width: 12 },  // G 出模数
+    { width: 15 },  // H 套数 / 印尼运费
+    { width: 16 },  // I 模具尺寸
+    { width: 14 },  // J 图片(左) / 总计 RMB
+    { width: 14 },  // K 图片(右) / 报客 HKD
+    { width: 18 },  // L 价格 / 总计 RMB
+    { width: 16 },  // M 价格/报价 / 报客 HKD
+    { width: 14 },  // N
+    { width: 14 },  // O
+    { width: 18 },  // P 模价 HKD
+    { width: 16 },  // Q 出货底价 RMB
+    { width: 16 },  // R 出货底价 HKD
+  ];
+
+  let row = 1;
+
+  // 报价单标题
+  ws.mergeCells(row, 1, row, 13);
+  const titleCell = ws.getCell(row, 1);
+  titleCell.value = `${quote.quote_no || ''} ${quote.product_name || ''} 内部报价明细`;
+  titleCell.font = { bold: true, size: 18, color: { argb: 'FF1F2937' }, name: 'Microsoft YaHei' };
+  titleCell.alignment = { horizontal: 'center', vertical: 'middle' };
+  titleCell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFFFFFFF' } };
+  ws.getRow(row).height = 40;
+  row += 1;
+
+  // 报价单元信息
+  ws.mergeCells(row, 1, row, 13);
+  const subCell = ws.getCell(row, 1);
+  subCell.value = `客户: ${quote.customer || '—'}    数量: ${quote.qty || '—'}    创建: ${quote.created_at || ''}`;
+  subCell.alignment = { horizontal: 'center', vertical: 'middle' };
+  subCell.font = { color: { argb: 'FF64748B' }, size: 11, italic: true, name: 'Microsoft YaHei' };
+  subCell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFF8FAFC' } };
+  ws.getRow(row).height = 22;
+  row += 2;
+
+  const get = (dept) => {
+    const s = sections.find(x => x.dept === dept);
+    if (!s) return {};
+    return s.payload_json ? JSON.parse(s.payload_json) : {};
+  };
+  const eng = get('engineering');
+  const mold = get('molding');
+  const pnt = get('painting');
+  const asm = get('assembly');
+  const sales = get('sales');
+  const slush = get('slush');
+  const sewing = get('sewing');
+  const electronic = get('electronic');
+  const fxRH = num(sales.header?.fx_rmb_hkd) || 0.85;
+
+  // ---------- 一、模具部分 ----------
+  // 列序与 UI（renderMolds）一致：A序号 B名称 C模号 D模胚类型 E模具结构 F材质 G颜色
+  //   H出模数 I套数 J净重(g) K周期(秒) L模具尺寸 M-N图片(合并) O价格RMB P模价HKD Q备注
+  ws.mergeCells(row, 1, row, 17); styleSection(ws.getCell(row, 1));
+  ws.getCell(row, 1).value = '一、模具部分';
+  row += 1;
+  const moldHeader = ['序号', '模具名称', '模号', '模胚类型', '模具结构', '材质', '颜色', '出模数', '套数', '净重(g)', '周期(秒)', '模具尺寸', '图   片', '', '模具价格（RMB）', '模价 HKD', '备   注'];
+  moldHeader.forEach((h, i) => { ws.getCell(row, i + 1).value = h; styleHeader(ws.getCell(row, i + 1)); });
+  ws.mergeCells(row, 13, row, 14); // 图片列合并(M:N)
+  row += 1;
+
+  const molds = eng.molds || [];
+  const moldDataStart = row;
+  for (let mi = 0; mi < molds.length; mi++) {
+    const m = molds[mi];
+    const r = row;
+    ws.getRow(r).height = 60;
+    ws.getCell(r, 1).value = mi + 1;
+    ws.getCell(r, 2).value = m.name || '';
+    ws.getCell(r, 3).value = m.mold_no || '';
+    ws.getCell(r, 4).value = m.mold_type || '';
+    ws.getCell(r, 4).alignment = { wrapText: true, vertical: 'middle', horizontal: 'center' };
+    ws.getCell(r, 5).value = m.structure || '';
+    ws.getCell(r, 6).value = m.material || '';
+    ws.getCell(r, 7).value = m.color || '';
+    ws.getCell(r, 8).value = m.cavity || '';
+    ws.getCell(r, 9).value = m.sets ?? 1;
+    ws.getCell(r, 10).value = m.weight_g == null || m.weight_g === '' ? '' : num(m.weight_g);
+    ws.getCell(r, 11).value = m.cycle_sec == null || m.cycle_sec === '' ? '' : num(m.cycle_sec);
+    ws.getCell(r, 12).value = (m.detail && m.detail.mold_size) || '';
+    ws.mergeCells(r, 13, r, 14);
+    ws.getCell(r, 15).value = num(m.price_rmb);
+    ws.getCell(r, 15).numFmt = RMB;
+    // 模价 HKD = 模具价格RMB(O) ÷ 汇率（活公式）
+    ws.getCell(r, 16).value = { formula: `O${r}/${fxRH}`, result: num(m.price_rmb) / fxRH };
+    ws.getCell(r, 16).numFmt = '"HK$"#,##0.00';
+    ws.getCell(r, 17).value = m.note || '';
+    for (let c = 1; c <= 17; c++) styleData(ws.getCell(r, c));
+
+    // 嵌入所有图片：2 列 × N 行 网格布局
+    const imgs = (m.images || []).filter(Boolean);
+    if (imgs.length) {
+      const perRow = 2;
+      const imgW = 55, imgH = 55;
+      const gridRows = Math.ceil(imgs.length / perRow);
+      const rowHeightPt = gridRows * 50 + 10; // 留 10pt 缓冲
+      ws.getRow(r).height = rowHeightPt;
+
+      // 每张图占的"行比例" = imgH(px) / rowHeight(pt) × (4/3 px/pt)
+      // 简化为均分行：每张图垂直占 (1/gridRows) 行
+      imgs.forEach((imgPath, i) => {
+        const abs = path.join(__dirname, '..', imgPath.replace(/^uploads\//, 'uploads/'));
+        if (!fs.existsSync(abs)) return;
+        try {
+          const ext = path.extname(abs).slice(1).toLowerCase().replace('jpeg', 'jpg');
+          const id = wb.addImage({ filename: abs, extension: ext === 'jpg' ? 'jpeg' : ext });
+          const xi = i % perRow;
+          const yi = Math.floor(i / perRow);
+          // tl.col: 第一张 → col 13 起始 (idx 12)，第二张 → col 14 起始 (idx 13)
+          // tl.row 用 yi/gridRows 把图均分行高
+          ws.addImage(id, {
+            tl: { col: 12 + xi, row: r - 1 + (yi / gridRows) },
+            ext: { width: imgW, height: imgH },
+          });
+        } catch (e) { /* skip bad image */ }
+      });
+    }
+    row += 1;
+  }
+  // 小计 RMB - SUM 公式（只在数值格上色）
+  const moldDataEnd = row - 1;
+  const whiteFill = (r) => {
+    for (let c = 1; c <= 17; c++) {
+      const cell = ws.getCell(r, c);
+      cell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFFFFFFF' } };
+      cell.border = thinBorder();
+      cell.alignment = cell.alignment || { horizontal: 'center', vertical: 'middle' };
+    }
+  };
+  // 小计：与 UI 一致，同一行 价格RMB(O) + 模价HKD(P)
+  ws.mergeCells(row, 1, row, 14);
+  ws.getCell(row, 1).value = `小计 (汇率 ${fxRH})`;
+  ws.getCell(row, 1).alignment = { horizontal: 'right', vertical: 'middle' };
+  const moldSubtotal = sum(molds, m => num(m.price_rmb));
+  const moldSubtotalRow = row;
+  ws.getCell(row, 15).value = molds.length
+    ? { formula: `SUM(O${moldDataStart}:O${moldDataEnd})`, result: moldSubtotal }
+    : 0;
+  ws.getCell(row, 15).numFmt = RMB;
+  // 模价 HKD 小计 = 上方 模价HKD(P) 列求和（与各行 HKD 公式一致）
+  ws.getCell(row, 16).value = molds.length
+    ? { formula: `SUM(P${moldDataStart}:P${moldDataEnd})`, result: moldSubtotal / fxRH }
+    : 0;
+  ws.getCell(row, 16).numFmt = '"HK$"#,##0.00';
+  whiteFill(row);
+  styleSubtotal(ws.getCell(row, 15), 'sub');
+  styleSubtotal(ws.getCell(row, 16), 'total');
+  ws.getCell(row, 1).font = { bold: true, color: { argb: 'FF1F2937' }, name: 'Microsoft YaHei' };
+  ws.getCell(row, 15).font = { bold: true, color: { argb: 'FF1F2937' }, name: 'Microsoft YaHei' };
+  ws.getCell(row, 16).font = { bold: true, color: { argb: 'FF1F2937' }, name: 'Microsoft YaHei' };
+  row += 2;
+
+  // 收集各 section 的"合计"单元格地址，供九、合计行用公式引用
+  const subRefs = {};
+
+  // 模具分摊 套数（与下方 九、合计 同源，确保 模具费用表 分摊 与 模具分摊 公式一致）
+  const moldAmortQty = Math.max(num((eng.mold_costs || {}).amortization_qty) || num((sales.pricing || {}).mold_amortization_qty) || num(quote.qty), 1);
+
+  // ---------- 模具费用（mold_costs 子表）----------
+  row = renderMoldCosts(ws, row, eng.mold_costs, quote, subRefs, moldAmortQty);
+
+  // ---------- 二、注塑部分 ----------
+  row = renderInjection(ws, row, mold, fxRH, subRefs);
+  const injSubtotal = injectionSubtotal(mold);
+
+  // ---------- 二·B、吹气 / 二·C、搪胶 ----------
+  row = renderBlowBlock(ws, row, mold, subRefs);
+  row = renderSlushBlock(ws, row, slush, fxRH, subRefs);
+
+  // ---------- 三、二次加工 ----------
+  row = renderSecondProc(ws, row, pnt, fxRH, subRefs);
+  const ppSubtotal = secondProcSubtotal(pnt);
+
+  // ---------- 四、电子 / 五、五金（两张子表，五金不计损耗） ----------
+  // 电子 总表：优先用 电子部 section 的 payload；回退用 工程的（兼容旧数据）
+  const elecRows = (electronic.electronics && electronic.electronics.length) ? electronic.electronics : (eng.electronics || []);
+  const elecLoss = 0;  // 电子 不计算损耗
+  row = renderFreeTable(ws, row, '四、电子', elecRows, elecLoss, fxRH, subRefs, 'electronic', { isHkd: true, skipLoss: true });
+  row = renderFreeTable(ws, row, '五、五金', eng.hardware   || [], 0, fxRH, subRefs, 'hardware', { skipLoss: true, isHkd: true });  // 五金不计损耗、按港币
+  const elecSubtotal = freeSubtotal(elecRows) + freeSubtotal(eng.hardware || []);  // 均不计损耗（HKD）
+
+  // ---------- 五、辅助材料 ----------
+  row = renderFreeTable(ws, row, '六、辅助材料', eng.aux_materials || [], 0, fxRH, subRefs, 'aux', { skipLoss: true, isHkd: true });  // 不计损耗、按港币
+  const auxSubtotal = freeSubtotal(eng.aux_materials || []);
+
+  // ---------- 六、包装材料 ----------
+  row = renderFreeTable(ws, row, '七、包装材料', eng.packaging_materials || [], 0, fxRH, subRefs, 'packaging', { skipLoss: true, isHkd: true });  // 不计损耗、按港币
+  const pkSubtotal = freeSubtotal(eng.packaging_materials || []);
+
+  // ---------- 七、组装人工 — 新版 排拉工序 ----------
+  const _asmBase = num(asm.assembly_base_rate ?? 310);
+  const _asmStd = num(asm.assembly_std_time ?? 11);
+  row = renderAssemblyStepGroups(ws, row, '八、组装人工 — 排拉工序', asm.assembly_step_groups || [], _asmBase, _asmStd, fxRH, subRefs, 'asmLabor');
+  const asmStepRmb = sum(asm.assembly_step_groups || [], g =>
+    sum(g.steps || [], s => _asmBase * num(s.count) / Math.max(num(g.qty), 1)));
+  const asmSubtotal = sum(asm.assembly_labor || [], r => num(r.unit_price) * num(r.qty)) + asmStepRmb;
+
+  // ---------- 八、包装/混装人工 — 新版 排拉工序 ----------
+  row = renderAssemblyStepGroups(ws, row, '九、包装/混装人工 — 排拉工序', asm.packaging_step_groups || [], _asmBase, _asmStd, fxRH, subRefs, 'pkgLabor');
+  const pkgStepRmb = sum(asm.packaging_step_groups || [], g =>
+    sum(g.steps || [], s => _asmBase * num(s.count) / Math.max(num(g.qty), 1)));
+  const pklSubtotal = sum(asm.packaging_labor || [], r => num(r.unit_price) * num(r.qty)) + pkgStepRmb;
+
+  // ---------- 车缝 ----------
+  row = renderSewingBlock(ws, row, sewing, fxRH, subRefs);
+
+  // ---------- 纸箱 / 运费（在九、合计前） ----------
+  row = renderCartonAndFreight(ws, row, eng, sales, subRefs);
+
+  // ---------- 九、合计（含搪胶/车缝/纸箱/附加税） ----------
+  ws.mergeCells(row, 1, row, 17); styleSection(ws.getCell(row, 1));
+  ws.getCell(row, 1).value = '十、合计';
+  row += 1;
+
+  // 整行 HKD（与 UI 一致）
+  const totalsHeader = ['注塑+吹气', '二次加工', '电子五金', '辅助材料', '包装材料', '组装人工', '包装/混装人工', '印尼运费', '搪胶', '车缝', '纸箱', '出厂价 HKD', '码点', '码点后价 HKD', '模具分摊', '附加税0.4%', '出货底价 HKD'];
+  totalsHeader.forEach((h, i) => { ws.getCell(row, i + 1).value = h; styleHeader(ws.getCell(row, i + 1)); });
+  row += 1;
+
+  const pricing = sales.pricing || {};
+  const header = sales.header || {};
+  // 运输费 = 减税明细 印尼运费 (HKD)；× fxRH 当 RMB（后面 /fxRH 还原 HKD）
+  const shipping = num(sales.pricing_summary?.indo_freight) * fxRH;
+  // 注塑是 HKD，换算成 RMB
+  const injSubtotalRmb = injSubtotal * fxRH;
+  // 模具分摊：从工程"模具费用"表取 套产品分摊
+  const mc = eng.mold_costs || {};
+  const moldCostSumRmb = sum(mc.items || [], r => num(r.price_rmb));
+  const moldShare = moldCostSumRmb / moldAmortQty;  // moldAmortQty 已在模具费用表前算好
+  const surtax = sales.pricing_summary?.surtax != null ? num(sales.pricing_summary.surtax) : 0;
+  const slushTotalRmb = sum(slush.slush_items || [], r => num(r.qty) * num(r.unit_price_hkd)) * fxRH;
+  const sewingGroupSum = sum(sewing.sewing_groups || [], g =>
+    sum(g.items || [], r => num(r.usage) * num(r.mat_price) * (num(r.markup) || 1)) + num(g.labor_amount));
+  const sewingTotalRmb = sewingGroupSum;  // 不计损耗
+  // 多纸箱 + 多平卡：Σ((箱价i + Σ平卡i_j) / qty_i) × 汇率
+  const ccx = eng.carton_calc || {};
+  const cartonListX = (ccx.cartons && ccx.cartons.length) ? ccx.cartons : (ccx.cl ? [{
+    cl: ccx.cl, cw: ccx.cw, ch: ccx.ch, qty: ccx.qty,
+    flat_cards: ccx.flat_card ? [{ l: ccx.cl, w: ccx.cw }] : [],
+  }] : []);
+  const cartonRmb = cartonListX.reduce((s, b) => {
+    const boxPrice = (num(b.cl) + num(b.cw) + 2) * (num(b.cw) + num(b.ch) + 1) * 2 * 2.8 / 1000;
+    const flatSum = (b.flat_cards || []).reduce((a, f) => a + (num(f.l) + 1) * (num(f.w) + 1) * 2 / 1000, 0);
+    const q = Math.max(num(b.qty), 1);
+    return s + (boxPrice + flatSum) / q;
+  }, 0) * fxRH;
+  // cost 包含 吹气/搪胶/车缝/纸箱
+  const blowRmb = sum(mold.blow_items || [], r => {
+    const mat = num(r.weight_g) * num(r.material_price_lb) / 454;
+    return (mat + num(r.blow_labor) + num(r.flash)) * (num(r.profit_x) || 1);
+  }) * fxRH;
+  // 电子/五金/辅助/包装/二次加工(喷油)/组装+包装人工 现按港币(HKD)，加入 RMB 成本时 ×fxRH 还原成 RMB
+  const cost = injSubtotalRmb + blowRmb + (ppSubtotal + elecSubtotal + auxSubtotal + pkSubtotal + asmSubtotal + pklSubtotal) * fxRH + shipping + slushTotalRmb + sewingTotalRmb + cartonRmb;
+  // 出厂价（直接 = 各项成本和，不含管理系数、模具分摊、附加税）
+  const factoryRmb = cost;
+  const factoryHkd = factoryRmb / fxRH;
+  // 出货底价（含模具分摊 + 附加税）
+  const priceRmb = factoryRmb + moldShare + surtax;
+  const priceHkd = priceRmb / fxRH;
+
+  // 11 个成本项 A-K (HKD) + L:出厂价HKD M:码点 N:码点后价HKD O:模具分摊HKD P:附加税HKD Q:出货底价HKD
+  // A B C D E F G H I J K L M N O P Q
+  const summaryRow = row;
+  const HKD_FMT = '"HK$"#,##0.0000';
+  const inputs = [
+    // A 注塑+吹气 (HKD) — 注塑、吹气都是 HKD
+    (subRefs.injection || subRefs.blow)
+      ? { formula: `(${[subRefs.injection, subRefs.blow].filter(Boolean).join('+')})`,
+          result: injSubtotal + sum(mold.blow_items || [], r => {
+            const mat = num(r.weight_g) * num(r.material_price_lb) / 454;
+            return (mat + num(r.blow_labor) + num(r.flash)) * (num(r.profit_x) || 1);
+          }) }
+      : injSubtotalRmb / fxRH,
+    // B 二次加工 (本身 HKD，不换算)
+    subRefs.secondProc ? { formula: `${subRefs.secondProc}`, result: ppSubtotal } : ppSubtotal,
+    // C 电子 + 五金 (本身 HKD，不换算)
+    subRefs.electronic && subRefs.hardware ? { formula: `(${subRefs.electronic}+${subRefs.hardware})`, result: elecSubtotal } : elecSubtotal,
+    // D 辅助材料 (HKD)
+    subRefs.aux ? { formula: `${subRefs.aux}`, result: auxSubtotal } : auxSubtotal,
+    // E 包装材料 (HKD)
+    subRefs.packaging ? { formula: `${subRefs.packaging}`, result: pkSubtotal } : pkSubtotal,
+    // F 组装人工 (本身 HKD，不换算)
+    subRefs.asmLabor ? { formula: `${subRefs.asmLabor}`, result: asmSubtotal } : asmSubtotal,
+    // G 包装人工 (本身 HKD，不换算)
+    subRefs.pkgLabor ? { formula: `${subRefs.pkgLabor}`, result: pklSubtotal } : pklSubtotal,
+    // H 运输费 (RMB → HKD)
+    shipping / fxRH,
+    // I 搪胶 (本身就是 HKD)
+    subRefs.slush ? { formula: subRefs.slush, result: slushTotalRmb / fxRH } : slushTotalRmb / fxRH,
+    // J 车缝 (RMB → HKD)
+    subRefs.sewing ? { formula: `${subRefs.sewing}/${fxRH}`, result: sewingTotalRmb / fxRH } : sewingTotalRmb / fxRH,
+    // K 纸箱 (HKD)
+    subRefs.cartonHkdPerPcs ? { formula: `(${subRefs.cartonHkdPerPcs})`, result: cartonRmb / fxRH } : cartonRmb / fxRH,
+  ];
+  inputs.forEach((v, i) => {
+    const c = ws.getCell(row, i + 1);
+    c.value = v; c.numFmt = HKD_FMT; styleData(c);
+  });
+  // L 出厂价 HKD = SUM(A:K)
+  ws.getCell(row, 12).value = { formula: `SUM(A${row}:K${row})`, result: factoryHkd };
+  ws.getCell(row, 12).numFmt = HKD_FMT; styleData(ws.getCell(row, 12)); styleSubtotal(ws.getCell(row, 12), 'sub');
+  // M 码点 (input, 默认 1.2)
+  const markupX = num(sales.shipping?.markup_x) || 1.2;
+  ws.getCell(row, 13).value = markupX; ws.getCell(row, 13).numFmt = '0.00'; styleData(ws.getCell(row, 13));
+  // N 码点后价 HKD = L × M
+  ws.getCell(row, 14).value = { formula: `L${row}*M${row}`, result: factoryHkd * markupX };
+  ws.getCell(row, 14).numFmt = HKD_FMT; styleData(ws.getCell(row, 14)); styleSubtotal(ws.getCell(row, 14), 'sub');
+  // O 模具分摊 HKD = 模具费用表「每套分摊(RMB)」÷ 汇率（活公式）
+  ws.getCell(row, 15).value = subRefs.moldShareRmbCell
+    ? { formula: `${subRefs.moldShareRmbCell}/${fxRH}`, result: moldShare / fxRH }
+    : moldShare / fxRH;
+  ws.getCell(row, 15).numFmt = HKD_FMT; styleData(ws.getCell(row, 15));
+  // P 附加税 HKD
+  ws.getCell(row, 16).value = surtax / fxRH; ws.getCell(row, 16).numFmt = HKD_FMT; styleData(ws.getCell(row, 16));
+  // Q 出货底价 HKD = N + O + P
+  const priceHkdMarked = factoryHkd * markupX + moldShare / fxRH + surtax / fxRH;
+  ws.getCell(row, 17).value = { formula: `N${row}+O${row}+P${row}`, result: priceHkdMarked };
+  ws.getCell(row, 17).numFmt = HKD_FMT; styleData(ws.getCell(row, 17)); styleSubtotal(ws.getCell(row, 17), 'hkd');
+  ws.getRow(row).font = { bold: true, color: { argb: 'FF1F2937' }, name: 'Microsoft YaHei' };
+  row += 2;
+
+  // ---------- 十、出货价算价（多场景） ----------
+  const shipOpts = { summaryRow, markedHkd: factoryHkd * markupX, combinedHkd: priceHkdMarked, freightCells: subRefs.freightCells };
+  row = renderShippingBlock(ws, row, sales.shipping, header, fxRH, shipOpts);
+  // 把"盐田40柜"运费/吊柜费单元格带回 subRefs，供减税明细 表2 直接引用
+  subRefs.shipFreightCell = shipOpts.shipFreightCell;
+  subRefs.shipCabinetCell = shipOpts.shipCabinetCell;
+
+  // ---------- 减税明细 / 成本汇总 ----------
+  row = renderTaxSummary(ws, row, sales, { subRefs, fxRH, summaryRow });
+
+  // 业务算价参数说明
+  ws.mergeCells(row, 1, row, 13);
+  ws.getCell(row, 1).value = `算价：管理费 ${pricing.mgmt_fee_pct || 0}% · 利润 ${pricing.profit_pct || 0}% · 税率 ${pricing.tax_pct || 0}% · RMB→HKD ${fxRH} · HKD→USD ${header.fx_hkd_usd || ''}`;
+  ws.getCell(row, 1).alignment = { horizontal: 'center' };
+  ws.getCell(row, 1).font = { color: { argb: 'FF6B7280' }, italic: true };
+
+  // 车缝明细：单独分表
+  addSewingDetailSheet(wb, sewing, fxRH);
+  // 电子明细：单独分表（用 electronic 部门 payload）
+  addElectronicDetailSheet(wb, electronic, quote);
+
+  beautifyFonts(wb);  // 统一美化字体
+  return wb;
+}
+
+// 统一字体（美化）：全表用同一字体族，保留各单元格的 size/bold/color/italic
+function beautifyFonts(wb, name = FONT) {
+  wb.eachSheet((ws) => {
+    ws.eachRow({ includeEmpty: false }, (row) => {
+      row.eachCell({ includeEmpty: false }, (cell) => {
+        const f = cell.font || {};
+        cell.font = { name, size: f.size || 11, ...f, name };  // name 始终覆盖为统一字体
+      });
+    });
+  });
+}
+
+// 电子明细 — 独立 sheet（按导入的"电子报价单"格式还原）
+function addElectronicDetailSheet(wb, electronic, quote) {
+  const doc = electronic && electronic.electronics_doc;
+  if (!doc || !doc.parts || !doc.parts.length) return;
+  const ws = wb.addWorksheet('电子明细');
+  ws.columns = [
+    { width: 12 },  // A 零件名称
+    { width: 30 },  // B 规格
+    { width: 8 },   // C 用量
+    { width: 12 },  // D 单价RMB
+    { width: 12 },  // E 合计RMB
+    { width: 14 },  // F 备注
+    { width: 14 },  // G 汇总标签
+    { width: 12 },  // H 汇总值
+    { width: 12 },  // I 注
+  ];
+  let row = 1;
+  // 标题
+  ws.mergeCells(row, 1, row, 9);
+  ws.getCell(row, 1).value = '电子报价单';
+  ws.getCell(row, 1).font = { bold: true, size: 16, name: 'Microsoft YaHei' };
+  ws.getCell(row, 1).alignment = { horizontal: 'center', vertical: 'middle' };
+  ws.getRow(row).height = 28;
+  row += 2;
+  // 元数据
+  const meta = doc.meta || {};
+  ws.getCell(row, 1).value = '产品名称：' + (meta.product || (quote && quote.product_name) || '');
+  ws.getCell(row, 3).value = '产品编号：' + (meta.product_no || (quote && quote.quote_no) || '');
+  ws.getCell(row, 5).value = '客户：' + (meta.customer || (quote && quote.customer) || '');
+  ws.getCell(row, 7).value = '报价日期：' + (meta.date || doc.imported_at || '');
+  for (let c = 1; c <= 9; c++) ws.getCell(row, c).font = { name: 'Microsoft YaHei' };
+  row += 2;
+  // 表头
+  const h = ['零件名称', '规格', '用量', '单价RMB', '合计RMB', '备注'];
+  h.forEach((v, i) => { ws.getCell(row, i + 1).value = v; styleHeader(ws.getCell(row, i + 1)); });
+  row += 1;
+  const dataStart = row;
+  doc.parts.forEach(p => {
+    // 父行
+    ws.getCell(row, 1).value = p.name || '';
+    ws.getCell(row, 2).value = p.spec || '';
+    ws.getCell(row, 3).value = num(p.qty);
+    ws.getCell(row, 4).value = num(p.unit_price);
+    ws.getCell(row, 5).value = { formula: `C${row}*D${row}`, result: num(p.qty) * num(p.unit_price) };
+    ws.getCell(row, 5).numFmt = '0.000';
+    ws.getCell(row, 6).value = p.note || '';
+    for (let c = 1; c <= 6; c++) styleData(ws.getCell(row, c));
+    if (p.name) ws.getCell(row, 1).font = { bold: true, name: 'Microsoft YaHei' };
+    row += 1;
+    // 子项行
+    (p.children || []).forEach(c => {
+      ws.getCell(row, 1).value = '';
+      ws.getCell(row, 2).value = c.spec || '';
+      ws.getCell(row, 3).value = num(c.qty);
+      ws.getCell(row, 4).value = num(c.unit_price);
+      ws.getCell(row, 5).value = { formula: `C${row}*D${row}`, result: num(c.qty) * num(c.unit_price) };
+      ws.getCell(row, 5).numFmt = '0.000';
+      ws.getCell(row, 6).value = c.note || '';
+      for (let k = 1; k <= 6; k++) styleData(ws.getCell(row, k));
+      row += 1;
+    });
+  });
+  const dataEnd = row - 1;
+  row += 1;
+  // 成本汇总
+  const ex = doc.extras || {};
+  const partsCost = sum(doc.parts, p => num(p.qty) * num(p.unit_price)
+    + sum(p.children || [], c => num(c.qty) * num(c.unit_price)));
+  const labels = [
+    ['零件成本', partsCost, `SUM(E${dataStart}:E${dataEnd})`],
+    ['邦定成本', num(ex.bonding_cost), null],
+    ['贴片成本', num(ex.smt_cost), null],
+    ['人工成本', num(ex.labor_cost), null],
+    ['测试费用', num(ex.test_repair), null],
+    ['包装运输', num(ex.packing_shipping), null],
+  ];
+  const summaryStart = row;
+  labels.forEach(([lab, val, fml]) => {
+    ws.getCell(row, 7).value = lab + '：';
+    ws.getCell(row, 7).alignment = { horizontal: 'right' };
+    ws.getCell(row, 8).value = fml ? { formula: fml, result: val } : val;
+    ws.getCell(row, 8).numFmt = '0.000';
+    styleData(ws.getCell(row, 7));
+    styleData(ws.getCell(row, 8));
+    row += 1;
+  });
+  // 合计成本
+  ws.getCell(row, 7).value = '合计成本：';
+  ws.getCell(row, 7).alignment = { horizontal: 'right' };
+  ws.getCell(row, 7).font = { bold: true, name: 'Microsoft YaHei' };
+  ws.getCell(row, 8).value = { formula: `SUM(H${summaryStart}:H${row - 1})`, result: partsCost + num(ex.test_repair) + num(ex.packing_shipping) };
+  ws.getCell(row, 8).numFmt = '0.000';
+  styleSubtotal(ws.getCell(row, 8), 'sub');
+  const totalCostRow = row;
+  row += 1;
+  // 含利润价
+  const profitPct = num(ex.profit_pct);
+  ws.getCell(row, 7).value = `含 ${profitPct}% 利润价：`;
+  ws.getCell(row, 7).alignment = { horizontal: 'right' };
+  ws.getCell(row, 7).font = { bold: true, name: 'Microsoft YaHei' };
+  const profitVal = ex.profit_price != null ? num(ex.profit_price) : (partsCost + num(ex.test_repair) + num(ex.packing_shipping)) * (1 + profitPct / 100);
+  ws.getCell(row, 8).value = { formula: `H${totalCostRow}*(1+${profitPct}/100)`, result: profitVal };
+  ws.getCell(row, 8).numFmt = '0.000';
+  ws.getCell(row, 9).value = 'RMB 不含税价';
+  styleSubtotal(ws.getCell(row, 8), 'sub');
+  row += 1;
+  // 抵税差额
+  ws.getCell(row, 7).value = '抵税差额：';
+  ws.getCell(row, 7).alignment = { horizontal: 'right' };
+  ws.getCell(row, 8).value = num(ex.tax_diff);
+  ws.getCell(row, 8).numFmt = '0.000';
+  styleData(ws.getCell(row, 8));
+  row += 1;
+  // 应交税负
+  ws.getCell(row, 7).value = '应交税负：';
+  ws.getCell(row, 7).alignment = { horizontal: 'right' };
+  ws.getCell(row, 8).value = num(ex.tax_payable);
+  ws.getCell(row, 8).numFmt = '0.000';
+  styleData(ws.getCell(row, 8));
+  row += 1;
+  // 含税报价
+  ws.getCell(row, 7).value = '含税报价：';
+  ws.getCell(row, 7).alignment = { horizontal: 'right' };
+  ws.getCell(row, 7).font = { bold: true, name: 'Microsoft YaHei' };
+  const taxedVal = ex.taxed_price != null ? num(ex.taxed_price) : profitVal + num(ex.tax_diff) + num(ex.tax_payable);
+  ws.getCell(row, 8).value = taxedVal;
+  ws.getCell(row, 8).numFmt = '0.000';
+  ws.getCell(row, 9).value = 'RMB 含税价';
+  styleSubtotal(ws.getCell(row, 8), 'hkd');
+}
+
+// 车缝明细 — 独立 sheet
+function addSewingDetailSheet(wb, sewing, fxRH) {
+  const groups = (sewing && sewing.sewing_groups) || [];
+  if (!groups.length) return;
+  const ws = wb.addWorksheet('车缝明细');
+  ws.columns = [
+    { width: 6 },   // A 序号
+    { width: 36 },  // B 布料名称
+    { width: 12 },  // C 部位
+    { width: 10 },  // D 工艺
+    { width: 10 },  // E 裁片数
+    { width: 14 },  // F 用量/码
+    { width: 14 },  // G 物料价(RMB)
+    { width: 14 },  // H 价钱(RMB)
+    { width: 10 },  // I 码点
+    { width: 14 },  // J 总价钱(RMB)
+    { width: 18 },  // K 备注
+  ];
+  let row = 1;
+  ws.mergeCells(row, 1, row, 11); styleSection(ws.getCell(row, 1));
+  ws.getCell(row, 1).value = '车缝明细';
+  row += 1;
+  let grand = 0;
+  groups.forEach((g, gi) => {
+    ws.mergeCells(row, 1, row, 11);
+    ws.getCell(row, 1).value = `产品：${g.name || '未命名 ' + (gi + 1)}`;
+    ws.getCell(row, 1).font = { bold: true, color: { argb: 'FF16A34A' }, name: 'Microsoft YaHei' };
+    ws.getCell(row, 1).fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFECFDF5' } };
+    row += 1;
+    const h = ['序号', '布料名称', '部位', '工艺', '裁片数', '用量/码', '物料价(RMB)', '价钱(RMB)', '码点', '总价钱(RMB)', '备注'];
+    h.forEach((v, i) => { ws.getCell(row, i + 1).value = v; styleHeader(ws.getCell(row, i + 1)); });
+    row += 1;
+    const start = row;
+    (g.items || []).forEach((r, i) => {
+      ws.getCell(row, 1).value = i + 1;
+      ws.getCell(row, 2).value = r.fabric || '';
+      ws.getCell(row, 3).value = r.part || '';
+      ws.getCell(row, 4).value = r.craft || '';
+      ws.getCell(row, 5).value = num(r.pieces);
+      ws.getCell(row, 6).value = num(r.usage);
+      ws.getCell(row, 6).numFmt = '0.000';
+      ws.getCell(row, 7).value = num(r.mat_price);
+      ws.getCell(row, 7).numFmt = '0.00';
+      ws.getCell(row, 8).value = { formula: `F${row}*G${row}`, result: num(r.usage) * num(r.mat_price) };
+      ws.getCell(row, 8).numFmt = '0.0000';
+      ws.getCell(row, 9).value = num(r.markup) || 1;
+      ws.getCell(row, 9).numFmt = '0.00';
+      ws.getCell(row, 10).value = { formula: `H${row}*I${row}`, result: num(r.usage) * num(r.mat_price) * (num(r.markup) || 1) };
+      ws.getCell(row, 10).numFmt = '0.0000';
+      ws.getCell(row, 11).value = r.note || '';
+      for (let c = 1; c <= 11; c++) styleData(ws.getCell(row, c));
+      row += 1;
+    });
+    const end = row - 1;
+    const itemsSum = sum(g.items || [], r => num(r.usage) * num(r.mat_price) * (num(r.markup) || 1));
+    const laborAmt = num(g.labor_amount);
+    const groupTotal = itemsSum + laborAmt;  // 与 UI 本组小计 一致 = 物料 + 人工(labor_amount)
+    // 本组合计
+    ws.mergeCells(row, 1, row, 9);
+    ws.getCell(row, 1).value = '本组合计 RMB（含人工 ' + laborAmt.toFixed(2) + '）';
+    ws.getCell(row, 1).alignment = { horizontal: 'right' };
+    ws.getCell(row, 10).value = (g.items || []).length
+      ? { formula: `SUM(J${start}:J${end})+${laborAmt}`, result: groupTotal } : groupTotal;
+    ws.getCell(row, 10).numFmt = RMB;
+    for (let c = 1; c <= 11; c++) { const cell = ws.getCell(row, c); cell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFFFFFFF' } }; cell.border = thinBorder(); }
+    styleSubtotal(ws.getCell(row, 10), 'sub');
+    ws.getCell(row, 1).font = { bold: true, name: 'Microsoft YaHei' };
+    ws.getCell(row, 10).font = { bold: true, name: 'Microsoft YaHei' };
+    grand += groupTotal;
+    row += 1;
+    row += 1;  // 空行
+  });
+  // 配套合计
+  ws.mergeCells(row, 1, row, 9);
+  ws.getCell(row, 1).value = '配套合计 RMB';
+  ws.getCell(row, 1).alignment = { horizontal: 'right' };
+  ws.getCell(row, 1).font = { bold: true, name: 'Microsoft YaHei' };
+  ws.getCell(row, 10).value = grand;
+  ws.getCell(row, 10).numFmt = RMB;
+  styleSubtotal(ws.getCell(row, 10), 'hkd');
+  ws.getCell(row, 10).font = { bold: true, name: 'Microsoft YaHei' };
+}
+
+function renderShippingBlock(ws, row, shipping, header, fxRH, refs = {}) {
+  if (!shipping || !shipping.scenarios || !shipping.scenarios.length) return row;
+  // 兜底：确保第一列是 出厂价（前端没打开过 汇总 tab 时缺失）
+  if (!shipping.scenarios[0].is_factory) {
+    shipping.scenarios = [{ name: '出厂价', base_rmb: 0, is_factory: true }, ...shipping.scenarios];
+  }
+  const fxHU = num(header.fx_hkd_usd) || 7.8;
+  const sc = shipping.scenarios;
+  const cols = sc.length;
+
+  // 章节标题
+  ws.mergeCells(row, 1, row, Math.max(13, cols + 1)); styleSection(ws.getCell(row, 1));
+  ws.getCell(row, 1).value = '十一、出货价算价（多场景）';
+  row += 1;
+
+  const headerCells = ['项', ...sc.map(x => x.name || '场景')];
+  headerCells.forEach((v, i) => { ws.getCell(row, i + 1).value = v; styleHeader(ws.getCell(row, i + 1)); });
+  row += 1;
+
+  const colLetter = (n) => { let s=''; while(n>0){const m=(n-1)%26; s=String.fromCharCode(65+m)+s; n=Math.floor((n-1)/26);} return s; };
+
+  // 标签列 = A，场景列从 B 开始（fxRH 由参数传入）
+
+  // 运费场景 freightMap key → 运费场景表行名（供引用 每PCS运费率 E 列）
+  const KEY_TO_NAME = { hk40: 'HK 40柜', yt40: 'YT 40柜', hk20: 'HK 20柜', yt20: 'YT 20柜', hk10t: 'HK 10吨车', yt10t: 'YT 10吨车', hk5t: 'HK 5吨车', yt5t: 'YT 5吨车' };
+  const fcells = refs.freightCells || {};
+  const rateCellOf = (x) => fcells[KEY_TO_NAME[x._freight_matched]] || null;
+  // 每行的预计算值（用作公式 fallback result）
+  const rows = sc.map(x => {
+    // 出货底价：出厂价列 = 码点后价 N(实时)；其他场景 = 出货底价 Q(实时)
+    const base = x.is_factory ? (refs.markedHkd != null ? refs.markedHkd : num(x.base_rmb))
+                              : (refs.combinedHkd != null ? refs.combinedHkd : num(x.base_rmb));
+    // 运费/吊柜费 = 该场景 每PCS运费率(_freight_rate) × 运费%/吊柜%（与前端一致，非出货底价×%）
+    const rate = num(x._freight_rate);
+    const freight = x.is_factory ? 0 : rate * num(shipping.freight_pct) / 100;
+    const lifting = x.is_factory ? 0 : rate * num(shipping.lifting_pct) / 100;
+    const afterShip = base + freight + lifting;
+    const afterMarkup = afterShip * num(shipping.markup_x);
+    const totalHKD = afterMarkup / Math.max(num(shipping.divisor), 1e-9);
+    const totalUSD = totalHKD / fxHU;
+    const moldShareUSD = num(x.mold_share_rmb) / fxRH / fxHU;
+    const finalUSD = totalUSD + moldShareUSD;
+    return { base, freight, lifting, afterShip, afterMarkup, totalHKD, totalUSD, moldShareUSD, finalUSD };
+  });
+
+  // 记录每行所在的 Excel 行号，构造公式
+  const writeRow = (label, valueFn, opts = {}) => {
+    ws.getCell(row, 1).value = label;
+    styleData(ws.getCell(row, 1));
+    ws.getCell(row, 1).alignment = { horizontal: 'right' };
+    sc.forEach((_, i) => {
+      const c = ws.getCell(row, i + 2);
+      c.value = valueFn(i);
+      if (opts.fmt) c.numFmt = opts.fmt;
+      styleData(c);
+      if (opts.bold) c.font = { ...(c.font || {}), bold: true };
+    });
+    row += 1;
+  };
+
+  // 1. 出货底价：出厂价列 = 九、合计 N（码点后价 HKD）；其他场景 = 九、合计 Q（出货底价 HKD）
+  const rBase = row;
+  const sumR = refs.summaryRow;
+  writeRow('出货底价 HK$', i => {
+    if (sumR) {
+      const ref = sc[i].is_factory ? `N${sumR}` : `Q${sumR}`;
+      return { formula: ref, result: rows[i].base };
+    }
+    return rows[i].base;
+  }, { fmt: '0.00' });
+  // 2. 运费：出厂价列 = 0；其他场景 = 该场景每PCS运费率 × 运费%（引用上方"运费场景"表对应行 E 列）
+  const rFre = row;
+  const freightRefFn = (pct) => (i) => {
+    if (sc[i].is_factory) return 0;
+    const rc = rateCellOf(sc[i]);
+    const ref = rc ? `${rc}*${pct}/100` : `${num(sc[i]._freight_rate)}*${pct}/100`;
+    return { formula: ref, result: sc[i].is_factory ? 0 : num(sc[i]._freight_rate) * pct / 100 };
+  };
+  writeRow(`运费 ${shipping.freight_pct || 0}%`, freightRefFn(num(shipping.freight_pct)), { fmt: '0.00' });
+  // 3. 吊柜费：出厂价列 = 0
+  const rLift = row;
+  writeRow(`吊柜费 ${shipping.lifting_pct || 0}%`, freightRefFn(num(shipping.lifting_pct)), { fmt: '0.00' });
+  // 记录"盐田40柜"(或首个非出厂价)场景的 运费/吊柜费 单元格，供减税明细 表2 直接引用
+  const freightColIdx = (() => { const i = sc.findIndex(x => !x.is_factory && /盐田.*40/i.test(x.name || '')); return i >= 0 ? i : sc.findIndex(x => !x.is_factory); })();
+  if (freightColIdx >= 0) {
+    refs.shipFreightCell = `${colLetter(freightColIdx + 2)}${rFre}`;
+    refs.shipCabinetCell = `${colLetter(freightColIdx + 2)}${rLift}`;
+  }
+  // 4. 含运 = 底价 + 运费 + 吊柜
+  const rAS = row;
+  writeRow('含运 HK$',
+    i => ({ formula: `${colLetter(i+2)}${rBase}+${colLetter(i+2)}${rFre}+${colLetter(i+2)}${rLift}`, result: rows[i].afterShip }),
+    { fmt: '0.00', bold: true });
+  // 5. 码点 ×
+  const rMk = row;
+  writeRow(`码点 × ${shipping.markup_x || 1}`,
+    i => ({ formula: `${colLetter(i+2)}${rAS}*${num(shipping.markup_x)}`, result: rows[i].afterMarkup }),
+    { fmt: '0.00' });
+  // 6. 找数 ÷
+  const rDiv = row;
+  writeRow(`找数 ÷ ${shipping.divisor || 1}`,
+    i => ({ formula: `${colLetter(i+2)}${rMk}/${num(shipping.divisor)}`, result: rows[i].totalHKD }),
+    { fmt: '0.00' });
+  // 7. TOTAL HK$
+  const rHKD = row;
+  writeRow('TOTAL (HK$)',
+    i => ({ formula: `${colLetter(i+2)}${rDiv}`, result: rows[i].totalHKD }),
+    { fmt: '0.00', bold: true });
+  // 8. USD
+  const rUSD = row;
+  writeRow(`(USD) = HK$/${fxHU}`,
+    i => ({ formula: `${colLetter(i+2)}${rHKD}/${fxHU}`, result: rows[i].totalUSD }),
+    { fmt: '0.0000' });
+  // 9. 模费分摊 RMB（输入）
+  const rMold = row;
+  writeRow('模费分摊 (RMB)', i => num(sc[i].mold_share_rmb), { fmt: '0.00' });
+  // 10. TOTAL USD 含模费 = USD + 模费RMB/汇率RH/汇率HU
+  const rFinal = row;
+  writeRow('TOTAL (USD) 含模费',
+    i => ({ formula: `${colLetter(i+2)}${rUSD}+${colLetter(i+2)}${rMold}/${fxRH}/${fxHU}`, result: rows[i].finalUSD }),
+    { fmt: '0.0000', bold: true });
+
+  // 报客货价 = 第一个非"出厂价"场景的 finalUSD（默认 盐田40柜）
+  const customerIdx = sc.findIndex(x => !x.is_factory);
+  const customerUSD = (customerIdx >= 0 && rows[customerIdx]) ? rows[customerIdx].finalUSD
+    : (rows.length ? Math.min(...rows.map(r => r.finalUSD)) : 0);
+  const target = num(shipping.target_usd);
+  const diffPct = target > 0 ? (customerUSD - target) / target : 0;
+  // 引用单元格地址：B 是 第1列(出厂价)，customerIdx >= 0 时 = B + customerIdx
+  const custCol = (customerIdx >= 0) ? colLetter(customerIdx + 2) : 'B';
+
+  ws.mergeCells(row, 1, row, cols + 1);
+  ws.getCell(row, 1).value = {
+    formula: `"报客货价: "&TEXT(${custCol}${rFinal},"0.0000")&" | 目标: ${target.toFixed(4)} | 相差: "&TEXT((${custCol}${rFinal}-${target})/${target || 1}*100,"0.00")&"%"`,
+    result: `报客货价: ${customerUSD.toFixed(4)} | 目标: ${target.toFixed(4)} | 相差: ${(diffPct * 100).toFixed(2)}%`,
+  };
+  ws.getCell(row, 1).alignment = { horizontal: 'center', vertical: 'middle' };
+  ws.getCell(row, 1).font = { bold: true, color: { argb: 'FF1F2937' } };
+  ws.getCell(row, 1).fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFE7E5E4' } };
+  styleData(ws.getCell(row, 1));
+  row += 2;
+  return row;
+}
+
+// ----- 子渲染函数 -----
+function renderInjection(ws, row, payload, fxRH, refs) {
+  const lossPct = num(payload.injection_loss_pct ?? 3);  // 注塑料损耗（默认3%）
+  const h = ['序号', '模具名称', '材质', '料型', '颜色', '啤净重(g)', `料损耗 ${lossPct}%`, '料价 HK$/g', '原料单价 HK$', '机台', '啤价 HK$/啤', '套数', '机型', '目标数', '周期(秒)', '成品金额 HK$'];
+  ws.mergeCells(row, 1, row, h.length); styleSection(ws.getCell(row, 1));
+  ws.getCell(row, 1).value = '二、注塑部分';
+  row += 1;
+  h.forEach((v, i) => { ws.getCell(row, i + 1).value = v; styleHeader(ws.getCell(row, i + 1)); });
+  row += 1;
+  const dataStart = row;
+  const lossM = 1 + lossPct / 100;
+  const impMatCells = [], domMatCells = [];  // 原料单价(I列)单元格，按材质分进口料/国内料（与前端 autoFill 同逻辑）
+  (payload.injection || []).forEach((r, i) => {
+    const wg = num(r.weight_g);
+    const up = num(r.material_unit_price);
+    const sp = num(r.shot_price);
+    const rawUnit = wg * lossM * up;
+    const finished = rawUnit + sp;
+
+    ws.getCell(row, 1).value = i + 1;
+    ws.getCell(row, 2).value = r.name || '';
+    ws.getCell(row, 3).value = r.material || '';
+    ws.getCell(row, 4).value = r.material_grade || '';
+    ws.getCell(row, 5).value = r.color || '';
+    ws.getCell(row, 6).value = wg;
+    // 料损耗 = 啤净重 × (1+损耗%)
+    ws.getCell(row, 7).value = { formula: `F${row}*${lossM}`, result: wg * lossM };
+    ws.getCell(row, 7).numFmt = '0.00';
+    ws.getCell(row, 8).value = up;
+    // 原料单价 = 料损耗 × 料价
+    ws.getCell(row, 9).value = { formula: `G${row}*H${row}`, result: rawUnit };
+    ws.getCell(row, 9).numFmt = '0.0000';
+    ws.getCell(row, 10).value = r.machine || '';
+    ws.getCell(row, 11).value = sp;
+    ws.getCell(row, 12).value = r.sets ?? 1;
+    ws.getCell(row, 13).value = r.machine_model || '';
+    ws.getCell(row, 14).value = num(r.target);
+    ws.getCell(row, 15).value = r.cycle_sec == null || r.cycle_sec === '' ? '' : num(r.cycle_sec);
+    // 成品金额 = 原料单价 + 啤价
+    ws.getCell(row, 16).value = { formula: `I${row}+K${row}`, result: finished };
+    ws.getCell(row, 16).numFmt = '0.0000';
+    for (let c = 1; c <= h.length; c++) styleData(ws.getCell(row, c));
+    // 按材质分进口料/国内料（与前端 workbench.js 同逻辑）：POM/PVC/C-PVC = 国内料；其余非空 = 进口料
+    const _mat = String(r.material || '').toUpperCase().trim();
+    if (/^(POM|PVC|C[- ]?PVC)/.test(_mat)) domMatCells.push(`I${row}`);
+    else if (_mat) impMatCells.push(`I${row}`);
+    row += 1;
+  });
+  const dataEnd = row - 1;
+  const cnt = (payload.injection || []).length;
+  if (cnt) {
+    const rawSumVal = sum(payload.injection, r => num(r.weight_g) * lossM * num(r.material_unit_price));
+    const shotSumVal = sum(payload.injection, r => num(r.shot_price));
+    const finSumVal = rawSumVal + shotSumVal;
+    // 合计行：分别 sum 原料单价(I) / 啤价(K) / 成品金额(O)
+    const totalRow = row;
+    ws.getCell(row, 1).value = '合计';
+    ws.getCell(row, 1).alignment = { horizontal: 'right', vertical: 'middle' };
+    ws.mergeCells(row, 1, row, 8);
+    ws.getCell(row, 9).value = { formula: `SUM(I${dataStart}:I${dataEnd})`, result: rawSumVal };
+    ws.getCell(row, 9).numFmt = '0.0000';
+    ws.getCell(row, 11).value = { formula: `SUM(K${dataStart}:K${dataEnd})`, result: shotSumVal };
+    ws.getCell(row, 11).numFmt = '0.0000';
+    ws.getCell(row, 16).value = { formula: `SUM(P${dataStart}:P${dataEnd})`, result: finSumVal };
+    ws.getCell(row, 16).numFmt = '0.0000';
+    for (let c = 1; c <= 16; c++) styleSubtotal(ws.getCell(row, c), 'hkd');
+    // 加粗 合计 标签 + 3 个数值
+    [1, 9, 11, 16].forEach(c => {
+      ws.getCell(row, c).font = { bold: true, color: { argb: 'FF1F2937' }, name: 'Microsoft YaHei' };
+    });
+    ws.getRow(row).height = 22;
+    row += 1;
+    if (refs) { refs.injection = `P${totalRow}`; refs.injShotSum = `K${totalRow}`; }  // K = Σ啤价 → 表3 啤工
+  }
+  if (refs) { refs.impMatCells = impMatCells; refs.domMatCells = domMatCells; }
+  return row;
+}
+function materialCost(r) {
+  if (r.material_cost_manual != null && r.material_cost_manual !== '') return num(r.material_cost_manual);
+  return num(r.weight_g) / 1000 * num(r.material_unit_price);
+}
+function injectionSubtotal(p) {
+  // 与注塑表"成品金额"一致 = 原料单价(啤净重×(1+料损耗%)×料价) + 啤价；用于出厂价成本
+  const lossM = 1 + num(p.injection_loss_pct ?? 3) / 100;
+  return sum(p.injection || [], r => num(r.weight_g) * lossM * num(r.material_unit_price) + num(r.shot_price));
+}
+
+function renderSecondProc(ws, row, payload, fxRH, refs) {
+  // 二次加工 = 喷油部 painting_items（夹模/移印/散枪/边模/抹油 五工序）
+  const items = payload.painting_items || payload.second_proc || [];
+  ws.mergeCells(row, 1, row, 14); styleSection(ws.getCell(row, 1));
+  ws.getCell(row, 1).value = '三、二次加工（印喷报价）';
+  row += 1;
+
+  // 表头双层：合并工序大标题 + 数量/单价子标题
+  // 列布局（14 列）:
+  // A 序号 | B 货号 | C 位置 | D 夹模数量 | E 夹模单价 | F 移印数量 | G 移印单价 | H 散枪数量 | I 散枪单价 | J 边模数量 | K 边模单价 | L 抹油数量 | M 抹油单价 | N 报价
+  const procs = ['夹模', '移印', '散枪', '边模', '抹油'];
+  // 第 1 行
+  ws.getCell(row, 1).value = '序号'; styleHeader(ws.getCell(row, 1));
+  ws.mergeCells(row, 1, row + 1, 1);
+  ws.getCell(row, 2).value = '货号'; styleHeader(ws.getCell(row, 2));
+  ws.mergeCells(row, 2, row + 1, 2);
+  ws.getCell(row, 3).value = '位置'; styleHeader(ws.getCell(row, 3));
+  ws.mergeCells(row, 3, row + 1, 3);
+  procs.forEach((p, pi) => {
+    const c = 4 + pi * 2;
+    ws.mergeCells(row, c, row, c + 1);
+    ws.getCell(row, c).value = p;
+    styleHeader(ws.getCell(row, c));
+    styleHeader(ws.getCell(row, c + 1));
+  });
+  ws.getCell(row, 14).value = '报价'; styleHeader(ws.getCell(row, 14));
+  ws.mergeCells(row, 14, row + 1, 14);
+  row += 1;
+  // 第 2 行：数量/单价
+  procs.forEach((_, pi) => {
+    const c = 4 + pi * 2;
+    ws.getCell(row, c).value = '数量'; styleHeader(ws.getCell(row, c));
+    ws.getCell(row, c + 1).value = '单价'; styleHeader(ws.getCell(row, c + 1));
+  });
+  row += 1;
+
+  const dataStart = row;
+  const procKeys = ['clamp', 'pad', 'spray', 'edge', 'oil'];
+  items.forEach((r, i) => {
+    ws.getCell(row, 1).value = i + 1;
+    ws.getCell(row, 2).value = r.item_code || '';
+    ws.getCell(row, 3).value = r.position || '';
+    procKeys.forEach((k, pi) => {
+      const c = 4 + pi * 2;
+      ws.getCell(row, c).value = num(r[k + '_qty']);
+      ws.getCell(row, c + 1).value = num(r[k + '_unit']);
+      ws.getCell(row, c + 1).numFmt = '0.0000';
+    });
+    // 报价 = SUM(数量*单价) 五个
+    const colLetter = (n) => { let s=''; while(n>0){const m=(n-1)%26; s=String.fromCharCode(65+m)+s; n=Math.floor((n-1)/26);} return s; };
+    const parts = procKeys.map((_, pi) => {
+      const c = 4 + pi * 2;
+      return `${colLetter(c)}${row}*${colLetter(c+1)}${row}`;
+    });
+    const computed = procKeys.reduce((s, k) => s + num(r[k+'_qty']) * num(r[k+'_unit']), 0);
+    ws.getCell(row, 14).value = { formula: parts.join('+'), result: computed };
+    ws.getCell(row, 14).numFmt = '0.0000';
+    for (let c = 1; c <= 14; c++) styleData(ws.getCell(row, c));
+    row += 1;
+  });
+  const dataEnd = row - 1;
+
+  const ppRaw = sum(items, r => procKeys.reduce((s, k) => s + num(r[k+'_qty']) * num(r[k+'_unit']), 0));
+  row = appendThreeRowSubtotal(ws, row, {
+    rawSum: ppRaw,
+    lossPct: 0, skipLoss: true,  // 不计损耗
+    fxRH, valueCol: 14,
+    sumFormula: items.length ? `SUM(N${dataStart}:N${dataEnd})` : null,
+    currency: 'HKD',  // 喷油报价为港币
+    refs, refKey: 'secondProc',
+  });
+  return row;
+}
+function secondProcSubtotal(p) {
+  const procKeys = ['clamp', 'pad', 'spray', 'edge', 'oil'];
+  const items = p.painting_items || p.second_proc || [];
+  const s = sum(items, r => {
+    if (r.price !== undefined) return num(r.price) * num(r.qty); // 旧结构兼容
+    return procKeys.reduce((acc, k) => acc + num(r[k+'_qty']) * num(r[k+'_unit']), 0);
+  });
+  return s;  // 不计损耗
+}
+
+function renderFreeTable(ws, row, title, rows, lossPct, fxRH, refs, refKey, opts) {
+  const isHkd = !!(opts && opts.isHkd);
+  const skipLoss = !!(opts && opts.skipLoss);
+  ws.mergeCells(row, 1, row, 13); styleSection(ws.getCell(row, 1));
+  ws.getCell(row, 1).value = title;
+  row += 1;
+  const priceLabel = isHkd ? '单价 HKD' : '单价';
+  const amtLabel   = isHkd ? '金额 HKD' : '成品金额';
+  const h = ['序号', '零件名称', '规格要求', '', '', '', '', '用量', priceLabel, amtLabel, '税点 %', '备注'];
+  h.forEach((v, i) => { ws.getCell(row, i + 1).value = v; styleHeader(ws.getCell(row, i + 1)); });
+  ws.mergeCells(row, 3, row, 7);
+  row += 1;
+  const dataStart = row;
+  const fmt = isHkd ? HKD4 : RMB;
+  const partRows = [];  // 记录每行 {name, spec, cell:金额(J列)} 供减税明细公式按关键字分类
+  rows.forEach((r, i) => {
+    if (!r.is_subtotal) partRows.push({ name: r.name || '', spec: r.spec || '', category: r.category || '', cell: `J${row}` });
+    ws.getCell(row, 1).value = i + 1;
+    ws.getCell(row, 2).value = r.name || '';
+    ws.mergeCells(row, 3, row, 7);
+    ws.getCell(row, 3).value = r.spec || '';
+    ws.getCell(row, 8).value = num(r.qty);
+    ws.getCell(row, 9).value = num(r.unit_price);
+    ws.getCell(row, 9).numFmt = fmt;
+    if (r.is_subtotal) {
+      ws.getCell(row, 10).value = num(r.amount);
+    } else {
+      ws.getCell(row, 10).value = { formula: `H${row}*I${row}`, result: num(r.qty) * num(r.unit_price) };
+    }
+    ws.getCell(row, 10).numFmt = fmt;
+    ws.getCell(row, 11).value = r.tax_pct == null || r.tax_pct === '' ? '' : num(r.tax_pct);
+    ws.getCell(row, 12).value = r.note || '';
+    for (let c = 1; c <= 12; c++) styleData(ws.getCell(row, c));
+    if (r.is_subtotal) ws.getRow(row).font = { bold: true };
+    row += 1;
+  });
+  const dataEnd = row - 1;
+  // 小计 / 损耗 / 合计
+  row = appendThreeRowSubtotal(ws, row, {
+    rawSum: freeRaw(rows),
+    lossPct: num(lossPct),
+    fxRH,
+    valueCol: 10,
+    sumFormula: dataEnd >= dataStart ? `SUM(J${dataStart}:J${dataEnd})` : null,
+    currency: isHkd ? 'HKD' : 'RMB',
+    skipLoss,
+    refs, refKey,
+  });
+  if (refs && refKey) { refs.partRows = refs.partRows || {}; refs.partRows[refKey] = partRows; }
+  return row;
+}
+function freeRaw(rows) {
+  return sum(rows.filter(r => !r.is_subtotal), r => num(r.qty) * num(r.unit_price));
+}
+function freeSubtotal(rows) {
+  return freeRaw(rows);  // 不计损耗
+}
+
+// 通用四行小计区块（带公式）：小计 / 损耗 / 合计 RMB / 合计 HKD
+// opts: { rawSum, lossPct, fxRH, valueCol (1-based 写入列), sumFormula (字符串 如 'SUM(L4:L9)') }
+function appendThreeRowSubtotal(ws, row, opts) {
+  const { rawSum = 0, lossPct = 0, fxRH, valueCol = 12, sumFormula = null, currency = 'RMB', refs = null, refKey = null, skipLoss = false } = opts;
+  const fx = num(fxRH) || 0.85;
+  const isHkd = currency === 'HKD';
+  const totalComputed = rawSum * (1 + lossPct / 100);
+  const labelCols = valueCol - 1;
+  const lossPctDecimal = lossPct / 100;
+
+  const colLetter = (n) => {
+    let s = '';
+    while (n > 0) { const m = (n - 1) % 26; s = String.fromCharCode(65 + m) + s; n = Math.floor((n - 1) / 26); }
+    return s;
+  };
+  const VAL_COL = colLetter(valueCol);
+
+  const mk = (label, value, fmt, level) => {
+    ws.mergeCells(row, 1, row, labelCols);
+    ws.getCell(row, 1).value = label;
+    ws.getCell(row, valueCol).value = value;
+    if (fmt) ws.getCell(row, valueCol).numFmt = fmt;
+    // 标签行：白底 + 右对齐；只在数值单元格高亮
+    for (let c = 1; c <= valueCol + 1; c++) {
+      const cell = ws.getCell(row, c);
+      cell.alignment = { horizontal: 'center', vertical: 'middle' };
+      cell.border = thinBorder();
+      cell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFFFFFFF' } };
+    }
+    ws.getCell(row, 1).alignment = { horizontal: 'right', vertical: 'middle' };
+    // 只给数值单元格上色
+    styleSubtotal(ws.getCell(row, valueCol), level);
+    if (level === 'total' || level === 'hkd') {
+      ws.getCell(row, 1).font = { bold: true, color: { argb: 'FF1F2937' }, name: 'Microsoft YaHei' };
+      ws.getCell(row, valueCol).font = { bold: true, color: { argb: 'FF1F2937' }, name: 'Microsoft YaHei' };
+    } else {
+      ws.getCell(row, 1).font = { color: { argb: 'FF6B7280' }, name: 'Microsoft YaHei' };
+      ws.getCell(row, valueCol).font = { color: { argb: 'FF6B7280' }, name: 'Microsoft YaHei' };
+    }
+    ws.getRow(row).height = 20;
+    row += 1;
+  };
+
+  const subRow = row;
+  const subLabel = isHkd ? '小计 HKD' : '小计 RMB';
+  const subFmt = isHkd ? HKD4 : RMB;
+  // skipLoss 且 lossPct=0 时，小计=合计 RMB，无需重复
+  const showSub = !(skipLoss && !lossPct);
+  if (showSub) {
+    mk(subLabel,
+      sumFormula ? { formula: sumFormula, result: rawSum } : rawSum,
+      subFmt, 'sub');
+  }
+  let lossRow = null;
+  if (!skipLoss) {
+    lossRow = row;
+    mk('损耗', lossPctDecimal, '0.00%', 'loss');
+  }
+  const totalRow = row;
+  // 记录"合计"单元格地址
+  if (refs && refKey) refs[refKey] = `${VAL_COL}${totalRow}`;
+  // totalFormula：若 小计行 被略过，直接用 sumFormula 作为底
+  const baseRef = showSub ? `${VAL_COL}${subRow}` : (sumFormula ? `(${sumFormula})` : rawSum);
+  const totalFormula = skipLoss
+    ? (lossPct ? `${baseRef}*${1 + lossPct/100}` : `${baseRef}`)
+    : `${baseRef}*(1+${VAL_COL}${lossRow})`;
+  if (isHkd) {
+    mk('合计 HKD',
+      { formula: totalFormula, result: totalComputed },
+      HKD4, 'hkd');
+  } else {
+    mk('合计 RMB',
+      { formula: totalFormula, result: totalComputed },
+      RMB, 'total');
+    mk(`合计 HKD (汇率 ${fx})`,
+      { formula: `${VAL_COL}${totalRow}/${fx}`, result: totalComputed / fx },
+      HKD4, 'hkd');
+  }
+  row += 1;
+  return row;
+}
+
+// 排拉工序：按产品分组（人数 / 基数 / 标准工时 / 人工/PCS）
+function renderAssemblyStepGroups(ws, row, title, groups, baseRate, stdTime, fxRH, refs, refKey) {
+  ws.mergeCells(row, 1, row, 8); styleSection(ws.getCell(row, 1));
+  ws.getCell(row, 1).value = title;
+  row += 1;
+  if (!groups.length) {
+    ws.mergeCells(row, 1, row, 8);
+    ws.getCell(row, 1).value = '（无）';
+    ws.getCell(row, 1).font = { italic: true, color: { argb: 'FF9CA3AF' } };
+    row += 1;
+    if (refs) refs[refKey] = null;
+    return row;
+  }
+  const groupTotalCells = [];
+  groups.forEach(g => {
+    // 产品标题
+    ws.mergeCells(row, 1, row, 8);
+    ws.getCell(row, 1).value = `产品：${g.product || '未命名'}    生产量：${num(g.qty)}    基数：${baseRate} HKD    标准工时：${stdTime} H`;
+    ws.getCell(row, 1).font = { bold: true, color: { argb: 'FF16A34A' }, name: 'Microsoft YaHei' };
+    ws.getCell(row, 1).fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFECFDF5' } };
+    row += 1;
+    // 表头
+    const h = ['序号', '工序名称', '人数', '标准工时', '基数 HKD', '生产量', '人工/PCS', '备注'];
+    h.forEach((v, i) => { ws.getCell(row, i + 1).value = v; styleHeader(ws.getCell(row, i + 1)); });
+    row += 1;
+    const start = row;
+    (g.steps || []).forEach((s, i) => {
+      ws.getCell(row, 1).value = i + 1;
+      ws.getCell(row, 2).value = s.name || '';
+      ws.getCell(row, 3).value = num(s.count);
+      ws.getCell(row, 4).value = stdTime;
+      ws.getCell(row, 5).value = baseRate;
+      ws.getCell(row, 6).value = num(g.qty);
+      // 人工/PCS = 基数 × 人数 ÷ 生产量
+      const amt = baseRate * num(s.count) / Math.max(num(g.qty), 1);
+      ws.getCell(row, 7).value = { formula: `E${row}*C${row}/MAX(F${row},1)`, result: amt };
+      ws.getCell(row, 7).numFmt = '0.0000';
+      ws.getCell(row, 8).value = s.note || '';
+      for (let c = 1; c <= 8; c++) styleData(ws.getCell(row, c));
+      row += 1;
+    });
+    const end = row - 1;
+    // 本组合计
+    ws.mergeCells(row, 1, row, 6);
+    ws.getCell(row, 1).value = '本组合计 HKD';
+    ws.getCell(row, 1).alignment = { horizontal: 'right' };
+    ws.getCell(row, 1).font = { bold: true, name: 'Microsoft YaHei' };
+    const gTotal = sum(g.steps || [], s => baseRate * num(s.count) / Math.max(num(g.qty), 1));
+    ws.getCell(row, 7).value = (g.steps || []).length
+      ? { formula: `SUM(G${start}:G${end})`, result: gTotal }
+      : gTotal;
+    ws.getCell(row, 7).numFmt = HKD4;
+    for (let c = 1; c <= 8; c++) { const cell = ws.getCell(row, c); cell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFFFFFFF' } }; cell.border = thinBorder(); }
+    styleSubtotal(ws.getCell(row, 7), 'sub');
+    groupTotalCells.push(`G${row}`);
+    row += 1;
+    row += 1; // 空行
+  });
+  // 所有产品 合计 — HKD（基数本身港币，直接求和，不再除汇率）
+  ws.mergeCells(row, 1, row, 6);
+  ws.getCell(row, 1).value = '所有产品 合计 人工/PCS HKD';
+  ws.getCell(row, 1).alignment = { horizontal: 'right' };
+  ws.getCell(row, 1).font = { bold: true, name: 'Microsoft YaHei' };
+  const totalAddr = `G${row}`;
+  const totalVal = sum(groups, g => sum(g.steps || [], s => baseRate * num(s.count) / Math.max(num(g.qty), 1)));
+  ws.getCell(row, 7).value = groupTotalCells.length
+    ? { formula: groupTotalCells.join('+'), result: totalVal }
+    : 0;
+  ws.getCell(row, 7).numFmt = HKD4;
+  styleSubtotal(ws.getCell(row, 7), 'total');
+  if (refs) refs[refKey] = totalAddr;
+  row += 1;
+  return row;
+}
+
+function renderLaborTable(ws, row, title, rows, fxRH, lossPct, refs, refKey) {
+  ws.mergeCells(row, 1, row, 13); styleSection(ws.getCell(row, 1));
+  ws.getCell(row, 1).value = title;
+  row += 1;
+  const h = ['序号', '工序名称', '', '', '', '', '标准工时', '工序单价(元/PCS)', '用量', '成品金额', '备注'];
+  h.forEach((v, i) => { ws.getCell(row, i + 1).value = v; styleHeader(ws.getCell(row, i + 1)); });
+  ws.mergeCells(row, 2, row, 6);
+  row += 1;
+  const dataStart = row;
+  rows.forEach((r, i) => {
+    ws.getCell(row, 1).value = i + 1;
+    ws.mergeCells(row, 2, row, 6);
+    ws.getCell(row, 2).value = r.step || '';
+    ws.getCell(row, 7).value = num(r.std_time);
+    ws.getCell(row, 8).value = num(r.unit_price);
+    ws.getCell(row, 9).value = num(r.qty);
+    // 公式: 成品金额 = 单价 × 用量
+    ws.getCell(row, 10).value = { formula: `H${row}*I${row}`, result: num(r.unit_price) * num(r.qty) };
+    ws.getCell(row, 10).numFmt = RMB;
+    ws.getCell(row, 11).value = r.note || '';
+    for (let c = 1; c <= 11; c++) styleData(ws.getCell(row, c));
+    row += 1;
+  });
+  const dataEnd = row - 1;
+  const rawSum = sum(rows, r => num(r.unit_price) * num(r.qty));
+  row = appendThreeRowSubtotal(ws, row, {
+    rawSum,
+    lossPct: num(lossPct ?? 0),
+    fxRH: num(fxRH) || 0.85,
+    valueCol: 10,
+    sumFormula: rows.length ? `SUM(J${dataStart}:J${dataEnd})` : null,
+    refs, refKey,
+  });
+  return row;
+}
+
+// ============ 新增：搪胶 / 车缝 / 吹气 / 纸箱 / 运费 / 减税明细 ============
+
+function renderSlushBlock(ws, row, slush, fxRH, refs) {
+  const items = slush.slush_items || [];
+  if (!items.length) return row;
+  ws.mergeCells(row, 1, row, 13); styleSection(ws.getCell(row, 1));
+  ws.getCell(row, 1).value = '二·C、搪胶部分';
+  row += 1;
+  const h = ['序号', '产品编号', '胶件名称', '材料', '料重(g)', '日产量24H', '用量(PC)', '单价 HKD', '总价 HKD', '', '', '', '备注'];
+  h.forEach((v, i) => { ws.getCell(row, i + 1).value = v; styleHeader(ws.getCell(row, i + 1)); });
+  ws.mergeCells(row, 9, row, 10);
+  row += 1;
+  const start = row;
+  items.forEach((r, i) => {
+    ws.getCell(row, 1).value = i + 1;
+    ws.getCell(row, 2).value = r.item_code || '';
+    ws.getCell(row, 3).value = r.name || '';
+    ws.getCell(row, 4).value = r.material || '';
+    ws.getCell(row, 5).value = num(r.weight_g);
+    ws.getCell(row, 6).value = num(r.daily_output);
+    ws.getCell(row, 7).value = num(r.qty);
+    ws.getCell(row, 8).value = num(r.unit_price_hkd);
+    ws.getCell(row, 9).value = { formula: `G${row}*H${row}`, result: num(r.qty) * num(r.unit_price_hkd) };
+    ws.mergeCells(row, 9, row, 10);
+    ws.getCell(row, 9).numFmt = '0.0000';
+    ws.getCell(row, 13).value = r.note || '';
+    for (let c = 1; c <= 13; c++) styleData(ws.getCell(row, c));
+    row += 1;
+  });
+  const end = row - 1;
+  ws.mergeCells(row, 1, row, 8);
+  ws.getCell(row, 1).value = '合计 HKD';
+  ws.getCell(row, 1).alignment = { horizontal: 'right', vertical: 'middle' };
+  ws.getCell(row, 9).value = items.length ? { formula: `SUM(I${start}:I${end})`, result: sum(items, r => num(r.qty) * num(r.unit_price_hkd)) } : 0;
+  ws.mergeCells(row, 9, row, 10);
+  ws.getCell(row, 9).numFmt = HKD4;
+  for (let c = 1; c <= 13; c++) {
+    const cell = ws.getCell(row, c);
+    cell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFFFFFFF' } };
+    cell.border = thinBorder();
+  }
+  styleSubtotal(ws.getCell(row, 9), 'total');
+  ws.getCell(row, 1).font = { bold: true, color: { argb: 'FF1F2937' }, name: 'Microsoft YaHei' };
+  ws.getCell(row, 9).font = { bold: true, color: { argb: 'FF1F2937' }, name: 'Microsoft YaHei' };
+  if (refs) refs.slush = `I${row}`;
+  row += 2;
+  return row;
+}
+
+function renderBlowBlock(ws, row, mold, refs) {
+  const items = mold.blow_items || [];
+  if (!items.length) return row;
+  ws.mergeCells(row, 1, row, 13); styleSection(ws.getCell(row, 1));
+  ws.getCell(row, 1).value = '二·B、吹气部分 (HKD)';
+  row += 1;
+  const h = ['货名', '日产量/22H', '用料', '预估料重(g)', '料价 HK$/lb', '产品料价', '吹工', '披锋', '小计', '利润 ×', '合计 HK$', '出数', '模价(¥)'];
+  h.forEach((v, i) => { ws.getCell(row, i + 1).value = v; styleHeader(ws.getCell(row, i + 1)); });
+  row += 1;
+  items.forEach(r => {
+    const mat = num(r.weight_g) * num(r.material_price_lb) / 454;
+    const sub = mat + num(r.blow_labor) + num(r.flash);
+    const tot = sub * (num(r.profit_x) || 1);
+    // 列：A货名 B产能 C用料 D重 E料价 F产品料价 G吹工 H披锋 I小计 J利润× K合计 L一出 M模价
+    ws.getCell(row, 1).value = r.name || '';
+    ws.getCell(row, 2).value = r.capacity || '';
+    ws.getCell(row, 3).value = r.material || '';
+    ws.getCell(row, 4).value = num(r.weight_g);
+    ws.getCell(row, 5).value = num(r.material_price_lb);
+    ws.getCell(row, 6).value = { formula: `D${row}*E${row}/454`, result: mat };  // 产品料价 = 重×料价/454
+    ws.getCell(row, 7).value = num(r.blow_labor);
+    ws.getCell(row, 8).value = num(r.flash);
+    ws.getCell(row, 9).value = { formula: `F${row}+G${row}+H${row}`, result: sub };  // 小计 = 产品料价+吹工+披锋
+    ws.getCell(row, 10).value = num(r.profit_x);
+    ws.getCell(row, 11).value = { formula: `I${row}*J${row}`, result: tot };  // 合计 = 小计×利润
+    ws.getCell(row, 12).value = r.cavity_note || '';
+    ws.getCell(row, 13).value = r.mold_price_note || '';
+    for (let c = 1; c <= 13; c++) styleData(ws.getCell(row, c));
+    [4, 5, 6, 7, 8, 9, 11].forEach(c => ws.getCell(row, c).numFmt = '0.0000');
+    row += 1;
+  });
+  const dataEnd = row - 1;
+  // 合计 HK$ - SUM 公式（只数值上色）
+  ws.mergeCells(row, 1, row, 10);
+  ws.getCell(row, 1).value = '合计 HK$';
+  ws.getCell(row, 1).alignment = { horizontal: 'right', vertical: 'middle' };
+  const blowTot = sum(items, r => {
+    const mat = num(r.weight_g) * num(r.material_price_lb) / 454;
+    return (mat + num(r.blow_labor) + num(r.flash)) * (num(r.profit_x) || 1);
+  });
+  ws.getCell(row, 11).value = { formula: `SUM(K${dataEnd - items.length + 1}:K${dataEnd})`, result: blowTot };
+  ws.getCell(row, 11).numFmt = HKD4;
+  for (let c = 1; c <= 13; c++) {
+    const cell = ws.getCell(row, c);
+    cell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFFFFFFF' } };
+    cell.border = thinBorder();
+  }
+  styleSubtotal(ws.getCell(row, 11), 'total');
+  ws.getCell(row, 1).font = { bold: true, color: { argb: 'FF1F2937' }, name: 'Microsoft YaHei' };
+  ws.getCell(row, 11).font = { bold: true, color: { argb: 'FF1F2937' }, name: 'Microsoft YaHei' };
+  if (refs) refs.blow = `K${row}`;
+  row += 2;
+  return row;
+}
+
+function renderSewingBlock(ws, row, sewing, fxRH, refs) {
+  const groups = sewing.sewing_groups || [];
+  if (!groups.length) return row;
+  // 主表只显示 车缝部分 标题 + 配套合计；明细已在 车缝明细 sheet 单独展示
+  ws.mergeCells(row, 1, row, 13); styleSection(ws.getCell(row, 1));
+  ws.getCell(row, 1).value = '车缝部分（明细见"车缝明细" sheet）';
+  row += 1;
+  let configRowTotal = 0;
+  const groupTotalCells = [];
+  const hairCells = [], clothCells = [];  // 按 category 分车发/车衣（小计 I列，RMB）— 与前端同逻辑
+  // 预计算每组在"车缝明细" sheet 的 items 行区间（用于公式引用）
+  let detailRow = 4; // 车缝明细 sheet 中第 1 个 group 的首行 items
+  const ranges = groups.map(g => {
+    const n = (g.items || []).length;
+    const r = { start: detailRow, end: detailRow + n - 1 };
+    detailRow += n + 4; // items + 本组合计 + blank + 产品label + header = n + 4
+    return r;
+  });
+  groups.forEach((g, gi) => {
+    const itemsSum = sum(g.items || [], r => num(r.usage) * num(r.mat_price) * (num(r.markup) || 1));
+    const groupTotal = itemsSum + num(g.labor_amount);
+    // 仅显示每组一行小计 — 用 车缝明细 sheet 的范围引用公式
+    ws.mergeCells(row, 1, row, 8);
+    const _embN = (g.items || []).filter(r => r.craft === '电绣').length;
+    ws.getCell(row, 1).value = `${g.name || '未命名'} 小计 RMB${_embN ? `（含电绣 ${_embN} 行）` : ''}`;
+    ws.getCell(row, 1).alignment = { horizontal: 'right', vertical: 'middle' };
+    ws.getCell(row, 1).font = { name: 'Microsoft YaHei' };
+    ws.mergeCells(row, 9, row, 10);
+    const rng = ranges[gi];
+    const hasItems = (g.items || []).length > 0;
+    if (hasItems) {
+      // 总价钱在"车缝明细"sheet 的 J 列（加了「工艺」列后右移）
+      ws.getCell(row, 9).value = { formula: `SUM('车缝明细'!J${rng.start}:J${rng.end})+${num(g.labor_amount)}`, result: groupTotal };
+    } else {
+      ws.getCell(row, 9).value = groupTotal;
+    }
+    ws.getCell(row, 9).numFmt = RMB;
+    for (let c = 1; c <= 13; c++) { const cell = ws.getCell(row, c); cell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFFFFFFF' } }; cell.border = thinBorder(); }
+    styleSubtotal(ws.getCell(row, 9), 'sub');
+    groupTotalCells.push(`I${row}`);
+    // 前端：车发 = category==='车发'；车衣 = 其余（默认）
+    if ((g.category || '车衣') === '车发') hairCells.push(`I${row}`); else clothCells.push(`I${row}`);
+    configRowTotal += groupTotal;
+    row += 1;
+  });
+  // 配套合计 → 小计/合计 RMB/合计 HKD（不计算损耗）
+  row = appendThreeRowSubtotal(ws, row, {
+    rawSum: configRowTotal,
+    lossPct: 0,
+    fxRH: num(fxRH) || 0.85,
+    valueCol: 9,
+    sumFormula: groupTotalCells.length ? groupTotalCells.join('+') : null,
+    skipLoss: true,
+    refs, refKey: 'sewing',
+  });
+  if (refs) { refs.sewHairCells = hairCells; refs.sewClothCells = clothCells; }
+  return row;
+}
+
+// ============ 旧的车缝详细块（保留备用，已废弃，主表用上面的简版） ============
+function _renderSewingBlockDetailed(ws, row, sewing, fxRH, refs) {
+  const groups = sewing.sewing_groups || [];
+  if (!groups.length) return row;
+  ws.mergeCells(row, 1, row, 13); styleSection(ws.getCell(row, 1));
+  ws.getCell(row, 1).value = '车缝部分';
+  row += 1;
+  let configRowTotal = 0;
+  const groupTotalCells = [];
+  groups.forEach((g, gi) => {
+    ws.mergeCells(row, 1, row, 13);
+    ws.getCell(row, 1).value = `产品：${g.name || '未命名 ' + (gi + 1)}`;
+    ws.getCell(row, 1).font = { bold: true, color: { argb: 'FF16A34A' }, name: 'Microsoft YaHei' };
+    ws.getCell(row, 1).fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFECFDF5' } };
+    row += 1;
+    const h = ['序号', '布料名称', '部位', '裁片数', '用量/码', '物料价(RMB)', '价钱(RMB)', '码点', '总价钱(RMB)', '', '', '', '备注'];
+    h.forEach((v, i) => { ws.getCell(row, i + 1).value = v; styleHeader(ws.getCell(row, i + 1)); });
+    ws.mergeCells(row, 9, row, 10);
+    row += 1;
+    const start = row;
+    (g.items || []).forEach((r, i) => {
+      ws.getCell(row, 1).value = i + 1;
+      ws.getCell(row, 2).value = r.fabric || '';
+      ws.getCell(row, 3).value = r.part || '';
+      ws.getCell(row, 4).value = num(r.pieces);
+      ws.getCell(row, 5).value = num(r.usage);
+      ws.getCell(row, 6).value = num(r.mat_price);
+      ws.getCell(row, 7).value = { formula: `E${row}*F${row}`, result: num(r.usage) * num(r.mat_price) };
+      ws.getCell(row, 8).value = num(r.markup) || 1;
+      ws.getCell(row, 9).value = { formula: `G${row}*H${row}`, result: num(r.usage) * num(r.mat_price) * (num(r.markup) || 1) };
+      ws.mergeCells(row, 9, row, 10);
+      ws.getCell(row, 9).numFmt = '0.0000';
+      ws.getCell(row, 13).value = r.note || '';
+      for (let c = 1; c <= 13; c++) styleData(ws.getCell(row, c));
+      row += 1;
+    });
+    const end = row - 1;
+    const itemsSum = sum(g.items || [], r => num(r.usage) * num(r.mat_price) * (num(r.markup) || 1));
+    // 人工行
+    ws.mergeCells(row, 1, row, 8);
+    ws.getCell(row, 1).value = '人工 (RMB)';
+    ws.getCell(row, 1).alignment = { horizontal: 'right' };
+    ws.getCell(row, 9).value = num(g.labor_amount);
+    ws.mergeCells(row, 9, row, 10);
+    ws.getCell(row, 9).numFmt = '0.0000';
+    for (let c = 1; c <= 13; c++) styleData(ws.getCell(row, c));
+    row += 1;
+    // 本组合计 - 只在数值上色
+    ws.mergeCells(row, 1, row, 8);
+    ws.getCell(row, 1).value = '本组合计 RMB';
+    ws.getCell(row, 1).alignment = { horizontal: 'right', vertical: 'middle' };
+    const groupTotal = itemsSum + num(g.labor_amount);
+    ws.getCell(row, 9).value = (g.items || []).length
+      ? { formula: `SUM(I${start}:I${end})+I${row - 1}`, result: groupTotal }
+      : groupTotal;
+    ws.mergeCells(row, 9, row, 10);
+    ws.getCell(row, 9).numFmt = RMB;
+    for (let c = 1; c <= 13; c++) {
+      const cell = ws.getCell(row, c);
+      cell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFFFFFFF' } };
+      cell.border = thinBorder();
+    }
+    styleSubtotal(ws.getCell(row, 9), 'sub');
+    ws.getCell(row, 1).font = { bold: true, color: { argb: 'FF1F2937' }, name: 'Microsoft YaHei' };
+    ws.getCell(row, 9).font = { bold: true, color: { argb: 'FF1F2937' }, name: 'Microsoft YaHei' };
+    groupTotalCells.push(`I${row}`);
+    row += 1;
+    configRowTotal += groupTotal;
+  });
+  // 配套合计 → 小计 / 损耗 / 合计 RMB / 合计 HKD（4 行）
+  row = appendThreeRowSubtotal(ws, row, {
+    rawSum: configRowTotal,
+    lossPct: num(sewing.sewing_loss_pct),
+    fxRH: num(fxRH) || 0.85,
+    valueCol: 9,
+    sumFormula: groupTotalCells.length ? groupTotalCells.join('+') : null,
+    refs, refKey: 'sewing',
+  });
+  return row;
+}
+
+function renderCartonAndFreight(ws, row, eng, sales, refs) {
+  const c = eng.carton_calc || {};
+  // 每个纸箱跟踪: { boxCell, flatCells: [...], qtyCell } 用于构造 九、合计 K 列公式
+  const cartonRefs = [];
+  const f = sales.freight_calc || {
+    cap_10t: 1166, cap_5t: 750, cap_40: 1980, cap_20: 883,
+    hk40: 8000, hk20: 7100, yt40: 7200, yt20: 6000,
+    hk10t: 14900, yt10t: 11500, hk5t: 12500, yt5t: 11000,
+  };
+  ws.mergeCells(row, 1, row, 13); styleSection(ws.getCell(row, 1));
+  ws.getCell(row, 1).value = '📦 纸箱 / 运费 计算（参考）';
+  row += 1;
+
+  // ---- 纸箱计算（多纸箱 + 多平卡）----
+  let cuftRow = 0, qtyRow = 0;
+  const cartons = (c.cartons && c.cartons.length) ? c.cartons : (c.cl ? [{
+    name: '主纸箱', cl: c.cl, cw: c.cw, ch: c.ch, qty: c.qty,
+    flat_cards: c.flat_card ? [{ name: '主平卡', l: c.cl, w: c.cw }] : [],
+  }] : []);
+
+  if (cartons.length) {
+    // 产品尺寸
+    ws.getCell(row, 1).value = '产品尺寸 CM'; ws.mergeCells(row, 1, row, 4);
+    ws.getCell(row, 5).value = 'L'; ws.getCell(row, 6).value = num(c.pl);
+    ws.getCell(row, 7).value = 'W'; ws.getCell(row, 8).value = num(c.pw);
+    ws.getCell(row, 9).value = 'H'; ws.getCell(row, 10).value = num(c.ph);
+    for (let cc = 1; cc <= 13; cc++) styleData(ws.getCell(row, cc));
+    ws.getCell(row, 1).alignment = { horizontal: 'left', vertical: 'middle', indent: 1 };
+    row += 1;
+
+    // 纸箱表头
+    const cartonHeader = ['名称', '纸箱 L (inch)', 'W', 'H', 'CU.FT', '箱价 (HK$)', '数量', '', '', '', '', '', ''];
+    cartonHeader.forEach((v, i) => { ws.getCell(row, i + 1).value = v; styleHeader(ws.getCell(row, i + 1)); });
+    row += 1;
+
+    cartons.forEach((b, bi) => {
+      // 纸箱主行
+      ws.getCell(row, 1).value = b.name || `纸箱${bi + 1}`;
+      ws.getCell(row, 2).value = num(b.cl);
+      ws.getCell(row, 3).value = num(b.cw);
+      ws.getCell(row, 4).value = num(b.ch);
+      ws.getCell(row, 5).value = { formula: `B${row}*C${row}*D${row}/1728`, result: num(b.cl) * num(b.cw) * num(b.ch) / 1728 };
+      ws.getCell(row, 5).numFmt = '0.0000';
+      ws.getCell(row, 6).value = { formula: `(B${row}+C${row}+2)*(C${row}+D${row}+1)*2*2.8/1000`,
+                                   result: (num(b.cl) + num(b.cw) + 2) * (num(b.cw) + num(b.ch) + 1) * 2 * 2.8 / 1000 };
+      ws.getCell(row, 6).numFmt = HKD;
+      ws.getCell(row, 7).value = num(b.qty);
+      for (let cc = 1; cc <= 7; cc++) styleData(ws.getCell(row, cc));
+      if (bi === 0) { cuftRow = row; qtyRow = row; } // 第一个纸箱供运费引用
+      const cartonRef = { boxCell: `F${row}`, qtyCell: `G${row}`, flatCells: [] };
+      row += 1;
+
+      // 平卡子表
+      const fcs = b.flat_cards || [];
+      if (fcs.length) {
+        ws.getCell(row, 2).value = '↳ 平卡';
+        ws.getCell(row, 2).font = { italic: true, color: { argb: 'FF78716C' } };
+        const fcHead = ['', '名称', 'L (inch)', 'W', '平卡价 (HK$)'];
+        fcHead.forEach((v, i) => { if (v) { ws.getCell(row, i + 2).value = v; styleHeader(ws.getCell(row, i + 2)); } });
+        row += 1;
+        fcs.forEach((f) => {
+          ws.getCell(row, 3).value = f.name || '';
+          ws.getCell(row, 4).value = num(f.l);
+          ws.getCell(row, 5).value = num(f.w);
+          ws.getCell(row, 6).value = { formula: `(D${row}+1)*(E${row}+1)*2/1000`, result: (num(f.l) + 1) * (num(f.w) + 1) * 2 / 1000 };
+          ws.getCell(row, 6).numFmt = HKD;
+          for (let cc = 3; cc <= 6; cc++) styleData(ws.getCell(row, cc));
+          cartonRef.flatCells.push(`F${row}`);
+          row += 1;
+        });
+      }
+      cartonRefs.push(cartonRef);
+      row += 1; // 纸箱之间空一行
+    });
+  }
+
+  // 构造 九、合计 K 列纸箱成本公式：Σ((box_i + Σflat_i_j) / qty_i)
+  if (refs && cartonRefs.length) {
+    const parts = cartonRefs.map(cr => {
+      const flatSum = cr.flatCells.length ? `+${cr.flatCells.join('+')}` : '';
+      return `(${cr.boxCell}${flatSum})/MAX(${cr.qtyCell},1)`;
+    });
+    refs.cartonHkdPerPcs = parts.join('+');  // HK$/PCS （还没 × 汇率）
+  }
+
+  // ---- 运费场景（含公式）----
+  if (f) {
+    const h = ['运费场景', '柜/车 CUFT', '运+吊柜费 HK$', '总箱数', '运+吊柜 HK$/PCS'];
+    h.forEach((v, i) => { ws.getCell(row, i + 1).value = v; styleHeader(ws.getCell(row, i + 1)); });
+    row += 1;
+    const types = [
+      ['HK 40柜', num(f.cap_40), num(f.hk40)], ['HK 20柜', num(f.cap_20), num(f.hk20)],
+      ['YT 40柜', num(f.cap_40), num(f.yt40)], ['YT 20柜', num(f.cap_20), num(f.yt20)],
+      ['HK 10吨车', num(f.cap_10t), num(f.hk10t)], ['YT 10吨车', num(f.cap_10t), num(f.yt10t)],
+      ['HK 5吨车', num(f.cap_5t), num(f.hk5t)], ['YT 5吨车', num(f.cap_5t), num(f.yt5t)],
+    ];
+    const cuftRef = cuftRow ? `E${cuftRow}` : null;
+    const qtyRef = qtyRow ? `E${qtyRow}` : null;
+    types.forEach(([name, cap, fee]) => {
+      ws.getCell(row, 1).value = name;
+      ws.getCell(row, 2).value = cap;
+      ws.getCell(row, 3).value = fee;
+      ws.getCell(row, 3).numFmt = HKD;
+      const cuftSafe = cuftRef ? `MAX(${cuftRef},0.01)` : '1';
+      const boxesFm = `MAX(ROUND(B${row}/${cuftSafe},0),1)`;
+      const qtySafe = qtyRef ? `MAX(${qtyRef},1)` : '1';
+      const boxesCalc = cap > 0 && cuftRef ? Math.max(Math.round(cap / Math.max(num(eng.carton_calc?.cuft) || ((num(eng.carton_calc?.cl) * num(eng.carton_calc?.cw) * num(eng.carton_calc?.ch)) / 1728), 0.01)), 1) : 1;
+      const ppCalc = fee / Math.max(boxesCalc, 1) / Math.max(num(eng.carton_calc?.qty) || 1, 1);
+      ws.getCell(row, 4).value = cuftRef ? { formula: boxesFm, result: boxesCalc } : boxesCalc;
+      ws.getCell(row, 5).value = { formula: `C${row}/D${row}/${qtySafe}`, result: ppCalc };
+      ws.getCell(row, 5).numFmt = HKD;
+      for (let cc = 1; cc <= 5; cc++) styleData(ws.getCell(row, cc));
+      // 记录每个运费场景的「运+吊柜 HK$/PCS」单元格(E列)，供减税明细 运费/吊柜费 公式引用
+      if (refs) { refs.freightCells = refs.freightCells || {}; refs.freightCells[name] = `E${row}`; }
+      row += 1;
+    });
+    row += 1;
+  }
+  return row;
+}
+
+function renderTaxSummary(ws, row, sales, extra = {}) {
+  const ps = sales.pricing_summary;
+  if (!ps) return row;
+  const { subRefs = {}, fxRH: fxR = 0.85 } = extra;
+  // 表1 部分单元格可关联到上方各部门 / 九、合计 HKD 小计
+  const sumR = extra.summaryRow;
+  const ov = ps.overrides || {};  // 用户手填覆盖的项 → 不写公式，保持静态值
+
+  // ---- 关键字分类，把减税明细做成引用上方明细的公式 ----
+  // ⚠️ 必须与前端 workbench.js 的 autoFill 分类逻辑（_catOf：显式类别优先 + 关键字兜底 及各项来源表）保持一致，
+  //    否则导出值会与 UI 提取计算静默不符。改动其一务必同步另一处。
+  const _isMotor   = s => /马达|motor/i.test(String(s || ''));
+  const _isBlister = s => /吸塑|blister/i.test(String(s || ''));
+  const _isBat     = s => /电池|battery/i.test(String(s || ''));
+  const _isLib     = s => /利宝|贴纸|libao|sticker/i.test(String(s || ''));
+  const _isPlate   = s => /电镀|plating/i.test(String(s || ''));
+  const _isCarton  = s => /纸箱|carton/i.test(String(s || ''));
+  const _row = (fn, r) => fn(r.name) || fn(r.spec);
+  const pr = subRefs.partRows || {};
+  const _pick    = (key, fn) => (pr[key] || []).filter(r => _row(fn, r)).map(r => r.cell);
+  const _pickNot = (key, pred) => (pr[key] || []).filter(r => !pred(r)).map(r => r.cell);
+  // 辅助/包装 行的类别：显式 category 优先，否则关键字兜底（纸箱 → null 单独计），与前端 _catOf 一致
+  const _catOf = (r, tbl) => {
+    if (r.category && MAT_CATEGORIES.includes(r.category)) return r.category;
+    if (_row(_isBlister, r)) return '吸塑';
+    if (_row(_isBat, r))     return '电池';
+    if (_row(_isLib, r))     return '利宝';
+    if (_row(_isPlate, r))   return '电镀';
+    if (_row(_isCarton, r))  return null;  // 纸箱另算
+    return tbl === 'aux' ? '其他外购' : '彩盒/内咭';
+  };
+  // 跨 包装 + 辅助 两表，取归属该类别的行的金额单元格
+  const byCat = (cat) => [
+    ...(pr.packaging || []).filter(r => _catOf(r, 'packaging') === cat).map(r => r.cell),
+    ...(pr.aux       || []).filter(r => _catOf(r, 'aux')       === cat).map(r => r.cell),
+  ];
+  // 马达 = 电子 + 五金 行（按关键字，电子/五金表无类别下拉）
+  const motorCells   = [..._pick('electronic', _isMotor), ..._pick('hardware', _isMotor)];
+  // 吸塑 = 辅助/包装按类别 + 电子/五金里关键字命中的吸塑行
+  const blisterCells = [...byCat('吸塑'), ..._pick('electronic', _isBlister), ..._pick('hardware', _isBlister)];
+  const batteryCells  = byCat('电池');
+  const libaoCells    = byCat('利宝');
+  const platingCells  = byCat('电镀');
+  const colorBoxCells = byCat('彩盒/内咭');
+  const otherBuyCells = byCat('其他外购');
+  // 五金/电子 均剔除马达（与前端一致，避免与「马达」列双算）
+  const hwNonMotorCells   = _pickNot('hardware',   r => _row(_isMotor, r));
+  const elecNonMotorCells = _pickNot('electronic', r => _row(_isMotor, r));
+
+  // cells → 公式 ref（fx=true 表示 RMB→HKD 除以汇率）；被手填覆盖或无来源则返回 null（回退静态值）
+  const auto = (tbl, key, cells, fx) => {
+    if (ov[`${tbl}.${key}`] || !cells || !cells.length) return null;
+    const body = cells.join('+');
+    return { ref: fx ? `(${body})/${fxR}` : body };
+  };
+
+  // 运费/吊柜费：盐田40柜 = 运费场景表「YT 40柜」行的每PCS运费率(E列)
+  const fPct = num(sales.shipping?.freight_pct ?? 48);
+  const lPct = num(sales.shipping?.lifting_pct ?? 52);
+  const ytRateCell = (subRefs.freightCells || {})['YT 40柜'];
+
+  // 直接引用单元格的项（非关键字累加）：被手填覆盖或无来源则回退静态值
+  const refLink = (tbl, key, ref) => (ref && !ov[`${tbl}.${key}`]) ? { ref } : null;
+
+  const linkMap = {
+    // 九、合计 N = 码点后价 HKD（货价）
+    base_price: sumR ? { ref: `N${sumR}` } : null,
+    blow:     subRefs.blow      ? { ref: subRefs.blow }   : null,  // 吹气 本身就是 HKD
+    slush:    subRefs.slush     ? { ref: subRefs.slush }  : null,  // 搪胶 本身就是 HKD
+    electronic: auto('t1', 'electronic', elecNonMotorCells, false),  // 电子已是 HKD（剔除马达）
+    // 注塑料按材质分（I列原料单价已是 HKD，不除汇率）
+    imp_mat: auto('t1', 'imp_mat', subRefs.impMatCells, false),
+    dom_mat: auto('t1', 'dom_mat', subRefs.domMatCells, false),
+    // 车缝按 category 分（小计 RMB → HKD，仍除汇率）
+    sewing_hair:  auto('t1', 'sewing_hair',  subRefs.sewHairCells,  true),
+    sewing_cloth: auto('t1', 'sewing_cloth', subRefs.sewClothCells, true),
+    motor:    auto('t1', 'motor',    motorCells,      false),  // 电子+五金 已 HKD
+    suction:  auto('t1', 'suction',  blisterCells,    false),  // 包装+电子+五金 已 HKD
+    hardware: auto('t1', 'hardware', hwNonMotorCells, false),  // 五金已 HKD（剔除马达）
+    // 表2 包装/外购：包装/辅助 已是 HKD，不除汇率
+    color_box: auto('t2', 'color_box', colorBoxCells, false),
+    other_buy: auto('t2', 'other_buy', otherBuyCells, false),
+    battery:   auto('t2', 'battery',   batteryCells,  false),
+    libao:     auto('t2', 'libao',     libaoCells,    false),
+    plating:   auto('t2', 'plating',   platingCells,  false),
+    // 表2 引用 九、合计：纸箱=K，杂项=印尼运费H+附加税P，未减税前码数=码点M
+    carton:      refLink('t2', 'carton',      sumR ? `K${sumR}` : null),
+    misc:        refLink('t2', 'misc',        sumR ? `H${sumR}+P${sumR}` : null),
+    code_before: refLink('t2', 'code_before', sumR ? `M${sumR}` : null),
+    // 运费/吊柜费 = 直接引用 出货价算价 盐田40柜 的 运费/吊柜费 单元格（单一来源）；回退到运费场景率×%
+    freight: refLink('t2', 'freight', subRefs.shipFreightCell || (ytRateCell ? `${ytRateCell}*${fPct}/100` : null)),
+    cabinet: refLink('t2', 'cabinet', subRefs.shipCabinetCell || (ytRateCell ? `${ytRateCell}*${lPct}/100` : null)),
+  };
+  const colL = (n) => { let s=''; while(n>0){const m=(n-1)%26; s=String.fromCharCode(65+m)+s; n=Math.floor((n-1)/26);} return s; };
+
+  // 实时重算公式 result（不依赖可能过期的 ps 存储快照）：读取被引用单元格的当前值代入求值。
+  // 所有被引用单元格都在本表之前已写入实时值，故结果 = UI 当前提取计算值。
+  const cellVal = (addr) => { const c = ws.getCell(addr); let v = c && c.value; if (v && typeof v === 'object') v = ('result' in v) ? v.result : (('formula' in v) ? 0 : v); return Number(v) || 0; };
+  const liveResult = (ref, fallback) => {
+    if (!ref) return fallback;
+    const expr = ref.replace(/[A-Z]+\d+/g, m => cellVal(m));
+    if (!/^[-+*/().\d\s]+$/.test(expr)) return fallback;  // 只允许纯算术，安全兜底
+    try { const r = Function(`return (${expr})`)(); return Number.isFinite(r) ? r : fallback; } catch { return fallback; }
+  };
+  // 写一行减税明细：有 link 写公式(result 实时重算)，否则写静态值
+  const writeDataRow = (cols, data, dataRow) => cols.forEach((c, i) => {
+    const cell = ws.getCell(dataRow, i + 1);
+    const link = linkMap[c[1]];
+    cell.value = link ? { formula: link.ref, result: liveResult(link.ref, num(data[c[1]])) } : num(data[c[1]]);
+    styleData(cell);
+    cell.numFmt = '0.0000';
+  });
+
+  ws.mergeCells(row, 1, row, 13); styleSection(ws.getCell(row, 1));
+  ws.getCell(row, 1).value = '十二、减税明细 / 成本汇总';
+  row += 1;
+
+  // 表 1 出厂货价核
+  const t1 = ps.t1 || {};
+  const t1Cols = [['货价', 'base_price'], ['进口料', 'imp_mat'], ['国内料', 'dom_mat'], ['吹气', 'blow'], ['搪胶', 'slush'],
+    ['车发', 'sewing_hair'], ['车衣', 'sewing_cloth'], ['五金', 'hardware'], ['电子', 'electronic'], ['马达', 'motor'], ['吸塑', 'suction']];
+  ws.getCell(row, 1).value = '一、出厂货价核';
+  ws.mergeCells(row, 1, row, 13);
+  ws.getCell(row, 1).font = { bold: true, name: 'Microsoft YaHei' };
+  row += 1;
+  t1Cols.forEach((c, i) => { ws.getCell(row, i + 1).value = c[0]; styleHeader(ws.getCell(row, i + 1)); });
+  row += 1;
+  const t1DataRow = row;
+  writeDataRow(t1Cols, t1, t1DataRow);
+  row += 2;
+  // 单元格地址
+  const t1Addr = {};
+  t1Cols.forEach((c, i) => { t1Addr[c[1]] = `${colL(i+1)}${t1DataRow}`; });
+
+  // 表 2 包装/外购
+  const t2 = ps.t2 || {};
+  // 与前端 UI 一致：彩盒/内咭 合并为一列（inner_card 为已废弃字段，前端已并入 color_box）
+  const t2Cols = [['彩盒/内咭', 'color_box'], ['未减税前码数', 'code_before'], ['减税后码数', 'code_after'],
+    ['电池', 'battery'], ['利宝', 'libao'], ['电镀', 'plating'], ['其他外购', 'other_buy'],
+    ['纸箱', 'carton'], ['运费', 'freight'], ['吊柜费', 'cabinet'], ['杂项', 'misc']];
+  ws.getCell(row, 1).value = '二、包装 / 外购';
+  ws.mergeCells(row, 1, row, 13);
+  ws.getCell(row, 1).font = { bold: true, name: 'Microsoft YaHei' };
+  row += 1;
+  t2Cols.forEach((c, i) => { ws.getCell(row, i + 1).value = c[0]; styleHeader(ws.getCell(row, i + 1)); });
+  row += 1;
+  const t2DataRow = row;
+  writeDataRow(t2Cols, t2, t2DataRow);
+  row += 2;
+  const t2Addr = {};
+  t2Cols.forEach((c, i) => { t2Addr[c[1]] = `${colL(i+1)}${t2DataRow}`; });
+
+  // 不含人工成本各项地址组（表1 除货价 + 表2 除码数）
+  const noLaborRefs = [];
+  t1Cols.slice(1).forEach(([, k]) => noLaborRefs.push(t1Addr[k]));
+  t2Cols.filter(([, k]) => k !== 'code_before' && k !== 'code_after').forEach(([, k]) => noLaborRefs.push(t2Addr[k]));
+
+  // 表 3 人工 & 成本汇总
+  const t3 = ps.t3 || {};
+  // result 用实时单元格值（不用过期 ps 快照），与 表1/表2 口径一致
+  const basePrice = cellVal(t1Addr.base_price);
+  const noLaborCost = noLaborRefs.reduce((s, ref) => s + cellVal(ref), 0)
+                    + num(t3.injection_labor) + num(t3.painting_labor) + num(t3.paint_material);
+  const totalCost = noLaborCost + num(t3.assembly_labor);
+  const gross = basePrice - noLaborCost;
+  const profit = basePrice - totalCost;
+
+  ws.getCell(row, 1).value = '三、人工 & 成本汇总';
+  ws.mergeCells(row, 1, row, 13);
+  ws.getCell(row, 1).font = { bold: true, name: 'Microsoft YaHei' };
+  row += 1;
+  // 与前端 UI 一致：啤工 喷油工 油漆 装配工 不含人工成本 人工比例 毛利 毛利率 利润 利润率 总成本（无 ABS 列）
+  const t3Header = ['啤工', '喷油工', '油漆', '装配工', '不含人工成本', '人工比例', '毛利', '毛利率', '利润', '利润率', '总成本'];
+  t3Header.forEach((v, i) => { ws.getCell(row, i + 1).value = v; styleHeader(ws.getCell(row, i + 1)); });
+  row += 1;
+  const t3Row = row;
+  const basePriceRef = t1Addr.base_price;  // 货价
+  // A 啤工 B 喷油工 C 油漆 D 装配工 — 套公式引用来源；被手填覆盖(ov)则保持静态值
+  //   啤工=注塑Σ啤价(K)；喷油工=二次加工合计×0.7；油漆=×0.3；装配工=组装人工+包装人工
+  const asmRef = (subRefs.asmLabor && subRefs.pkgLabor) ? `${subRefs.asmLabor}+${subRefs.pkgLabor}`
+                : (subRefs.asmLabor || subRefs.pkgLabor || null);
+  const t3cell = (key, formula, result) => (ov[`t3.${key}`] || !formula) ? result : { formula, result };
+  ws.getCell(row, 1).value = t3cell('injection_labor', subRefs.injShotSum || null, num(t3.injection_labor)); ws.getCell(row, 1).numFmt = '0.0000';
+  ws.getCell(row, 2).value = t3cell('painting_labor', subRefs.secondProc ? `${subRefs.secondProc}*0.7` : null, num(t3.painting_labor)); ws.getCell(row, 2).numFmt = '0.0000';
+  ws.getCell(row, 3).value = t3cell('paint_material', subRefs.secondProc ? `${subRefs.secondProc}*0.3` : null, num(t3.paint_material)); ws.getCell(row, 3).numFmt = '0.0000';
+  ws.getCell(row, 4).value = t3cell('assembly_labor', asmRef, num(t3.assembly_labor)); ws.getCell(row, 4).numFmt = '0.0000';
+  // E 不含人工成本 = 表1(无货价)+表2(成本) + 啤工+喷油工+油漆
+  const noLaborFormula = `${noLaborRefs.join('+')}+A${row}+B${row}+C${row}`;
+  ws.getCell(row, 5).value = { formula: noLaborFormula, result: noLaborCost }; ws.getCell(row, 5).numFmt = '0.0000';
+  // F 人工比例 = 装配工/货价
+  ws.getCell(row, 6).value = { formula: `IFERROR(D${row}/${basePriceRef},0)`, result: basePrice ? num(t3.assembly_labor)/basePrice : 0 }; ws.getCell(row, 6).numFmt = '0.00%';
+  // G 毛利 = 货价 - 不含人工成本
+  ws.getCell(row, 7).value = { formula: `${basePriceRef}-E${row}`, result: gross }; ws.getCell(row, 7).numFmt = '0.0000';
+  // H 毛利率
+  ws.getCell(row, 8).value = { formula: `IFERROR(G${row}/${basePriceRef},0)`, result: basePrice ? gross/basePrice : 0 }; ws.getCell(row, 8).numFmt = '0.00%';
+  // I 利润 = 货价 - 总成本
+  ws.getCell(row, 9).value = { formula: `${basePriceRef}-K${row}`, result: profit }; ws.getCell(row, 9).numFmt = '0.0000';
+  // J 利润率
+  ws.getCell(row, 10).value = { formula: `IFERROR(I${row}/${basePriceRef},0)`, result: basePrice ? profit/basePrice : 0 }; ws.getCell(row, 10).numFmt = '0.00%';
+  // K 总成本 = 不含人工成本 + 装配工
+  const totalCostFormula = `E${row}+D${row}`;
+  ws.getCell(row, 11).value = { formula: totalCostFormula, result: totalCost }; ws.getCell(row, 11).numFmt = '0.0000';
+  for (let c = 1; c <= 11; c++) styleData(ws.getCell(row, c));
+  row += 2;
+
+  // 表 4 减税明细（金额行 + 税率行）
+  const t4 = ps.t4 || {};
+  const t4Cols = [['人民币外购件成本', 'rmb_buy'], ['含税13%类成本', 'tax13'], ['人工类13%', 'labor13'], ['纸箱类', 'carton'],
+    ['含税1%', 'tax1'], ['搪胶类3%', 'slush3'], ['车发类13%', 'sewhair13'], ['车衣类13%', 'sewcloth13'],
+    ['吸塑类6%', 'suction6'], ['运费类9%', 'freight9'], ['含税13%类', 'tax13b']];
+  const T4_NO_RATE = new Set(['rmb_buy', 'tax13']);  // 参考列：无税率、不参与减税
+  ws.getCell(row, 1).value = '四、减税明细';
+  ws.mergeCells(row, 1, row, 13);
+  ws.getCell(row, 1).font = { bold: true, name: 'Microsoft YaHei' };
+  row += 1;
+  t4Cols.forEach((c, i) => { ws.getCell(row, i + 1).value = c[0]; styleHeader(ws.getCell(row, i + 1)); });
+  ws.getCell(row, 12).value = '合计减税'; styleHeader(ws.getCell(row, 12));
+  row += 1;
+  const t4AmtRow = row;
+  let totalDed = 0;
+  const t4AmtVals = [];  // 各列实时金额，供"减税额"行 result
+  // 各列金额公式（引用 t1/t2/t3 对应单元格）
+  const tA = t1Addr, tB = t2Addr;
+  const T3_INJ = `A${t3Row}`, T3_PNT = `B${t3Row}`, T3_PMAT = `C${t3Row}`, T3_ASM = `D${t3Row}`;
+  const rmbBuyFormula =
+    `${tA.dom_mat}+${tA.sewing_hair}+${tA.sewing_cloth}+${tA.hardware}+${tA.electronic}+${tA.motor}`
+    + `+${tB.color_box}+${tB.battery}+${tB.libao}+${tB.plating}+${tB.other_buy}+${tB.carton}+${tB.misc}+${T3_PMAT}`;
+  const T4_FORMULA = {
+    rmb_buy: rmbBuyFormula,
+    tax13: `${tB.libao}+${tB.other_buy}`,
+    labor13: `${T3_INJ}+${T3_PNT}+${T3_ASM}`,
+    carton: tB.carton,
+    tax1: tB.plating,
+    slush3: tA.slush,
+    sewhair13: tA.sewing_hair,
+    sewcloth13: tA.sewing_cloth,
+    suction6: tA.suction,
+    freight9: tB.freight,
+    tax13b: `${tB.libao}+${tB.other_buy}`,
+  };
+  t4Cols.forEach((c, i) => {
+    const e = t4[c[1]] || { amt: 0, rate: 0 };
+    const fml = T4_FORMULA[c[1]];
+    // result 实时重算（引用 表1/表2 实时单元格），不用过期 ps
+    const amtLive = fml ? liveResult(fml, num(e.amt)) : num(e.amt);
+    t4AmtVals.push(amtLive);
+    ws.getCell(row, i + 1).value = fml ? { formula: fml, result: amtLive } : amtLive;
+    styleData(ws.getCell(row, i + 1));
+    ws.getCell(row, i + 1).numFmt = '0.0000';
+    if (!T4_NO_RATE.has(c[1])) totalDed += amtLive * num(e.rate) / 100;  // 参考列不计减税
+  });
+  row += 1;
+  const t4RateRow = row;
+  t4Cols.forEach((c, i) => {
+    const e = t4[c[1]] || { amt: 0, rate: 0 };
+    if (T4_NO_RATE.has(c[1])) { styleData(ws.getCell(row, i + 1)); return; }  // 参考列无税率
+    ws.getCell(row, i + 1).value = num(e.rate) / 100;
+    ws.getCell(row, i + 1).numFmt = '0.00%';
+    styleData(ws.getCell(row, i + 1));
+  });
+  ws.getCell(row, 12).value = '税率 %';
+  styleData(ws.getCell(row, 12));
+  row += 1;
+  // 减税额 = 金额 × 税率（逐项，引用上方金额行×税率行）
+  const t4DedRow = row;
+  const t4LastCol = colL(t4Cols.length);
+  t4Cols.forEach((c, i) => {
+    const e = t4[c[1]] || { amt: 0, rate: 0 };
+    if (T4_NO_RATE.has(c[1])) { ws.getCell(row, i + 1).value = '—'; styleData(ws.getCell(row, i + 1)); return; }  // 参考列无减税额
+    const col = colL(i + 1);
+    ws.getCell(row, i + 1).value = { formula: `${col}${t4AmtRow}*${col}${t4RateRow}`, result: num(t4AmtVals[i]) * num(e.rate) / 100 };
+    ws.getCell(row, i + 1).numFmt = '0.0000';
+    styleData(ws.getCell(row, i + 1));
+  });
+  ws.getCell(row, 12).value = '减税额'; styleData(ws.getCell(row, 12));
+  // 合计减税 = SUM(减税额 行)，放在 减税额行(最后一行) col12
+  ws.getCell(t4DedRow, 12).value = { formula: `SUM(A${t4DedRow}:${t4LastCol}${t4DedRow})`, result: totalDed };
+  ws.getCell(t4DedRow, 12).numFmt = '0.0000';
+  styleSubtotal(ws.getCell(t4DedRow, 12), 'total');
+  row += 2;
+
+  // 减税后结果
+  const totalDedRef = `L${t4DedRow}`;  // 合计减税在减税额行(最后一行)
+  const noLaborRefExpanded = `E${t3Row}`;    // 表3 不含人工成本 单元格
+  const totalCostRefExpanded = `K${t3Row}`;  // 表3 总成本 单元格
+  const afterCost = totalCost - totalDed;
+  const afterGross = basePrice - (noLaborCost - totalDed);
+  const afterProfit = afterGross - num(t3.assembly_labor);
+
+  const summaryRows = [
+    ['合计减税', { formula: totalDedRef, result: totalDed }, '0.0000'],
+    ['减税后成本', { formula: `(${totalCostRefExpanded})-${totalDedRef}`, result: afterCost }, '0.0000'],
+    ['减税后毛利', { formula: `${basePriceRef}-((${noLaborRefExpanded})-${totalDedRef})`, result: afterGross }, '0.0000'],
+    ['减税后毛利率', { formula: `IFERROR((${basePriceRef}-((${noLaborRefExpanded})-${totalDedRef}))/${basePriceRef},0)`, result: basePrice ? afterGross/basePrice : 0 }, '0.00%'],
+    ['减税后利润', { formula: `(${basePriceRef}-((${noLaborRefExpanded})-${totalDedRef}))-D${t3Row}`, result: afterProfit }, '0.0000'],
+    ['减税后利润率', { formula: `IFERROR(((${basePriceRef}-((${noLaborRefExpanded})-${totalDedRef}))-D${t3Row})/${basePriceRef},0)`, result: basePrice ? afterProfit/basePrice : 0 }, '0.00%'],
+  ];
+  let afterCostRow = null;
+  summaryRows.forEach(([k, v, fmt]) => {
+    if (k === '减税后成本') afterCostRow = row;  // 减税后成本 值在 I 列
+    ws.getCell(row, 1).value = k; ws.mergeCells(row, 1, row, 8);
+    ws.getCell(row, 9).value = v; ws.mergeCells(row, 9, row, 13);
+    ws.getCell(row, 9).numFmt = fmt;
+    for (let cc = 1; cc <= 13; cc++) styleSubtotal(ws.getCell(row, cc), 'sub');
+    row += 1;
+  });
+  row += 1;
+
+  // 减税后码数(表2) = 货价 / 减税后成本（前向引用：减税后成本 此处才渲染完，回填公式）
+  const codeAfterIdx = t2Cols.findIndex(c => c[1] === 'code_after') + 1;
+  if (afterCostRow && codeAfterIdx && !ov['t2.code_after']) {
+    const baseLive = cellVal(basePriceRef), afterLive = cellVal(`I${afterCostRow}`);
+    const cell = ws.getCell(t2DataRow, codeAfterIdx);
+    cell.value = { formula: `IFERROR(${basePriceRef}/I${afterCostRow},0)`, result: afterLive > 0 ? baseLive / afterLive : 0 };
+    cell.numFmt = '0.0000';
+  }
+  return row;
+}
+
+// ============ 模具费用 (eng.mold_costs) ============
+function renderMoldCosts(ws, row, mc, quote, refs, amortQty) {
+  if (!mc || !mc.items || !mc.items.length) return row;
+  const fx = num(mc.fx_rmb_usd) || 7.75;
+  ws.mergeCells(row, 1, row, 13); styleSection(ws.getCell(row, 1));
+  ws.getCell(row, 1).value = '生产模具费用';
+  row += 1;
+  // 表头
+  const h = ['模具名称', '', '', '', '', '', '', '', '', '', '模价 (RMB)', '', '模价 (USD)'];
+  h.forEach((v, i) => { ws.getCell(row, i + 1).value = v; styleHeader(ws.getCell(row, i + 1)); });
+  ws.mergeCells(row, 1, row, 10);
+  ws.mergeCells(row, 11, row, 12);
+  row += 1;
+  const dataStart = row;
+  mc.items.forEach(r => {
+    ws.mergeCells(row, 1, row, 10);
+    ws.getCell(row, 1).value = r.name || '';
+    ws.mergeCells(row, 11, row, 12);
+    ws.getCell(row, 11).value = num(r.price_rmb);
+    ws.getCell(row, 11).numFmt = RMB;
+    ws.getCell(row, 13).value = { formula: `K${row}/${fx}`, result: num(r.price_rmb) / fx };
+    ws.getCell(row, 13).numFmt = '"$"#,##0.0000';
+    for (let c = 1; c <= 13; c++) styleData(ws.getCell(row, c));
+    ws.getCell(row, 1).alignment = { horizontal: 'left', vertical: 'middle', indent: 1 };
+    row += 1;
+  });
+  const dataEnd = row - 1;
+  const sumRmb = sum(mc.items, r => num(r.price_rmb));
+  // 模具总计
+  ws.mergeCells(row, 1, row, 10);
+  ws.getCell(row, 1).value = '模具总计';
+  ws.getCell(row, 1).alignment = { horizontal: 'right', vertical: 'middle' };
+  ws.mergeCells(row, 11, row, 12);
+  ws.getCell(row, 11).value = { formula: `SUM(K${dataStart}:K${dataEnd})`, result: sumRmb };
+  ws.getCell(row, 11).numFmt = RMB;
+  ws.getCell(row, 13).value = { formula: `K${row}/${fx}`, result: sumRmb / fx };
+  ws.getCell(row, 13).numFmt = '"$"#,##0.0000';
+  for (let c = 1; c <= 13; c++) styleSubtotal(ws.getCell(row, c), 'sub');
+  ws.getRow(row).font = { bold: true, color: { argb: 'FF1F2937' }, name: 'Microsoft YaHei' };
+  const totalRow = row;
+  row += 1;
+  // 客补贴模费美金
+  ws.mergeCells(row, 1, row, 10);
+  ws.getCell(row, 1).value = '客补贴模费美金';
+  ws.getCell(row, 1).alignment = { horizontal: 'right', vertical: 'middle' };
+  ws.mergeCells(row, 11, row, 12);
+  ws.getCell(row, 11).value = '';
+  ws.getCell(row, 13).value = num(mc.customer_subsidy_usd);
+  ws.getCell(row, 13).numFmt = '"$"#,##0.0000';
+  for (let c = 1; c <= 13; c++) styleData(ws.getCell(row, c));
+  const subsidyRow = row;
+  row += 1;
+  // 模费按 N 套产品分摊（qty 与 九、合计 模具分摊 同源）
+  const qty = Math.max(num(amortQty) || num(mc.amortization_qty), 1);
+  ws.mergeCells(row, 1, row, 10);
+  ws.getCell(row, 1).value = `模费按 ${qty} 套产品分摊`;
+  ws.getCell(row, 1).alignment = { horizontal: 'right', vertical: 'middle' };
+  ws.mergeCells(row, 11, row, 12);
+  ws.getCell(row, 11).value = { formula: `K${totalRow}/${qty}`, result: sumRmb / qty };
+  ws.getCell(row, 11).numFmt = RMB;
+  if (refs) refs.moldShareRmbCell = `K${row}`;  // 每PCS模具分摊(RMB)，供 九、合计 模具分摊 引用
+  ws.getCell(row, 13).value = { formula: `(M${totalRow}-M${subsidyRow})/${qty}`, result: (sumRmb / fx - num(mc.customer_subsidy_usd)) / qty };
+  ws.getCell(row, 13).numFmt = '"$"#,##0.0000';
+  for (let c = 1; c <= 13; c++) styleSubtotal(ws.getCell(row, c), 'total');
+  ws.getRow(row).font = { bold: true, color: { argb: 'FF1F2937' }, name: 'Microsoft YaHei' };
+  row += 2;
+  return row;
+}
+
+module.exports = { buildWorkbook };

--- a/apps/业务部/内部报价系统/backend/services/extractXlsxImages.js
+++ b/apps/业务部/内部报价系统/backend/services/extractXlsxImages.js
@@ -1,0 +1,65 @@
+// 从 .xlsx 抽取嵌入图片 + 它们的 cell anchor 行号
+// .xls 二进制不支持（让前端提示用户另存为 xlsx）
+const JSZip = require('jszip');
+const { XMLParser } = require('fast-xml-parser');
+const path = require('path');
+const fs = require('fs');
+
+async function extractImagesByRow(buf, outDir) {
+  const zip = await JSZip.loadAsync(buf);
+
+  const drawingFiles = Object.keys(zip.files).filter(p => /^xl\/drawings\/drawing\d+\.xml$/.test(p));
+  const mediaFiles = Object.keys(zip.files).filter(p => /^xl\/media\//.test(p));
+  if (drawingFiles.length === 0 || mediaFiles.length === 0) return [];
+
+  const parser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: '@_' });
+  const results = [];
+  // 去重：同一 (媒体源, 行号) 只输出一次（避免多 sheet 重复引用同张图）
+  const seen = new Set();
+
+  for (const dpath of drawingFiles) {
+    const name = path.basename(dpath); // drawing1.xml
+    const relsPath = `xl/drawings/_rels/${name}.rels`;
+    if (!zip.files[relsPath]) continue;
+    const relsXml = await zip.files[relsPath].async('string');
+    const relsObj = parser.parse(relsXml);
+    const relList = [].concat(relsObj?.Relationships?.Relationship || []);
+    const ridToTarget = {};
+    for (const r of relList) {
+      ridToTarget[r['@_Id']] = r['@_Target']; // ../media/imageN.png
+    }
+
+    const drawXml = await zip.files[dpath].async('string');
+    const drawObj = parser.parse(drawXml);
+    const anchors = [].concat(
+      drawObj?.['xdr:wsDr']?.['xdr:twoCellAnchor'] || [],
+      drawObj?.['xdr:wsDr']?.['xdr:oneCellAnchor'] || []
+    );
+    for (const a of anchors) {
+      const from = a['xdr:from'];
+      const fromRow = Number(from?.['xdr:row']); // 0-based
+      const fromCol = Number(from?.['xdr:col']);
+      const blip = a?.['xdr:pic']?.['xdr:blipFill']?.['a:blip'];
+      const rid = blip?.['@_r:embed'] || blip?.['@_xmlns:r']; // 取 r:embed
+      const targetRel = blip?.['@_r:embed'];
+      const target = ridToTarget[targetRel];
+      if (!target) continue;
+      const mediaPath = ('xl/' + target.replace(/^\.\.\//, '')).replace(/\\/g, '/');
+      const mediaFile = zip.files[mediaPath];
+      if (!mediaFile) continue;
+      // 去重：同一媒体源 + 同一行号 已收 → 跳过
+      const key = `${mediaPath}@${fromRow}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      const data = await mediaFile.async('nodebuffer');
+      const ext = path.extname(mediaPath).toLowerCase() || '.png';
+      const outName = `xls-${Date.now()}-${Math.random().toString(36).slice(2, 7)}${ext}`;
+      const outPath = path.join(outDir, outName);
+      fs.writeFileSync(outPath, data);
+      results.push({ row: fromRow, col: fromCol, file: outName });
+    }
+  }
+  return results;
+}
+
+module.exports = { extractImagesByRow };

--- a/apps/业务部/内部报价系统/backend/services/parseAssemblySheet.js
+++ b/apps/业务部/内部报价系统/backend/services/parseAssemblySheet.js
@@ -1,0 +1,129 @@
+// 解析"产品生产排拉工序表"型 xlsx → 返回 { steps: [{ name, count }] }
+// 文件常见结构：序号1 / 工序名称 / 工具 / 人数 / 物料规格 / 重点工位注意事项
+//             序号2 / 工序名称 / 工具 / 人数 / 物料规格 / 重点工位注意事项
+const ExcelJS = require('exceljs');
+const XLSX = require('xlsx');
+
+function toStr(v) {
+  if (v == null) return '';
+  if (typeof v === 'object' && 'richText' in v) return v.richText.map(t => t.text).join('');
+  if (typeof v === 'object' && 'text' in v) return String(v.text);
+  if (typeof v === 'object' && 'result' in v) return String(v.result);
+  return String(v).trim();
+}
+function toNum(v) {
+  if (v == null || v === '') return null;
+  if (typeof v === 'object' && 'result' in v) return Number(v.result) || null;
+  const n = Number(String(v).replace(/[^\d.\-]/g, ''));
+  return isNaN(n) ? null : n;
+}
+
+function isHeaderRow(values) {
+  const j = values.map(toStr).join('|');
+  return /工序名称/.test(j) && /人数/.test(j);
+}
+
+// 找出表头里所有 "工序名称" 和 "人数" 的列位置（可能有 2 套）
+function indexHeader(values) {
+  const cols = []; // [{ nameCol, countCol }]
+  let lastName = null;
+  values.forEach((v, i) => {
+    const s = toStr(v);
+    if (s.includes('工序名称')) lastName = i;
+    else if (s.includes('人数') && lastName != null) {
+      cols.push({ nameCol: lastName, countCol: i });
+      lastName = null;
+    }
+  });
+  return cols;
+}
+
+// 用 SheetJS 把任意 sheet 转成 rows 数组（与 ExcelJS 输出格式一致：arr[colIdx]，1-based）
+function sheetjsToRows(sheet) {
+  const aoa = XLSX.utils.sheet_to_json(sheet, { header: 1, defval: null, raw: true });
+  return aoa.map(row => {
+    const arr = [];
+    (row || []).forEach((v, i) => { arr[i + 1] = v; }); // 1-based
+    return arr;
+  });
+}
+
+async function parseWorkbook(buffer) {
+  let sheets = [];
+  let usedExceljs = false;
+  // 尝试 .xlsx（ExcelJS）
+  try {
+    const wb = new ExcelJS.Workbook();
+    await wb.xlsx.load(buffer);
+    if (wb.worksheets && wb.worksheets.length) {
+      usedExceljs = true;
+      for (const ws of wb.worksheets) {
+        const tmp = [];
+        ws.eachRow({ includeEmpty: true }, (row) => {
+          const arr = [];
+          row.eachCell({ includeEmpty: true }, (cell, cn) => { arr[cn] = cell.value; });
+          tmp.push(arr);
+        });
+        sheets.push({ name: ws.name, rows: tmp });
+      }
+    }
+  } catch {}
+  // 回退到 SheetJS（支持 .xls 旧二进制）
+  if (!sheets.length) {
+    try {
+      const wb = XLSX.read(buffer, { type: 'buffer' });
+      for (const name of wb.SheetNames) {
+        sheets.push({ name, rows: sheetjsToRows(wb.Sheets[name]) });
+      }
+    } catch (e) {
+      return { error: '解析失败：' + e.message };
+    }
+  }
+  if (!sheets.length) return { error: '工作簿为空' };
+
+  // 找出有"工序名称"+"人数"表头的 sheet
+  let pickedSheet = null;
+  for (const s of sheets) {
+    if (s.rows.some(r => isHeaderRow(r))) { pickedSheet = s; break; }
+  }
+  if (!pickedSheet) return { error: '所有 sheet 都找不到"工序名称 / 人数"表头' };
+  const ws = { name: pickedSheet.name };
+  const rows = pickedSheet.rows;
+
+  let cols = null;
+  let meta = {};
+  const steps = [];
+
+  for (let i = 0; i < rows.length; i++) {
+    const r = rows[i] || [];
+    const text = r.map(toStr).join('|');
+
+    // 抓抬头元数据
+    const m1 = text.match(/客名[：:]\s*([^\s|]+)/); if (m1) meta.customer = m1[1];
+    const m2 = text.match(/货号[：:]\s*([^\s|]+)/); if (m2) meta.quote_no = m2[1];
+    const m3 = text.match(/日期[：:]\s*([\d.\-/]+)/); if (m3) meta.date = m3[1];
+    const m4 = text.match(/目标数[：:]?\s*(\d{2,})/); if (m4) meta.target_qty = Number(m4[1]);
+    const m5 = text.match(/人数[：:]?\s*(\d{1,3})\s*人/); if (m5) meta.total_people = Number(m5[1]);
+    const m6 = text.match(/时间[：:]?\s*(\d{1,2})\s*[Hh小时]/); if (m6) meta.work_hours = Number(m6[1]);
+
+    if (!cols) {
+      if (isHeaderRow(r)) cols = indexHeader(r);
+      continue;
+    }
+
+    // 数据行：遍历每组 (nameCol, countCol)
+    for (const { nameCol, countCol } of cols) {
+      const name = toStr(r[nameCol]);
+      const count = toNum(r[countCol]);
+      if (!name) continue;
+      if (/序号|工序名称|^生产拉线$/.test(name)) continue;
+      if (count == null) continue;
+      steps.push({ name, count });
+    }
+  }
+
+  if (!steps.length) return { error: '未解析到任何工序行（请确认表头含 工序名称 / 人数）' };
+  return { meta, steps, count: steps.length, sheet_used: ws.name };
+}
+
+module.exports = { parseWorkbook };

--- a/apps/业务部/内部报价系统/backend/services/parseElectronicSheet.js
+++ b/apps/业务部/内部报价系统/backend/services/parseElectronicSheet.js
@@ -1,0 +1,146 @@
+// 解析"电子报价单"型 xlsx
+// 表头：零件名称 / 规格 / 用量 / 单价RMB / 合计RMB / 备注
+// 末尾：模费/外购 + 成本汇总（零件成本 / 邦定 / 贴片 / 人工 / 测试 / 包装运输 / 含利润价 / 含税报价）
+const ExcelJS = require('exceljs');
+
+function toStr(v) {
+  if (v == null) return '';
+  if (typeof v === 'object' && 'richText' in v) return v.richText.map(t => t.text).join('');
+  if (typeof v === 'object' && 'text' in v) return String(v.text);
+  if (typeof v === 'object' && 'result' in v) return String(v.result);
+  return String(v).trim();
+}
+function toNum(v) {
+  if (v == null || v === '') return null;
+  if (typeof v === 'object' && 'result' in v) return Number(v.result) || null;
+  const n = Number(String(v).replace(/[^\d.\-]/g, ''));
+  return isNaN(n) ? null : n;
+}
+function isHeader(values) {
+  const j = values.map(toStr).join('|');
+  return j.includes('零件名称') && j.includes('规格') && j.includes('用量');
+}
+function indexHeader(headerCells) {
+  const idx = {};
+  const setOnce = (k, i) => { if (idx[k] == null) idx[k] = i; };
+  headerCells.forEach((v, i) => {
+    const s = toStr(v);
+    if (!s) return;
+    if (s.includes('零件名称')) setOnce('name', i);
+    else if (s.includes('规格')) setOnce('spec', i);
+    else if (s.includes('用量')) setOnce('qty', i);
+    else if (s.includes('单价')) setOnce('unit_price', i);
+    else if (s.includes('合计')) setOnce('amount', i);
+    else if (s.includes('备注')) setOnce('note', i);
+  });
+  return idx;
+}
+
+async function parseWorkbook(buffer) {
+  const wb = new ExcelJS.Workbook();
+  await wb.xlsx.load(buffer);
+  const ws = wb.worksheets[0];
+  if (!ws) return { error: '工作簿为空' };
+
+  const rows = [];
+  ws.eachRow({ includeEmpty: true }, (row) => {
+    const arr = [];
+    row.eachCell({ includeEmpty: true }, (cell, cn) => { arr[cn] = cell.value; });
+    rows.push(arr);
+  });
+
+  let headerIdx = null;
+  const parts = [];
+  let lastParent = null;
+  const extras = { test_repair: 0, packing_shipping: 0, profit_pct: 0, tax_diff: 0, tax_payable: 0 };
+  let meta = {};
+
+  for (let i = 0; i < rows.length; i++) {
+    const r = rows[i] || [];
+    const joined = r.map(toStr);
+    const text = joined.join('|');
+
+    // 标题元数据
+    const productMatch = text.match(/产品(?:名称|编号)[：:]\s*([^\s|]+)/);
+    if (productMatch) meta.product = productMatch[1];
+    const custMatch = text.match(/客户[：:]\s*([^\s|]+)/);
+    if (custMatch) meta.customer = custMatch[1];
+    const dateMatch = text.match(/报价日期[：:]\s*([\d.\-/]+)/);
+    if (dateMatch) meta.date = dateMatch[1];
+
+    if (!headerIdx) {
+      if (isHeader(r)) headerIdx = indexHeader(r);
+      continue;
+    }
+
+    // 在表头后扫描数据行
+    const name = toStr(r[headerIdx.name]);
+    const spec = toStr(r[headerIdx.spec]);
+    const qty = toNum(r[headerIdx.qty]);
+    const unitPrice = toNum(r[headerIdx.unit_price]);
+    const amount = toNum(r[headerIdx.amount]);
+    const note = toStr(r[headerIdx.note]);
+
+    // 成本汇总段（散落在右侧）
+    if (text.includes('零件成本') || text.includes('邦定成本') || text.includes('贴片成本')
+        || text.includes('人工成本') || text.includes('测试费用') || text.includes('包装运输')
+        || text.includes('含利润价') || text.includes('抵税差额') || text.includes('应交税负')
+        || text.includes('含税报价') || text.includes('合计成本')) {
+      // 在该行里找标签 + 紧邻数值
+      for (let c = 1; c < r.length; c++) {
+        const label = toStr(r[c]);
+        const val = toNum(r[c + 1]);
+        if (val == null) continue;
+        if (label.includes('测试费用')) extras.test_repair = val;
+        else if (label.includes('包装运输')) extras.packing_shipping = val;
+        else if (label.includes('邦定成本')) extras.bonding_cost = val;
+        else if (label.includes('贴片成本')) extras.smt_cost = val;
+        else if (label.includes('人工成本')) extras.labor_cost = val;
+        else if (label.includes('抵税差额')) extras.tax_diff = val;
+        else if (label.includes('应交税负')) extras.tax_payable = val;
+        else if (label.includes('含税报价')) extras.taxed_price = val;
+        else if (label.includes('含利润价')) extras.profit_price = val;
+        else if (label.includes('零件成本')) extras.parts_cost = val;
+      }
+      // 含 *N%利润 提取利润 %
+      const profitMatch = text.match(/[*\s]*(\d{1,3})%\s*利润/);
+      if (profitMatch) extras.profit_pct = +profitMatch[1];
+      continue;
+    }
+    // 模费/外购 / 报价人 / 审核 / 核准 / 注 等说明行 — 跳过
+    if (text.includes('模费') || text.includes('此报价') || text.includes('注：')
+        || /报价人|审\s*核|核\s*准|签\s*字/.test(text)) continue;
+
+    // 跳过完全空行
+    if (!name && !spec && qty == null && unitPrice == null) continue;
+
+    // 子项（name 空 + 有 spec）→ 挂到 lastParent.children
+    if (!name && spec && lastParent) {
+      lastParent.children = lastParent.children || [];
+      lastParent.children.push({
+        name: '', spec, qty: qty || 1,
+        unit_price: unitPrice || 0,
+        amount: amount || (qty || 0) * (unitPrice || 0),
+        note,
+      });
+      continue;
+    }
+    if (name) {
+      const part = {
+        name, spec: spec || '',
+        qty: qty || 1, unit_price: unitPrice || 0,
+        amount: amount || (qty || 0) * (unitPrice || 0),
+        note,
+        children: [],
+      };
+      parts.push(part);
+      lastParent = part;
+    }
+  }
+
+  if (!parts.length) return { error: '未解析到任何零件行（请确认表头含 零件名称/规格/用量/单价）' };
+
+  return { meta, parts, extras, count: parts.length, sheet_used: ws.name };
+}
+
+module.exports = { parseWorkbook };

--- a/apps/业务部/内部报价系统/backend/services/parseMoldSheet.js
+++ b/apps/业务部/内部报价系统/backend/services/parseMoldSheet.js
@@ -1,0 +1,215 @@
+// 解析任意"模具相关报价 xlsx" → 自适应输出 molds[]
+// 支持两种已知格式：
+//   A. "模具报价单&合同"型：列 = 模号/产品名称/材质/出模数/套数/含税模价/...，多行子产品按主模号合并
+//   B. "改模/配件报价"型：列 = 序号/模具编号/客人模具编号/加工内容/数量/单价/总价/备注，每行一副模具
+// 通用思路：
+//   1. 找 header 行：含 ≥3 个常见关键字的行
+//   2. 用关键字字典把表头列名 → 抽象字段 (mold_no / name / ... )
+//   3. 数据行映射到 molds[]；若存在"主模号"列且子行无模号，则视为前一行的子产品 → 合并
+
+const XLSX = require('xlsx');
+
+// 字段 → 关键词候选（越靠前优先级越高）
+// 关键词全部以「去空格 + 大写」比较，故英文关键词写成大写即可同时兼容中英表头
+const FIELD_KEYWORDS = {
+  mold_no:        ['模号', '模具编号', '客人模具编号', '编号', 'MOLDNO'],
+  name:           ['产品名称', '零件名称', '中文名', 'CHINESENAME', '加工内容', '修改内容', '模具名称', '名称', 'PARTNAME', 'DESCRIPTION'],
+  // 模具材料(内呵钢材) / 模具尺寸(模胚型号) 优先映射（避免被 "材质/材料" 短词抢占）
+  mold_material:  ['模具材料', '内呵材质', '内呵', '钢号', '钢材', 'TOOLINSERT', 'INSERT'],
+  mold_size:      ['模具尺寸', '模胚尺寸', 'DIM', 'HXWXD', 'TOOLINFORMATION'],
+  material:       ['塑胶原料', '塑胶', '产品材质', '产品材料', '材质', '材料', '原料', "MAT'L", 'MATERIAL'],
+  color:          ['颜色', 'COLOR'],
+  cavity:         ['出模数', '模数', 'CAV'],
+  sets:           ['套数', 'UP', '数量/件', '数量'],
+  product_size:   ['产品尺寸'],
+  weight:         ['净重', '克重', '零件重', 'PARTWEIGHT'],
+  cycle:          ['周期', 'CYCLETIME', 'CYCLE'],   // 注塑生产周期(秒)
+  structure:      ['滑块', '斜顶', '模具结构', '加工内容', 'SLIDE', '行位'],
+  price_rmb:      ['含税模价', '总价', '模价', '价格', '单价', 'TOTALAMOUNT', 'AMOUNT'],
+  price_usd:      ['USD', '美元'],
+  mold_type:      ['模胚类型', '模胚大约', '模胚型号', '模胚', '水口', 'GATE'],
+  note:           ['备注', '说明', 'REMARK'],
+};
+
+const HEADER_HINT_WORDS = ['序号', '编号', '名称', '材质', '出模数', '套数', '数量', '单价', '总价', '模价', '价格', '备注', '图片', '加工', '产品', '客户',
+  'MOLD', 'PART', 'CAV', 'COLOR', 'CYCLE', 'AMOUNT', 'REMARK', 'GATE', 'WEIGHT', 'MATERIAL', 'PICTURE', 'SLIDE'];
+
+function norm(s) { return String(s || '').replace(/\s+/g, '').replace(/[（）]/g, ''); }
+function nu(s) { return norm(s).toUpperCase(); }  // 去空格+大写，中英不敏感
+
+function findHeaderRow(rows) {
+  let best = -1, bestHits = 0;
+  for (let i = 0; i < Math.min(rows.length, 25); i++) {
+    const r = rows[i] || [];
+    const text = r.map(nu).join('|');
+    let hits = 0;
+    for (const w of HEADER_HINT_WORDS) if (text.includes(nu(w))) hits++;
+    if (hits > bestHits) { bestHits = hits; best = i; }
+  }
+  return bestHits >= 3 ? best : -1;
+}
+
+function mapColumns(headerRow) {
+  const cols = {};
+  const used = new Set();
+  for (const [field, kws] of Object.entries(FIELD_KEYWORDS)) {
+    cols[field] = -1;
+    for (const kw of kws) {
+      for (let i = 0; i < headerRow.length; i++) {
+        if (used.has(i)) continue;
+        if (nu(headerRow[i]).includes(nu(kw))) { cols[field] = i; used.add(i); break; }
+      }
+      if (cols[field] >= 0) break;
+    }
+  }
+  return cols;
+}
+
+function parseNumber(v) {
+  if (v == null || v === '') return null;
+  const n = Number(String(v).replace(/[￥$,，\s元RMB]/gi, ''));
+  return Number.isFinite(n) ? n : null;
+}
+
+function parseWorkbook(buf) {
+  const wb = XLSX.read(buf, { cellStyles: false, cellFormula: false });
+  // 遍历所有候选 sheet，挑解析出最多模具的那个（跳过明显无关 sheet）
+  const EXCLUDE = /电子|五金|印喷|彩盒|包装|辅料|工艺/;
+  const candidates = wb.SheetNames.filter(n => wb.Sheets[n] && wb.Sheets[n]['!ref'] && !EXCLUDE.test(n));
+  if (candidates.length === 0) return { error: '所有工作表都是空的或被排除', sheets: wb.SheetNames };
+
+  let best = null;
+  for (const sheetName of candidates) {
+    const r = tryParseSheet(wb, sheetName);
+    if (!best) best = r;
+    if (r.molds && (!best.molds || r.molds.length > best.molds.length)) best = r;
+  }
+  if (!best.molds || best.molds.length === 0) {
+    return {
+      error: best.error || '未在任何工作表中解析到模具行',
+      sheets: wb.SheetNames,
+      sheet_used: best.sheet_used,
+      preview: best.preview,
+    };
+  }
+  return best;
+}
+
+function tryParseSheet(wb, sheetName) {
+  const ws = wb.Sheets[sheetName];
+  const aoa = XLSX.utils.sheet_to_json(ws, { header: 1, raw: false, defval: '' });
+  const hIdx = findHeaderRow(aoa);
+  if (hIdx < 0) {
+    return {
+      error: '未识别到表头',
+      sheets: wb.SheetNames, sheet_used: sheetName,
+      preview: aoa.slice(0, 15),
+    };
+  }
+  // 表头可能是双行（英文主表头 + 中文/单位副表头）；若下一行也像表头则按列合并
+  let header = (aoa[hIdx] || []).slice();
+  let dataStart = hIdx + 1;
+  const nextRow = aoa[hIdx + 1];
+  if (nextRow) {
+    const ntext = nextRow.map(nu).join('|');
+    let nextHits = 0;
+    for (const w of HEADER_HINT_WORDS) if (ntext.includes(nu(w))) nextHits++;
+    const numeric = nextRow.filter(c => String(c).trim() && /^[\d,.]+$/.test(String(c).trim())).length;
+    if (nextHits >= 2 && numeric <= 1) {  // 副表头：含表头词且几乎无数值 → 合并
+      const len = Math.max(header.length, nextRow.length);
+      const merged = [];
+      for (let c = 0; c < len; c++) merged[c] = `${header[c] || ''} ${nextRow[c] || ''}`.trim();
+      header = merged;
+      dataStart = hIdx + 2;
+    }
+  }
+  const cols = mapColumns(header);
+
+  const cell = (r, k) => cols[k] >= 0 ? String(r[cols[k]] ?? '').trim() : '';
+
+  // 数据行：从 dataStart 起；遇到新的 section 标题（如"二、注塑部分"）或新表头则停止
+  const dataRows = [];
+  for (let i = dataStart; i < aoa.length; i++) {
+    const r = aoa[i] || [];
+    const txt = r.map(c => String(c ?? '')).join('').trim();
+    if (!txt) continue;
+    const rowText = r.map(c => nu(c)).join('|');
+    // 边界：再遇到 "X、XXX部分" 章节标题 → 停止
+    if (/[一二三四五六七八九十]、.+部分/.test(rowText)) break;
+    // 边界：再遇到 header-like 行（高密度关键字）→ 停止
+    let hits = 0;
+    for (const w of HEADER_HINT_WORDS) if (rowText.includes(nu(w))) hits++;
+    if (hits >= 3) break;
+    // 跳过条款 / 说明 / 签名 / 合计 等非数据行
+    if (/^(小计|合计|总计|大写|说明|备注|以下空白|客户确认|签名|损耗)/.test(norm(r[0]))) continue;
+    if (/以下空白|客户确认|确认签名|付款方式|完成时间|交货地点|交货时间|交货期|不含税|不含报价|不包含报价|请回电|协商|此单有问题|交付后|工作日完成|甲方|乙方|签字|盖章|改图|抄数费用|模具寿命|消耗品|本报价单|影印件|特别说明|蚀纹|温控箱|订金|首款|尾款|中款|另计/.test(rowText)) continue;
+    // 条款编号行：col-1 以"数字+点/、"开头（如 "1.模具符合..." "2、付款"）
+    const c1 = String(r[1] || '').trim();
+    if (/^\d+\s*[.、、，,]/.test(c1) && c1.length > 12) continue;
+    if (/[一二三四五六七八九十]、/.test(String(r[0] || ''))) continue;
+    // 页脚/签名/条款（如 "Authorized signature"）；英文条款
+    if (/AUTHORIZED|SIGNATURE|I\/WE ACCEPT|COMPANY CHOP|TERMS/i.test(txt)) continue;
+    // 有模号列时：既无模号又无名称的行（合计/签名/条款）不并入上一副模具
+    if (cols.mold_no >= 0 && !cell(r, 'mold_no') && !cell(r, 'name')) continue;
+    dataRows.push({ r, ri: i });  // ri = 0-based 原始行号，供图片按行归属
+  }
+
+  // 决定是否做"主模号合并"——仅当 mold_no 列存在且存在多个含值/空值交替的子行
+  const hasMoldNoCol = cols.mold_no >= 0;
+  const groups = [];
+  let current = null;
+  for (const { r, ri } of dataRows) {
+    const moldNo = hasMoldNoCol ? cell(r, 'mold_no') : '';
+    const isNew = !hasMoldNoCol || /^P?\w/.test(moldNo);
+
+    if (isNew || !current) {
+      if (current) groups.push(current);
+      current = { mold_no: moldNo, names: [], materials: [], colors: [], cavities: [], sets: null, weight: null, cycle: null, mold_material: '', mold_size: '', structures: [], price_rmb: null, mold_type: '', notes: [], rowStart: ri, rowEnd: ri };
+    }
+    current.rowEnd = ri;  // 该组覆盖到当前行
+    const name = cell(r, 'name');
+    if (name) current.names.push(name);
+    const mat = cell(r, 'material'); if (mat) current.materials.push(mat);
+    const colorVal = cell(r, 'color'); if (colorVal) current.colors.push(colorVal);
+    const cav = cell(r, 'cavity');   if (cav) current.cavities.push(cav);
+    const sets = parseNumber(cell(r, 'sets')); if (sets != null && current.sets == null) current.sets = sets;
+    const wt = parseNumber(cell(r, 'weight')); if (wt != null && current.weight == null) current.weight = wt;
+    const cyc = parseNumber(cell(r, 'cycle')); if (cyc != null && current.cycle == null) current.cycle = cyc;
+    const mm = cell(r, 'mold_material'); if (mm && !current.mold_material) current.mold_material = mm;
+    const ms = cell(r, 'mold_size'); if (ms && !current.mold_size) current.mold_size = ms;
+    const st = cell(r, 'structure'); if (st && st !== '无') current.structures.push(st);
+    const pr = parseNumber(cell(r, 'price_rmb')); if (pr != null && current.price_rmb == null) current.price_rmb = pr;
+    const mt = cell(r, 'mold_type'); if (mt && !current.mold_type) current.mold_type = mt;
+    const nt = cell(r, 'note'); if (nt) current.notes.push(nt);
+  }
+  if (current) groups.push(current);
+
+  const molds = groups.filter(g => g.names.length > 0 || g.mold_no).map(g => {
+    const firstCav = g.cavities[0] || '';
+    const allOne = g.cavities.length === g.names.length && g.cavities.length > 1 && g.cavities.every(c => /^1$/.test(c));
+    const cavity = allOne ? `${g.names.length}*1` : firstCav;
+    return {
+      mold_no: g.mold_no,
+      name: g.names.join('/') || g.mold_no,
+      mold_type: g.mold_type || (/细水口/.test(g.notes.join('')) ? '细水口'
+                              : /大水口|潜水/.test(g.notes.join('')) ? '大水口'
+                              : /三板/.test(g.notes.join('')) ? '三板模' : ''),
+      structure: g.structures.length ? (g.structures.length === g.names.length ? g.structures[0] : [...new Set(g.structures)].join(' / ')) : '',
+      material: [...new Set(g.materials)].join('/'),
+      color: [...new Set(g.colors)].join('/'),
+      cavity,
+      sets: g.sets ?? 1,
+      weight_g: g.weight,
+      cycle_sec: g.cycle,
+      price_rmb: g.price_rmb,
+      images: [],
+      detail: { mold_material: g.mold_material, mold_size: g.mold_size },
+      note: [...new Set(g.notes)].join('；'),
+      _rows: [g.rowStart, g.rowEnd],  // 0-based 原始行范围，供图片归属
+    };
+  });
+
+  return { sheets: wb.SheetNames, sheet_used: sheetName, header_row: hIdx + 1, cols_found: cols, molds };
+}
+
+module.exports = { parseWorkbook };

--- a/apps/业务部/内部报价系统/backend/services/parseSewingSheet.js
+++ b/apps/业务部/内部报价系统/backend/services/parseSewingSheet.js
@@ -1,0 +1,144 @@
+// 解析"车缝报价单"型 xlsx
+// 期望结构：每个产品分组顶部有一个标题行（一般是合并单元格 + 浅色填充），
+// 紧接着是表头行（物料名称 / 裁片部位 / 供应商 / ... / 用量 / 单价 / 成本 / 码点 / 价钱 / 备注），
+// 然后是若干物料行 + 人工行（裁床人工 / 车缝人工 / 手工人工），
+// 末行 "合计 ¥xx.xx"
+// 多个产品在同一工作表里堆叠。
+const ExcelJS = require('exceljs');
+
+const HEADER_KEYS = ['物料名称', '裁片部位', '用量', '单价', '价钱'];
+
+function toStr(v) {
+  if (v == null) return '';
+  if (typeof v === 'object' && 'richText' in v) {
+    return v.richText.map(t => t.text).join('');
+  }
+  if (typeof v === 'object' && 'text' in v) return String(v.text);
+  if (typeof v === 'object' && 'result' in v) return String(v.result);
+  return String(v).trim();
+}
+
+function toNum(v) {
+  if (v == null || v === '') return null;
+  if (typeof v === 'object' && 'result' in v) return Number(v.result) || null;
+  const n = Number(String(v).replace(/[^\d.\-]/g, ''));
+  return isNaN(n) ? null : n;
+}
+
+function isHeaderRow(values) {
+  const joined = values.map(toStr).join('|');
+  return HEADER_KEYS.every(k => joined.includes(k));
+}
+
+// 给一行的 header 单元格，建 colIndex 索引（1-based）
+function buildHeaderIndex(headerCells) {
+  const idx = {};
+  const setOnce = (key, i) => { if (idx[key] == null) idx[key] = i; };
+  headerCells.forEach((v, i) => {
+    const s = toStr(v);
+    if (!s) return;
+    // 只取第一次匹配，避免右侧"显示客人单价/用量/总价"等额外列覆盖
+    if (s.includes('物料名称')) setOnce('material', i);
+    else if (s.includes('裁片部位')) setOnce('part', i);
+    else if (s.includes('供应商')) setOnce('supplier', i);
+    else if (s.includes('用量')) setOnce('qty', i);
+    else if (s === '单价' || s.includes('单价')) setOnce('unit_price', i);
+    else if (s.includes('成本')) setOnce('cost', i);
+    else if (s.includes('码点')) setOnce('markup', i);
+    else if (s.includes('价钱')) setOnce('price', i);
+    else if (s.includes('备注')) setOnce('note', i);
+  });
+  return idx;
+}
+
+async function parseWorkbook(buffer) {
+  const wb = new ExcelJS.Workbook();
+  await wb.xlsx.load(buffer);
+  const ws = wb.worksheets[0];
+  if (!ws) return { error: '工作簿为空' };
+
+  // 抓出每行 values（1-based 的数组）
+  const rows = [];
+  ws.eachRow({ includeEmpty: true }, (row, rn) => {
+    const arr = [];
+    row.eachCell({ includeEmpty: true }, (cell, cn) => { arr[cn] = cell.value; });
+    rows.push(arr);
+  });
+
+  const groups = [];
+  let cur = null;
+  let headerIdx = null;
+  let pendingTitle = null;
+
+  for (let i = 0; i < rows.length; i++) {
+    const r = rows[i] || [];
+    const joined = r.map(toStr).filter(Boolean);
+    if (!joined.length) { continue; }
+
+    // header 行 → 新分组开始
+    if (isHeaderRow(r)) {
+      headerIdx = buildHeaderIndex(r);
+      const name = pendingTitle || ('产品 ' + (groups.length + 1));
+      cur = { name, items: [], labor_amount: 0, sub_parts: [] };
+      groups.push(cur);
+      pendingTitle = null;
+      continue;
+    }
+
+    // 全行只有 1 个 cell + 不是 header → 视为下一分组的标题
+    if (joined.length <= 2 && !isHeaderRow(r) && !headerIdx) {
+      pendingTitle = joined.join(' ');
+      continue;
+    }
+
+    if (!cur || !headerIdx) continue;
+
+    const matName = toStr(r[headerIdx.material]);
+    const part = toStr(r[headerIdx.part]);
+    const price = toNum(r[headerIdx.price]);
+    const qty = toNum(r[headerIdx.qty]);
+    const unitPrice = toNum(r[headerIdx.unit_price]);
+
+    // 合计行
+    if (matName.includes('合计') || (part === '' && matName === '' && price != null && qty == null)) {
+      // 重置 header 等待下一个产品
+      headerIdx = null;
+      continue;
+    }
+
+    // 仅当行没有 价钱 和 用量 → 跳过
+    if (matName === '' && qty == null && price == null) continue;
+
+    // 人工类
+    if (/裁床人工|车缝人工|手工人工|人工/.test(matName)) {
+      cur.labor_amount = (cur.labor_amount || 0) + (price || 0);
+      cur.items.push({
+        material: matName, part: part || '',
+        qty: qty || 1, unit_price: unitPrice || price || 0,
+        markup: toNum(r[headerIdx.markup]) || 1,
+        price: price || 0,
+        note: toStr(r[headerIdx.note]),
+        is_labor: true,
+      });
+      continue;
+    }
+
+    cur.items.push({
+      material: matName,
+      part: part || '',
+      supplier: toStr(r[headerIdx.supplier]),
+      qty: qty || 0,
+      unit_price: unitPrice || 0,
+      cost: toNum(r[headerIdx.cost]) || 0,
+      markup: toNum(r[headerIdx.markup]) || 1,
+      price: price || 0,
+      note: toStr(r[headerIdx.note]),
+    });
+  }
+
+  if (!groups.length) return { error: '没有解析到任何产品分组（请确认表头含 物料名称/裁片部位/用量/单价/价钱）' };
+
+  return { groups, count: groups.length, sheet_used: ws.name };
+}
+
+module.exports = { parseWorkbook };

--- a/apps/业务部/内部报价系统/frontend/admin.html
+++ b/apps/业务部/内部报价系统/frontend/admin.html
@@ -126,6 +126,18 @@
     </div>
   </div>
 
+  <script>
+    // nginx 子路径部署适配：绝对 /api 请求自动加当前页面路径前缀（如 /internal-quote）；根路径部署无副作用
+    (function () {
+      var base = location.pathname.replace(/\/[^/]*$/, '');
+      if (!base) return;
+      var origFetch = window.fetch.bind(window);
+      window.fetch = function (url, opts) {
+        if (typeof url === 'string' && url.indexOf('/api/') === 0) url = base + url;
+        return origFetch(url, opts);
+      };
+    })();
+  </script>
   <script src="./admin.js"></script>
 </body>
 </html>

--- a/apps/业务部/内部报价系统/frontend/admin.html
+++ b/apps/业务部/内部报价系统/frontend/admin.html
@@ -1,0 +1,131 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>管理后台 · 账号管理</title>
+  <link rel="stylesheet" href="./styles.css" />
+</head>
+<body>
+  <div class="topbar">
+    <div class="brand">⚙️ 管理后台 <small>账号管理</small></div>
+    <div id="user-chip">
+      <span id="who-chip"></span>
+      <a href="./index.html">← 报价单</a>
+      <a href="#" id="btn-logout">登出</a>
+    </div>
+  </div>
+
+  <div id="app">
+    <section class="card">
+      <div class="list-head">
+        <h2 style="margin:0">用户账号</h2>
+        <button id="btn-new-user">＋ 注册新账号</button>
+      </div>
+
+      <div id="new-user-form" class="hidden" style="margin-top:14px;padding:14px;background:#fef9c3;border-radius:8px">
+        <div style="display:grid;grid-template-columns:repeat(5,1fr);gap:8px;align-items:end">
+          <label>用户名 <input id="nu-username" type="text" /></label>
+          <label>姓名 <input id="nu-display" type="text" maxlength="32" /></label>
+          <label>初始密码 <input id="nu-password" type="text" /></label>
+          <label>部门
+            <select id="nu-dept">
+              <option value="sales">业务</option>
+              <option value="engineering">工程</option>
+              <option value="electronic">电子部</option>
+              <option value="molding">啤机部</option>
+              <option value="painting">喷油部</option>
+              <option value="slush">搪胶</option>
+              <option value="sewing">车缝</option>
+              <option value="assembly">装配部</option>
+            </select>
+          </label>
+          <label>角色
+            <select id="nu-role">
+              <option value="staff">员工</option>
+              <option value="supervisor">主管</option>
+              <option value="admin">管理员</option>
+            </select>
+          </label>
+        </div>
+        <div style="margin-top:10px;display:flex;gap:8px">
+          <button id="btn-create-user">创建</button>
+          <button id="btn-cancel-user" class="mini">取消</button>
+          <span id="nu-msg" class="msg"></span>
+        </div>
+      </div>
+
+      <table class="wb-table" style="margin-top:14px">
+        <thead><tr>
+          <th style="width:50px">#</th>
+          <th style="width:120px">用户名</th>
+          <th style="width:120px">姓名</th>
+          <th style="width:100px">部门</th>
+          <th style="width:80px">角色</th>
+          <th style="width:100px">状态</th>
+          <th style="width:150px">上次登录</th>
+          <th>操作</th>
+        </tr></thead>
+        <tbody id="users-tbody"></tbody>
+      </table>
+    </section>
+  </div>
+
+  <!-- 权限矩阵编辑抽屉 -->
+  <div id="perm-overlay" class="hidden" style="position:fixed;inset:0;background:rgba(0,0,0,.3);z-index:99"></div>
+  <div id="perm-drawer" class="hidden" style="position:fixed;top:0;right:0;width:780px;max-width:95vw;height:100vh;background:#fff;box-shadow:-2px 0 12px rgba(0,0,0,.15);z-index:100;display:flex;flex-direction:column">
+    <div style="padding:14px 18px;border-bottom:1px solid #e7e5e4;display:flex;justify-content:space-between;align-items:center">
+      <h3 style="margin:0">编辑权限 — <span id="pd-user"></span></h3>
+      <div>
+        <button id="pd-reset-template" class="mini">按角色重置</button>
+        <button id="pd-close" class="mini">✕</button>
+      </div>
+    </div>
+    <div style="padding:14px 18px;overflow:auto;flex:1">
+      <table class="wb-table" id="perm-table" style="font-size:13px">
+        <thead><tr>
+          <th style="width:90px">分组</th>
+          <th style="width:180px">菜单</th>
+          <th style="width:80px;text-align:center">查看<br><a href="#" data-toggle-col="view" style="font-size:11px;font-weight:400">全选/清</a></th>
+          <th style="width:80px;text-align:center">编辑<br><a href="#" data-toggle-col="edit" style="font-size:11px;font-weight:400">全选/清</a></th>
+          <th style="width:80px;text-align:center">审核<br><a href="#" data-toggle-col="review" style="font-size:11px;font-weight:400">全选/清</a></th>
+          <th style="width:80px;text-align:center">管理<br><a href="#" data-toggle-col="admin" style="font-size:11px;font-weight:400">全选/清</a></th>
+        </tr></thead>
+        <tbody id="perm-tbody"></tbody>
+      </table>
+    </div>
+    <div style="padding:14px 18px;border-top:1px solid #e7e5e4;display:flex;gap:10px;justify-content:flex-end">
+      <span id="pd-msg" class="msg" style="margin-right:auto"></span>
+      <button id="pd-cancel" class="mini">取消</button>
+      <button id="pd-save">💾 保存</button>
+    </div>
+  </div>
+
+  <!-- 客户范围抽屉 -->
+  <div id="cust-overlay" class="hidden" style="position:fixed;inset:0;background:rgba(0,0,0,.3);z-index:99"></div>
+  <div id="cust-drawer" class="hidden" style="position:fixed;top:0;right:0;width:520px;max-width:95vw;height:100vh;background:#fff;box-shadow:-2px 0 12px rgba(0,0,0,.15);z-index:100;display:flex;flex-direction:column">
+    <div style="padding:14px 18px;border-bottom:1px solid #e7e5e4;display:flex;justify-content:space-between;align-items:center">
+      <h3 style="margin:0">客户范围 — <span id="cd-user"></span></h3>
+      <button id="cd-close" class="mini">✕</button>
+    </div>
+    <div style="padding:14px 18px;overflow:auto;flex:1">
+      <p class="muted" style="margin-top:0">勾选该账号能看到的客户。未勾选 = 看不到对应客户的报价单。</p>
+      <div id="cd-list" style="display:flex;flex-direction:column;gap:6px"></div>
+      <hr style="margin:14px 0">
+      <label style="font-size:13px">手动添加客户（即使该客户暂无报价单也可预先授权）
+        <div style="display:flex;gap:6px;margin-top:4px">
+          <input id="cd-new-cust" type="text" placeholder="客户名" style="flex:1" />
+          <button id="cd-add" class="mini">＋ 添加</button>
+        </div>
+      </label>
+    </div>
+    <div style="padding:14px 18px;border-top:1px solid #e7e5e4;display:flex;gap:10px;justify-content:flex-end">
+      <span id="cd-msg" class="msg" style="margin-right:auto"></span>
+      <button id="cd-cancel" class="mini">取消</button>
+      <button id="cd-save">💾 保存</button>
+    </div>
+  </div>
+
+  <script src="./admin.js"></script>
+</body>
+</html>

--- a/apps/业务部/内部报价系统/frontend/admin.js
+++ b/apps/业务部/内部报价系统/frontend/admin.js
@@ -1,0 +1,295 @@
+const $ = (id) => document.getElementById(id);
+
+async function api(path, opts = {}) {
+  const r = await fetch('/api' + path, {
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    ...opts,
+  });
+  if (!r.ok) throw new Error((await r.json().catch(() => ({}))).error || r.statusText);
+  return r.json();
+}
+
+const ROLE_ZH = { admin: '管理员', supervisor: '主管', staff: '员工' };
+
+async function init() {
+  let me;
+  try {
+    me = await api('/auth/me');
+  } catch {
+    location.href = './index.html';
+    return;
+  }
+  if (!me.perms || !me.perms['账号管理'] || !me.perms['账号管理'].can_admin) {
+    document.body.innerHTML = '<div style="padding:40px;text-align:center"><h2>无权访问</h2><a href="./index.html">← 返回</a></div>';
+    return;
+  }
+  $('who-chip').textContent = `${me.display_name || me.username} · 管理员`;
+  window.__me = me;
+  await loadUsers();
+}
+
+async function loadUsers() {
+  const rows = await api('/admin/users');
+  const tbody = $('users-tbody');
+  tbody.innerHTML = '';
+  for (const u of rows) {
+    const tr = document.createElement('tr');
+    const isLocked = !!u.is_locked;
+    const last = u.last_login ? new Date(u.last_login.includes('T') ? u.last_login : u.last_login.replace(' ', 'T') + 'Z').toLocaleString() : '—';
+    tr.innerHTML = `
+      <td>${u.id}</td>
+      <td><b>${u.username}</b></td>
+      <td>${u.display_name}</td>
+      <td>${u.dept_name || u.dept}</td>
+      <td>${ROLE_ZH[u.role] || u.role}</td>
+      <td>${isLocked ? '<span class="badge b-empty">已锁定</span>' : '<span class="badge b-approved">正常</span>'}</td>
+      <td class="ro" style="font-size:12px">${last}</td>
+      <td>
+        <button class="mini btn-perms" data-id="${u.id}" data-username="${u.username}">✏️ 权限</button>
+        <button class="mini btn-cust" data-id="${u.id}" data-username="${u.username}">🎯 客户范围</button>
+        <button class="mini btn-reset" data-id="${u.id}" data-username="${u.username}">重置密码</button>
+        ${isLocked
+          ? `<button class="mini btn-unlock" data-id="${u.id}">解锁</button>`
+          : `<button class="mini btn-lock" data-id="${u.id}" data-username="${u.username}">锁定</button>`}
+        <button class="mini danger btn-del" data-id="${u.id}" data-username="${u.username}">删除</button>
+      </td>`;
+    tbody.appendChild(tr);
+  }
+  // 绑定按钮
+  document.querySelectorAll('.btn-perms').forEach(b => b.onclick = () => openPerms(b.dataset.id, b.dataset.username));
+  document.querySelectorAll('.btn-cust').forEach(b => b.onclick = () => openCust(b.dataset.id, b.dataset.username));
+  document.querySelectorAll('.btn-reset').forEach(b => b.onclick = () => resetPwd(b.dataset.id, b.dataset.username));
+  document.querySelectorAll('.btn-lock').forEach(b => b.onclick = () => lockUser(b.dataset.id, b.dataset.username));
+  document.querySelectorAll('.btn-unlock').forEach(b => b.onclick = () => unlockUser(b.dataset.id));
+  document.querySelectorAll('.btn-del').forEach(b => b.onclick = () => delUser(b.dataset.id, b.dataset.username));
+}
+
+// ============== 权限矩阵抽屉 ==============
+let __permState = { userId: null, username: null, perms: [] };
+
+async function openPerms(id, username) {
+  __permState.userId = +id;
+  __permState.username = username;
+  $('pd-user').textContent = username;
+  $('pd-msg').textContent = '';
+  try {
+    const r = await api('/admin/users/' + id + '/perms');
+    __permState.perms = r.perms;
+    renderPermMatrix();
+    $('perm-overlay').classList.remove('hidden');
+    $('perm-drawer').classList.remove('hidden');
+  } catch (e) { alert(e.message); }
+}
+
+function closePerms() {
+  $('perm-overlay').classList.add('hidden');
+  $('perm-drawer').classList.add('hidden');
+}
+
+function renderPermMatrix() {
+  const tbody = $('perm-tbody');
+  tbody.innerHTML = '';
+  let lastGroup = null;
+  __permState.perms.forEach((p, i) => {
+    const tr = document.createElement('tr');
+    const groupCell = (p.group !== lastGroup) ? `<td rowspan="1" style="background:#fef9c3;font-weight:600;vertical-align:top">${p.group}</td>` : `<td></td>`;
+    lastGroup = p.group;
+    tr.innerHTML = `
+      ${groupCell}
+      <td>${p.menu}</td>
+      <td style="text-align:center"><input type="checkbox" data-i="${i}" data-k="can_view"   ${p.can_view?'checked':''}/></td>
+      <td style="text-align:center"><input type="checkbox" data-i="${i}" data-k="can_edit"   ${p.can_edit?'checked':''}/></td>
+      <td style="text-align:center"><input type="checkbox" data-i="${i}" data-k="can_review" ${p.can_review?'checked':''}/></td>
+      <td style="text-align:center"><input type="checkbox" data-i="${i}" data-k="can_admin"  ${p.can_admin?'checked':''}/></td>`;
+    tbody.appendChild(tr);
+  });
+  // 绑定 checkbox 改动
+  tbody.querySelectorAll('input[type="checkbox"]').forEach(cb => {
+    cb.onchange = () => {
+      const i = +cb.dataset.i, k = cb.dataset.k;
+      __permState.perms[i][k] = cb.checked ? 1 : 0;
+    };
+  });
+}
+
+$('pd-close').onclick = closePerms;
+$('pd-cancel').onclick = closePerms;
+$('perm-overlay').onclick = closePerms;
+
+document.querySelectorAll('[data-toggle-col]').forEach(a => {
+  a.onclick = (e) => {
+    e.preventDefault();
+    const col = a.dataset.toggleCol;
+    const key = 'can_' + col;
+    // 看当前是否全选 → 切换
+    const allOn = __permState.perms.every(p => p[key]);
+    __permState.perms.forEach(p => p[key] = allOn ? 0 : 1);
+    renderPermMatrix();
+  };
+});
+
+$('pd-reset-template').onclick = async () => {
+  if (!confirm('按当前角色模板重置该用户权限（手动改动会被覆盖）？')) return;
+  try {
+    await api('/admin/users/' + __permState.userId + '/apply-template', { method: 'POST' });
+    const r = await api('/admin/users/' + __permState.userId + '/perms');
+    __permState.perms = r.perms;
+    renderPermMatrix();
+    $('pd-msg').style.color = 'green';
+    $('pd-msg').textContent = '✓ 已重置';
+    setTimeout(() => { $('pd-msg').textContent = ''; $('pd-msg').style.color = ''; }, 1500);
+  } catch (e) { $('pd-msg').style.color = ''; $('pd-msg').textContent = e.message; }
+};
+
+$('pd-save').onclick = async () => {
+  $('pd-msg').textContent = '';
+  try {
+    await api('/admin/users/' + __permState.userId + '/perms', {
+      method: 'PUT',
+      body: JSON.stringify({ perms: __permState.perms }),
+    });
+    $('pd-msg').style.color = 'green';
+    $('pd-msg').textContent = '✓ 已保存';
+    setTimeout(closePerms, 800);
+  } catch (e) { $('pd-msg').style.color = ''; $('pd-msg').textContent = e.message; }
+};
+
+async function resetPwd(id, username) {
+  const pwd = prompt(`重置 ${username} 的密码（≥6 位）:`);
+  if (!pwd) return;
+  if (pwd.length < 6) return alert('密码至少 6 位');
+  try {
+    await api('/admin/users/' + id + '/reset-password', { method: 'POST', body: JSON.stringify({ password: pwd }) });
+    alert('✓ 重置成功');
+  } catch (e) { alert(e.message); }
+}
+
+async function lockUser(id, username) {
+  if (!confirm(`锁定 ${username}？锁定后无法登录。`)) return;
+  try { await api('/admin/users/' + id + '/lock', { method: 'POST' }); await loadUsers(); }
+  catch (e) { alert(e.message); }
+}
+async function unlockUser(id) {
+  try { await api('/admin/users/' + id + '/unlock', { method: 'POST' }); await loadUsers(); }
+  catch (e) { alert(e.message); }
+}
+async function delUser(id, username) {
+  if (!confirm(`删除 ${username}？此操作不可恢复，相关审计日志保留。`)) return;
+  try { await api('/admin/users/' + id, { method: 'DELETE' }); await loadUsers(); }
+  catch (e) { alert(e.message); }
+}
+
+$('btn-new-user').onclick = () => {
+  $('new-user-form').classList.remove('hidden');
+  $('nu-username').focus();
+};
+$('btn-cancel-user').onclick = () => $('new-user-form').classList.add('hidden');
+$('btn-create-user').onclick = async () => {
+  $('nu-msg').textContent = '';
+  const body = {
+    username: $('nu-username').value.trim(),
+    password: $('nu-password').value,
+    display_name: $('nu-display').value.trim(),
+    dept: $('nu-dept').value,
+    role: $('nu-role').value,
+  };
+  if (!body.username || !body.password || !body.display_name) {
+    $('nu-msg').textContent = '用户名/密码/姓名 必填';
+    return;
+  }
+  try {
+    await api('/admin/users', { method: 'POST', body: JSON.stringify(body) });
+    $('nu-msg').style.color = 'green';
+    $('nu-msg').textContent = '✓ 创建成功';
+    ['nu-username', 'nu-password', 'nu-display'].forEach(id => $(id).value = '');
+    await loadUsers();
+    setTimeout(() => { $('new-user-form').classList.add('hidden'); $('nu-msg').style.color = ''; $('nu-msg').textContent = ''; }, 1200);
+  } catch (e) { $('nu-msg').style.color = ''; $('nu-msg').textContent = e.message; }
+};
+
+$('btn-logout').onclick = async (e) => {
+  e.preventDefault();
+  await api('/auth/logout', { method: 'POST' });
+  location.href = './index.html';
+};
+
+// ============== 客户范围抽屉 ==============
+let __custState = { userId: null, username: null, all: [], selected: new Set() };
+
+async function openCust(id, username) {
+  __custState.userId = +id;
+  __custState.username = username;
+  $('cd-user').textContent = username;
+  $('cd-msg').textContent = '';
+  $('cd-new-cust').value = '';
+  try {
+    const [allRes, myRes] = await Promise.all([
+      api('/admin/customers'),
+      api('/admin/users/' + id + '/customers'),
+    ]);
+    const all = allRes.customers || [];
+    const mine = new Set(myRes.customers || []);
+    // 把已勾选但未在 all 里的（手动加的）也合进列表
+    for (const c of mine) if (!all.includes(c)) all.push(c);
+    all.sort();
+    __custState.all = all;
+    __custState.selected = mine;
+    renderCustList();
+    $('cust-overlay').classList.remove('hidden');
+    $('cust-drawer').classList.remove('hidden');
+  } catch (e) { alert(e.message); }
+}
+
+function closeCust() {
+  $('cust-overlay').classList.add('hidden');
+  $('cust-drawer').classList.add('hidden');
+}
+
+function renderCustList() {
+  const list = $('cd-list');
+  list.innerHTML = '';
+  if (!__custState.all.length) {
+    list.innerHTML = '<p class="muted">暂无客户，请下方手动添加</p>';
+    return;
+  }
+  for (const c of __custState.all) {
+    const checked = __custState.selected.has(c) ? 'checked' : '';
+    const div = document.createElement('div');
+    div.innerHTML = `<label><input type="checkbox" data-cust="${c.replace(/"/g, '&quot;')}" ${checked}/> ${c}</label>`;
+    div.querySelector('input').onchange = (e) => {
+      if (e.target.checked) __custState.selected.add(c);
+      else __custState.selected.delete(c);
+    };
+    list.appendChild(div);
+  }
+}
+
+$('cd-close').onclick = closeCust;
+$('cd-cancel').onclick = closeCust;
+$('cust-overlay').onclick = closeCust;
+
+$('cd-add').onclick = () => {
+  const c = $('cd-new-cust').value.trim();
+  if (!c) return;
+  if (!__custState.all.includes(c)) __custState.all.push(c);
+  __custState.selected.add(c);
+  __custState.all.sort();
+  $('cd-new-cust').value = '';
+  renderCustList();
+};
+
+$('cd-save').onclick = async () => {
+  $('cd-msg').textContent = '';
+  try {
+    await api('/admin/users/' + __custState.userId + '/customers', {
+      method: 'PUT',
+      body: JSON.stringify({ customers: [...__custState.selected] }),
+    });
+    $('cd-msg').style.color = 'green';
+    $('cd-msg').textContent = '✓ 已保存';
+    setTimeout(closeCust, 800);
+  } catch (e) { $('cd-msg').style.color = ''; $('cd-msg').textContent = e.message; }
+};
+
+init();

--- a/apps/业务部/内部报价系统/frontend/admin.js
+++ b/apps/业务部/内部报价系统/frontend/admin.js
@@ -12,6 +12,11 @@ async function api(path, opts = {}) {
 
 const ROLE_ZH = { admin: '管理员', supervisor: '主管', staff: '员工' };
 
+// HTML 转义：用户可控字段(用户名/姓名/客户名)插入 innerHTML 前必须过它，防 XSS
+function esc(s) {
+  return String(s ?? '').replace(/[&<>"']/g, c => ({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' }[c]));
+}
+
 async function init() {
   let me;
   try {
@@ -39,20 +44,20 @@ async function loadUsers() {
     const last = u.last_login ? new Date(u.last_login.includes('T') ? u.last_login : u.last_login.replace(' ', 'T') + 'Z').toLocaleString() : '—';
     tr.innerHTML = `
       <td>${u.id}</td>
-      <td><b>${u.username}</b></td>
-      <td>${u.display_name}</td>
-      <td>${u.dept_name || u.dept}</td>
+      <td><b>${esc(u.username)}</b></td>
+      <td>${esc(u.display_name)}</td>
+      <td>${esc(u.dept_name || u.dept)}</td>
       <td>${ROLE_ZH[u.role] || u.role}</td>
       <td>${isLocked ? '<span class="badge b-empty">已锁定</span>' : '<span class="badge b-approved">正常</span>'}</td>
       <td class="ro" style="font-size:12px">${last}</td>
       <td>
-        <button class="mini btn-perms" data-id="${u.id}" data-username="${u.username}">✏️ 权限</button>
-        <button class="mini btn-cust" data-id="${u.id}" data-username="${u.username}">🎯 客户范围</button>
-        <button class="mini btn-reset" data-id="${u.id}" data-username="${u.username}">重置密码</button>
+        <button class="mini btn-perms" data-id="${u.id}" data-username="${esc(u.username)}">✏️ 权限</button>
+        <button class="mini btn-cust" data-id="${u.id}" data-username="${esc(u.username)}">🎯 客户范围</button>
+        <button class="mini btn-reset" data-id="${u.id}" data-username="${esc(u.username)}">重置密码</button>
         ${isLocked
           ? `<button class="mini btn-unlock" data-id="${u.id}">解锁</button>`
-          : `<button class="mini btn-lock" data-id="${u.id}" data-username="${u.username}">锁定</button>`}
-        <button class="mini danger btn-del" data-id="${u.id}" data-username="${u.username}">删除</button>
+          : `<button class="mini btn-lock" data-id="${u.id}" data-username="${esc(u.username)}">锁定</button>`}
+        <button class="mini danger btn-del" data-id="${u.id}" data-username="${esc(u.username)}">删除</button>
       </td>`;
     tbody.appendChild(tr);
   }
@@ -256,7 +261,7 @@ function renderCustList() {
   for (const c of __custState.all) {
     const checked = __custState.selected.has(c) ? 'checked' : '';
     const div = document.createElement('div');
-    div.innerHTML = `<label><input type="checkbox" data-cust="${c.replace(/"/g, '&quot;')}" ${checked}/> ${c}</label>`;
+    div.innerHTML = `<label><input type="checkbox" data-cust="${esc(c)}" ${checked}/> ${esc(c)}</label>`;
     div.querySelector('input').onchange = (e) => {
       if (e.target.checked) __custState.selected.add(c);
       else __custState.selected.delete(c);

--- a/apps/业务部/内部报价系统/frontend/index.html
+++ b/apps/业务部/内部报价系统/frontend/index.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>公司内部报价明细系统</title>
+  <link rel="stylesheet" href="./styles.css" />
+</head>
+<body>
+  <div class="topbar">
+    <div class="brand">📋 内部报价明细系统 <small>多部门协同 · 主管审核 · 受控导出</small></div>
+    <div id="user-chip" class="hidden">
+      <span id="who-chip"></span>
+      <a href="#" id="btn-change-pwd">修改密码</a>
+      <a href="./admin.html" id="btn-admin" class="hidden">⚙️ 管理后台</a>
+      <a href="#" id="btn-logout">登出</a>
+    </div>
+  </div>
+
+  <div id="app">
+
+    <section id="login-card" class="card login-card">
+      <h2>欢迎登录</h2>
+      <p class="muted" style="margin-top:-6px">请输入用户名和密码</p>
+      <label>用户名 <input id="username" type="text" autocomplete="username" placeholder="如 admin" /></label>
+      <label>密码 <input id="password" type="password" autocomplete="current-password" /></label>
+      <button id="btn-login" style="margin-top:6px;width:100%">登 录</button>
+      <p id="login-msg" class="msg"></p>
+    </section>
+
+    <section id="main-card" class="hidden">
+      <div id="pwd-card" class="card hidden">
+        <h3>修改密码</h3>
+        <label>当前密码 <input id="pwd-current" type="password" autocomplete="current-password" /></label>
+        <label>新密码（≥6 位）<input id="pwd-new" type="password" autocomplete="new-password" /></label>
+        <label>确认新密码 <input id="pwd-new2" type="password" autocomplete="new-password" /></label>
+        <div style="margin-top:10px;display:flex;gap:8px">
+          <button id="btn-pwd-submit">确认</button>
+          <button id="btn-pwd-cancel" class="mini">取消</button>
+        </div>
+        <p id="pwd-msg" class="msg"></p>
+      </div>
+
+      <div class="card">
+        <div class="list-head">
+          <h2 style="margin:0">报价单列表</h2>
+          <div style="display:flex;gap:10px;align-items:center;flex-wrap:wrap">
+            <div class="search-box">
+              <input id="search-input" type="text" placeholder="🔍 搜索 货号 / 产品 / 客户…" />
+              <small id="search-count" class="muted"></small>
+            </div>
+            <div id="new-quote-form" class="hidden new-quote-form">
+              <input id="q-no" placeholder="货号" />
+              <input id="q-product" placeholder="产品名" />
+              <input id="q-version" placeholder="版本(可选)" />
+              <input id="q-customer" placeholder="客户" />
+              <input id="q-qty" placeholder="数量" type="number" />
+              <button id="btn-create">＋ 新建报价单</button>
+            </div>
+          </div>
+        </div>
+        <table id="quotes-table" class="wb-table" style="margin-top:14px">
+          <thead><tr>
+            <th style="width:50px">#</th>
+            <th style="width:140px">货号</th>
+            <th>产品</th>
+            <th style="width:120px">版本</th>
+            <th style="width:140px">客户</th>
+            <th style="width:90px">进度</th>
+            <th style="width:100px">状态</th>
+            <th style="width:140px">创建时间</th>
+            <th style="width:80px"></th>
+          </tr></thead>
+          <tbody></tbody>
+        </table>
+      </div>
+    </section>
+  </div>
+  <script src="./main.js"></script>
+</body>
+</html>

--- a/apps/业务部/内部报价系统/frontend/index.html
+++ b/apps/业务部/内部报价系统/frontend/index.html
@@ -76,6 +76,18 @@
       </div>
     </section>
   </div>
+  <script>
+    // nginx 子路径部署适配：绝对 /api 请求自动加当前页面路径前缀（如 /internal-quote）；根路径部署无副作用
+    (function () {
+      var base = location.pathname.replace(/\/[^/]*$/, '');
+      if (!base) return;
+      var origFetch = window.fetch.bind(window);
+      window.fetch = function (url, opts) {
+        if (typeof url === 'string' && url.indexOf('/api/') === 0) url = base + url;
+        return origFetch(url, opts);
+      };
+    })();
+  </script>
   <script src="./main.js"></script>
 </body>
 </html>

--- a/apps/业务部/内部报价系统/frontend/main.js
+++ b/apps/业务部/内部报价系统/frontend/main.js
@@ -11,6 +11,11 @@ async function api(path, opts = {}) {
   return r.json();
 }
 
+// HTML 转义：用户可控字段(货号/产品名/客户/版本)插入 innerHTML 前必须过它，防存储型 XSS
+function esc(s) {
+  return String(s ?? '').replace(/[&<>"']/g, c => ({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' }[c]));
+}
+
 // 权限检查工具
 function hasPerm(me, menu, action) {
   if (!me || !me.perms) return false;
@@ -88,14 +93,14 @@ function renderQuotes() {
     const total = q.total_depts || 7;
     const pct = Math.round((q.approved_count / total) * 100);
     const nVer = prodCount[String(q.product_name || '').trim()] || 1;
-    const verCell = `${q.version ? `<span class="badge b-filled">${q.version}</span>` : '<span class="muted">—</span>'}`
+    const verCell = `${q.version ? `<span class="badge b-filled">${esc(q.version)}</span>` : '<span class="muted">—</span>'}`
       + (nVer > 1 ? ` <small class="muted" title="该产品共有 ${nVer} 个报价版本">·同产品${nVer}版</small>` : '');
     tr.innerHTML = `
       <td class="ro">${q.id}</td>
-      <td><b>${q.quote_no}</b></td>
-      <td>${q.product_name}</td>
+      <td><b>${esc(q.quote_no)}</b></td>
+      <td>${esc(q.product_name)}</td>
       <td>${verCell}</td>
-      <td>${q.customer || '<span class="muted">—</span>'}</td>
+      <td>${q.customer ? esc(q.customer) : '<span class="muted">—</span>'}</td>
       <td>
         <div class="progress"><div class="progress-bar" style="width:${pct}%"></div></div>
         <small class="muted">${q.approved_count} / ${total}</small>
@@ -104,7 +109,7 @@ function renderQuotes() {
       <td class="ro" style="font-family:ui-monospace,monospace;font-size:12px">${fmtTime(q.created_at)}</td>
       <td style="display:flex;gap:6px">
         <a href="./quote.html?id=${q.id}" class="open-btn">打开 →</a>
-        ${window.__me && window.__me.dept === 'sales' ? `<button class="mini btn-clone" data-id="${q.id}" data-no="${q.quote_no}" data-name="${q.product_name}">📋 复制</button>` : ''}
+        ${window.__me && window.__me.dept === 'sales' ? `<button class="mini btn-clone" data-id="${q.id}" data-no="${esc(q.quote_no)}" data-name="${esc(q.product_name)}">📋 复制</button>` : ''}
       </td>
     `;
     tbody.appendChild(tr);

--- a/apps/业务部/内部报价系统/frontend/main.js
+++ b/apps/业务部/内部报价系统/frontend/main.js
@@ -1,0 +1,200 @@
+// 报价单列表 + 登录入口
+const $ = (id) => document.getElementById(id);
+
+async function api(path, opts = {}) {
+  const r = await fetch('/api' + path, {
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    ...opts,
+  });
+  if (!r.ok) throw new Error((await r.json().catch(() => ({}))).error || r.statusText);
+  return r.json();
+}
+
+// 权限检查工具
+function hasPerm(me, menu, action) {
+  if (!me || !me.perms) return false;
+  const p = me.perms[menu];
+  return !!(p && p['can_' + action]);
+}
+
+async function refreshMe() {
+  try {
+    const me = await api('/auth/me');
+    $('login-card').classList.add('hidden');
+    $('main-card').classList.remove('hidden');
+    $('user-chip').classList.remove('hidden');
+    const roleZh = { admin: '管理员', supervisor: '主管', staff: '员工' }[me.role] || me.role;
+    $('who-chip').textContent = `${me.dept_name} · ${roleZh} · ${me.display_name || me.username}`;
+    // 新建报价：业务 dept 才显示
+    if (hasPerm(me, '报价单列表', 'edit') && me.dept === 'sales') $('new-quote-form').classList.remove('hidden');
+    else $('new-quote-form').classList.add('hidden');
+    // 管理后台入口
+    if (hasPerm(me, '账号管理', 'admin')) $('btn-admin').classList.remove('hidden');
+    else $('btn-admin').classList.add('hidden');
+    window.__me = me;
+    await loadQuotes();
+  } catch {
+    $('login-card').classList.remove('hidden');
+    $('main-card').classList.add('hidden');
+    $('user-chip').classList.add('hidden');
+  }
+}
+
+function fmtTime(s) {
+  if (!s) return '';
+  const d = new Date(s.includes('T') ? s : s.replace(' ', 'T') + 'Z');
+  if (isNaN(d.getTime())) return s;
+  const p = (n) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())} ${p(d.getHours())}:${p(d.getMinutes())}`;
+}
+
+window.__allQuotes = [];
+async function loadQuotes() {
+  try {
+    window.__allQuotes = await api('/quotes');
+  } catch (e) {
+    window.__allQuotes = [];
+    const tbody = $('quotes-table').querySelector('tbody');
+    tbody.innerHTML = `<tr><td colspan="9" style="text-align:center;padding:40px;color:#b91c1c">${e.message}</td></tr>`;
+    if ($('search-count')) $('search-count').textContent = '';
+    return;
+  }
+  renderQuotes();
+}
+
+function renderQuotes() {
+  const tbody = $('quotes-table').querySelector('tbody');
+  tbody.innerHTML = '';
+  const q = ($('search-input')?.value || '').trim().toLowerCase();
+  const rows = q
+    ? window.__allQuotes.filter(r =>
+        String(r.quote_no || '').toLowerCase().includes(q) ||
+        String(r.product_name || '').toLowerCase().includes(q) ||
+        String(r.customer || '').toLowerCase().includes(q))
+    : window.__allQuotes;
+  if ($('search-count')) $('search-count').textContent = q ? `匹配 ${rows.length} / ${window.__allQuotes.length}` : `共 ${window.__allQuotes.length} 条`;
+  if (rows.length === 0) {
+    tbody.innerHTML = `<tr><td colspan="9" class="ro" style="text-align:center;padding:30px;color:#9ca3af">暂无报价单</td></tr>`;
+    return;
+  }
+  const STATUS_LABEL = { drafting: '草拟中', fully_approved: '全部已审', exported: '已导出' };
+  const STATUS_CLS = { drafting: 'b-filled', fully_approved: 'b-approved', exported: 'b-empty' };
+  // 同产品(按产品名)版本数：>1 时在版本列加提示徽标
+  const prodCount = {};
+  for (const r of window.__allQuotes) { const k = String(r.product_name || '').trim(); if (k) prodCount[k] = (prodCount[k] || 0) + 1; }
+  for (const q of rows) {
+    const tr = document.createElement('tr');
+    const total = q.total_depts || 7;
+    const pct = Math.round((q.approved_count / total) * 100);
+    const nVer = prodCount[String(q.product_name || '').trim()] || 1;
+    const verCell = `${q.version ? `<span class="badge b-filled">${q.version}</span>` : '<span class="muted">—</span>'}`
+      + (nVer > 1 ? ` <small class="muted" title="该产品共有 ${nVer} 个报价版本">·同产品${nVer}版</small>` : '');
+    tr.innerHTML = `
+      <td class="ro">${q.id}</td>
+      <td><b>${q.quote_no}</b></td>
+      <td>${q.product_name}</td>
+      <td>${verCell}</td>
+      <td>${q.customer || '<span class="muted">—</span>'}</td>
+      <td>
+        <div class="progress"><div class="progress-bar" style="width:${pct}%"></div></div>
+        <small class="muted">${q.approved_count} / ${total}</small>
+      </td>
+      <td><span class="badge ${STATUS_CLS[q.status] || 'b-empty'}">${STATUS_LABEL[q.status] || q.status}</span></td>
+      <td class="ro" style="font-family:ui-monospace,monospace;font-size:12px">${fmtTime(q.created_at)}</td>
+      <td style="display:flex;gap:6px">
+        <a href="./quote.html?id=${q.id}" class="open-btn">打开 →</a>
+        ${window.__me && window.__me.dept === 'sales' ? `<button class="mini btn-clone" data-id="${q.id}" data-no="${q.quote_no}" data-name="${q.product_name}">📋 复制</button>` : ''}
+      </td>
+    `;
+    tbody.appendChild(tr);
+  }
+  document.querySelectorAll('.btn-clone').forEach(b => b.onclick = () => cloneQuote(b.dataset.id, b.dataset.no, b.dataset.name));
+}
+
+async function cloneQuote(srcId, srcNo, srcName) {
+  const newNo = prompt(`复制 #${srcNo} (${srcName})\n\n请输入新报价单号：`, srcNo + '-copy');
+  if (!newNo) return;
+  const ver = prompt(`版本标签（标注这是同一产品的哪个版本，可留空）：`, '');
+  try {
+    const r = await api('/quotes/' + srcId + '/clone', {
+      method: 'POST',
+      body: JSON.stringify({ quote_no: newNo.trim(), version: ver != null ? ver.trim() : undefined }),
+    });
+    if (confirm(`✓ 复制成功，新报价单 #${r.id} 已建好。\n\n是否立即打开？`)) {
+      location.href = './quote.html?id=' + r.id;
+    } else {
+      await loadQuotes();
+    }
+  } catch (e) { alert(e.message); }
+}
+
+$('btn-login').onclick = async () => {
+  $('login-msg').textContent = '';
+  const username = $('username').value.trim();
+  const password = $('password').value;
+  if (!username) { $('login-msg').textContent = '请输入用户名'; $('username').focus(); return; }
+  if (!password) { $('login-msg').textContent = '请输入密码'; $('password').focus(); return; }
+  try {
+    await api('/auth/login', {
+      method: 'POST',
+      body: JSON.stringify({ username, password }),
+    });
+    $('password').value = '';
+    await refreshMe();
+  } catch (e) { $('login-msg').textContent = e.message; }
+};
+
+['username', 'password'].forEach(id => {
+  $(id).onkeydown = (e) => { if (e.key === 'Enter') $('btn-login').click(); };
+});
+
+$('btn-logout').onclick = async (e) => {
+  e.preventDefault();
+  await api('/auth/logout', { method: 'POST' });
+  await refreshMe();
+};
+
+if ($('btn-create')) $('btn-create').onclick = async () => {
+  try {
+    await api('/quotes', {
+      method: 'POST',
+      body: JSON.stringify({
+        quote_no: $('q-no').value.trim(),
+        product_name: $('q-product').value.trim(),
+        version: $('q-version').value.trim() || null,
+        customer: $('q-customer').value.trim(),
+        qty: Number($('q-qty').value) || null,
+      }),
+    });
+    $('q-no').value = $('q-product').value = $('q-version').value = $('q-customer').value = $('q-qty').value = '';
+    await loadQuotes();
+  } catch (e) { alert(e.message); }
+};
+
+// --- 修改密码 ---
+$('btn-change-pwd').onclick = (e) => {
+  e.preventDefault();
+  $('pwd-msg').textContent = '';
+  $('pwd-current').value = $('pwd-new').value = $('pwd-new2').value = '';
+  $('pwd-card').classList.remove('hidden');
+};
+$('btn-pwd-cancel').onclick = () => $('pwd-card').classList.add('hidden');
+$('btn-pwd-submit').onclick = async () => {
+  const cur = $('pwd-current').value, n1 = $('pwd-new').value, n2 = $('pwd-new2').value;
+  if (n1 !== n2) { $('pwd-msg').textContent = '两次输入的新密码不一致'; return; }
+  if (n1.length < 6) { $('pwd-msg').textContent = '新密码至少 6 位'; return; }
+  try {
+    await api('/auth/change-password', {
+      method: 'POST',
+      body: JSON.stringify({ current: cur, new: n1 }),
+    });
+    $('pwd-msg').style.color = 'green';
+    $('pwd-msg').textContent = '✓ 修改成功';
+    setTimeout(() => { $('pwd-card').classList.add('hidden'); $('pwd-msg').style.color = ''; }, 1200);
+  } catch (e) { $('pwd-msg').style.color = ''; $('pwd-msg').textContent = e.message; }
+};
+
+if ($('search-input')) $('search-input').oninput = () => renderQuotes();
+
+refreshMe();

--- a/apps/业务部/内部报价系统/frontend/palette-preview.html
+++ b/apps/业务部/内部报价系统/frontend/palette-preview.html
@@ -1,0 +1,134 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<title>导出表格 — 米黄系配色预览</title>
+<style>
+  body { font-family: 'Microsoft YaHei', system-ui, sans-serif; background:#fafaf7; padding:30px; margin:0; color:#3f3f3a }
+  h1 { font-size:22px; margin:0 0 6px }
+  .sub { color:#92928a; margin:0 0 30px }
+  .grid { display:grid; grid-template-columns:repeat(2,1fr); gap:30px; max-width:1500px }
+  .palette { background:#fff; border-radius:12px; box-shadow:0 1px 3px rgba(0,0,0,.08); overflow:hidden }
+  .pname { padding:14px 18px; font-weight:600; font-size:16px; display:flex; justify-content:space-between; align-items:center; border-bottom:1px solid #ede9d9 }
+  .pname small { font-weight:400; color:#92928a }
+  table { width:100%; border-collapse:collapse; font-size:13px }
+  th, td { padding:8px 10px; border:1px solid var(--border); text-align:center }
+  .title { background:#fff; font-weight:700; font-size:15px; padding:14px; border:none; text-align:center }
+  .sec { font-weight:700; font-size:14px; text-align:left; padding:10px 14px }
+  .hdr { font-weight:700 }
+  .sub-row { font-weight:600 }
+  .total-row { font-weight:700 }
+  .loss-row { font-size:12px }
+  .meta { padding:10px 16px; font-size:12px; color:#92928a; background:#fafaf7; display:flex; gap:14px; flex-wrap:wrap }
+  .swatch { display:inline-flex; align-items:center; gap:6px }
+  .chip { width:16px; height:16px; border-radius:3px; border:1px solid #d4d0bc }
+  button.pick { background:#a16207; color:#fff; border:0; padding:6px 14px; border-radius:6px; cursor:pointer; font-size:13px }
+  button.pick:hover { background:#854d0e }
+  .pick-row { padding:12px 18px; border-top:1px solid #ede9d9; display:flex; justify-content:flex-end; gap:8px; background:#fefdf8 }
+</style>
+</head>
+<body>
+<h1>🌾 导出表格 — 米黄系 4 套（清爽淡雅，中等饱和）</h1>
+<p class="sub">偏米色 / 黄色系。看好告诉我编号。</p>
+
+<div class="grid">
+
+  <!-- 1 香槟金 -->
+  <div class="palette" style="--border:#F5EBC7">
+    <div class="pname">1. 香槟金 <small>米黄 + 淡金</small></div>
+    <table>
+      <tr><td class="title" colspan="4">47765A 车盖 内部报价明细</td></tr>
+      <tr class="sec" style="background:#FEF3C7; color:#78350F"><td colspan="4">一、模具部分</td></tr>
+      <tr class="hdr" style="background:#FCD34D; color:#78350F">
+        <th>模号</th><th>名称</th><th>材质</th><th>模具价格</th></tr>
+      <tr><td>P01</td><td>头盔/尾辨</td><td>PVC</td><td>¥33,000.00</td></tr>
+      <tr><td>P02</td><td>面部/尾翼</td><td>ABS</td><td>¥33,500.00</td></tr>
+      <tr class="sub-row" style="background:#FFFBEB; color:#92400E"><td colspan="3" style="text-align:right">小计 RMB</td><td>¥256,000.00</td></tr>
+      <tr class="loss-row" style="background:#FEFCE8; color:#A16207"><td colspan="3" style="text-align:right">损耗</td><td>1.00%</td></tr>
+      <tr class="total-row" style="background:#FDE68A; color:#713F12"><td colspan="3" style="text-align:right">合计 HKD</td><td>HK$ 301,176.47</td></tr>
+    </table>
+    <div class="meta">
+      <span class="swatch"><span class="chip" style="background:#FEF3C7"></span>章节</span>
+      <span class="swatch"><span class="chip" style="background:#FCD34D"></span>列头</span>
+      <span class="swatch"><span class="chip" style="background:#FFFBEB"></span>小计</span>
+      <span class="swatch"><span class="chip" style="background:#FDE68A"></span>合计</span>
+    </div>
+    <div class="pick-row"><button class="pick" onclick="pick(1)">选 1 号</button></div>
+  </div>
+
+  <!-- 2 麦穗暖黄 -->
+  <div class="palette" style="--border:#F0E4C1">
+    <div class="pname">2. 麦穗暖黄 <small>带土黄 · 温润</small></div>
+    <table>
+      <tr><td class="title" colspan="4">47765A 车盖 内部报价明细</td></tr>
+      <tr class="sec" style="background:#FDE68A; color:#713F12"><td colspan="4">一、模具部分</td></tr>
+      <tr class="hdr" style="background:#EAB308; color:#FFFFFF">
+        <th>模号</th><th>名称</th><th>材质</th><th>模具价格</th></tr>
+      <tr><td>P01</td><td>头盔/尾辨</td><td>PVC</td><td>¥33,000.00</td></tr>
+      <tr><td>P02</td><td>面部/尾翼</td><td>ABS</td><td>¥33,500.00</td></tr>
+      <tr class="sub-row" style="background:#FEFCE8; color:#854D0E"><td colspan="3" style="text-align:right">小计 RMB</td><td>¥256,000.00</td></tr>
+      <tr class="loss-row" style="background:#FAF7E4; color:#A16207"><td colspan="3" style="text-align:right">损耗</td><td>1.00%</td></tr>
+      <tr class="total-row" style="background:#FCD34D; color:#713F12"><td colspan="3" style="text-align:right">合计 HKD</td><td>HK$ 301,176.47</td></tr>
+    </table>
+    <div class="meta">
+      <span class="swatch"><span class="chip" style="background:#FDE68A"></span>章节</span>
+      <span class="swatch"><span class="chip" style="background:#EAB308"></span>列头</span>
+      <span class="swatch"><span class="chip" style="background:#FEFCE8"></span>小计</span>
+      <span class="swatch"><span class="chip" style="background:#FCD34D"></span>合计</span>
+    </div>
+    <div class="pick-row"><button class="pick" onclick="pick(2)">选 2 号</button></div>
+  </div>
+
+  <!-- 3 奶油拿铁 -->
+  <div class="palette" style="--border:#EFE7D2">
+    <div class="pname">3. 奶油拿铁 <small>奶咖米色 · 文艺</small></div>
+    <table>
+      <tr><td class="title" colspan="4">47765A 车盖 内部报价明细</td></tr>
+      <tr class="sec" style="background:#FAF1D8; color:#704917"><td colspan="4">一、模具部分</td></tr>
+      <tr class="hdr" style="background:#D4A85E; color:#FFFFFF">
+        <th>模号</th><th>名称</th><th>材质</th><th>模具价格</th></tr>
+      <tr><td>P01</td><td>头盔/尾辨</td><td>PVC</td><td>¥33,000.00</td></tr>
+      <tr><td>P02</td><td>面部/尾翼</td><td>ABS</td><td>¥33,500.00</td></tr>
+      <tr class="sub-row" style="background:#FDF8E7; color:#845C1F"><td colspan="3" style="text-align:right">小计 RMB</td><td>¥256,000.00</td></tr>
+      <tr class="loss-row" style="background:#FBF5E0; color:#9C7029"><td colspan="3" style="text-align:right">损耗</td><td>1.00%</td></tr>
+      <tr class="total-row" style="background:#F0DBA1; color:#5C3B0F"><td colspan="3" style="text-align:right">合计 HKD</td><td>HK$ 301,176.47</td></tr>
+    </table>
+    <div class="meta">
+      <span class="swatch"><span class="chip" style="background:#FAF1D8"></span>章节</span>
+      <span class="swatch"><span class="chip" style="background:#D4A85E"></span>列头</span>
+      <span class="swatch"><span class="chip" style="background:#FDF8E7"></span>小计</span>
+      <span class="swatch"><span class="chip" style="background:#F0DBA1"></span>合计</span>
+    </div>
+    <div class="pick-row"><button class="pick" onclick="pick(3)">选 3 号</button></div>
+  </div>
+
+  <!-- 4 柠檬奶昔 -->
+  <div class="palette" style="--border:#F2EDD0">
+    <div class="pname">4. 柠檬奶昔 <small>清新嫩黄 · 最淡雅</small></div>
+    <table>
+      <tr><td class="title" colspan="4">47765A 车盖 内部报价明细</td></tr>
+      <tr class="sec" style="background:#FEF9C3; color:#713F12"><td colspan="4">一、模具部分</td></tr>
+      <tr class="hdr" style="background:#FACC15; color:#713F12">
+        <th>模号</th><th>名称</th><th>材质</th><th>模具价格</th></tr>
+      <tr><td>P01</td><td>头盔/尾辨</td><td>PVC</td><td>¥33,000.00</td></tr>
+      <tr><td>P02</td><td>面部/尾翼</td><td>ABS</td><td>¥33,500.00</td></tr>
+      <tr class="sub-row" style="background:#FEFCE8; color:#854D0E"><td colspan="3" style="text-align:right">小计 RMB</td><td>¥256,000.00</td></tr>
+      <tr class="loss-row" style="background:#FDFBE5; color:#A16207"><td colspan="3" style="text-align:right">损耗</td><td>1.00%</td></tr>
+      <tr class="total-row" style="background:#FEF08A; color:#713F12"><td colspan="3" style="text-align:right">合计 HKD</td><td>HK$ 301,176.47</td></tr>
+    </table>
+    <div class="meta">
+      <span class="swatch"><span class="chip" style="background:#FEF9C3"></span>章节</span>
+      <span class="swatch"><span class="chip" style="background:#FACC15"></span>列头</span>
+      <span class="swatch"><span class="chip" style="background:#FEFCE8"></span>小计</span>
+      <span class="swatch"><span class="chip" style="background:#FEF08A"></span>合计</span>
+    </div>
+    <div class="pick-row"><button class="pick" onclick="pick(4)">选 4 号</button></div>
+  </div>
+
+</div>
+
+<script>
+function pick(n) { alert('已选 ' + n + ' 号。回到对话窗告诉 AI：用 ' + n + ' 号'); }
+</script>
+</body>
+</html>

--- a/apps/业务部/内部报价系统/frontend/quote.html
+++ b/apps/业务部/内部报价系统/frontend/quote.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>报价单详情</title>
+  <link rel="stylesheet" href="./styles.css" />
+</head>
+<body>
+  <div class="topbar">
+    <div class="brand">📋 内部报价明细系统 <small>报价单详情</small></div>
+    <div id="user-chip" style="display:flex;align-items:center;gap:4px;background:rgba(255,255,255,.12);padding:6px 14px;border-radius:999px;font-size:13px">
+      <span id="who-chip" style="color:#fff;font-weight:500;margin-right:8px"></span>
+      <a href="./index.html" style="color:rgba(255,255,255,.85);text-decoration:none;margin-left:4px;padding:2px 8px;border-radius:6px">← 列表</a>
+      <a href="./index.html" id="btn-switch" style="color:rgba(255,255,255,.85);text-decoration:none;margin-left:4px;padding:2px 8px;border-radius:6px">🔄 切换账号</a>
+    </div>
+  </div>
+  <div id="app">
+    <h1>报价单 #<span id="qid"></span></h1>
+    <div id="status-bar"></div>
+    <div id="sections"></div>
+  </div>
+  <script src="./workbench.js"></script>
+</body>
+</html>

--- a/apps/业务部/内部报价系统/frontend/quote.html
+++ b/apps/业务部/内部报价系统/frontend/quote.html
@@ -20,6 +20,18 @@
     <div id="status-bar"></div>
     <div id="sections"></div>
   </div>
+  <script>
+    // nginx 子路径部署适配：绝对 /api 请求自动加当前页面路径前缀（如 /internal-quote）；根路径部署无副作用
+    (function () {
+      var base = location.pathname.replace(/\/[^/]*$/, '');
+      if (!base) return;
+      var origFetch = window.fetch.bind(window);
+      window.fetch = function (url, opts) {
+        if (typeof url === 'string' && url.indexOf('/api/') === 0) url = base + url;
+        return origFetch(url, opts);
+      };
+    })();
+  </script>
   <script src="./workbench.js"></script>
 </body>
 </html>

--- a/apps/业务部/内部报价系统/frontend/styles.css
+++ b/apps/业务部/内部报价系统/frontend/styles.css
@@ -1,0 +1,476 @@
+/* ========== 设计令牌 ========== */
+:root {
+  --bg: #f5f7fb;
+  --surface: #ffffff;
+  --surface-soft: #f9fafb;
+  --border: #e5e7eb;
+  --border-soft: #f1f3f5;
+  --text: #1f2937;
+  --text-dim: #6b7280;
+  --text-light: #9ca3af;
+  --primary: #2563eb;
+  --primary-hover: #1d4ed8;
+  --primary-soft: #eff6ff;
+  --danger: #dc2626;
+  --danger-hover: #b91c1c;
+  --success: #16a34a;
+  --warning: #d97706;
+  --shadow-sm: 0 1px 2px rgba(15, 23, 42, .04), 0 1px 3px rgba(15, 23, 42, .06);
+  --shadow-md: 0 4px 12px rgba(15, 23, 42, .06), 0 2px 4px rgba(15, 23, 42, .04);
+  --radius: 10px;
+  --radius-sm: 6px;
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  font-size: 14px;
+  line-height: 1.5;
+  padding: 0;
+}
+
+.topbar {
+  background: linear-gradient(135deg, #1e40af 0%, #2563eb 100%);
+  color: #fff;
+  padding: 14px 32px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  box-shadow: 0 2px 8px rgba(15, 23, 42, .08);
+}
+.topbar .brand { font-weight: 700; font-size: 18px; letter-spacing: 0.02em; }
+.topbar .brand small { font-weight: 400; opacity: 0.75; margin-left: 8px; font-size: 13px; }
+.topbar a { color: rgba(255,255,255,.85); text-decoration: none; margin-left: 16px; font-size: 13px; }
+.topbar a:hover { color: #fff; text-decoration: underline; }
+
+#app { max-width: 1560px; margin: 0 auto; padding: 24px; }
+/* 宽表（模具/注塑等）在卡片内横向滚动，避免内容溢出板块 */
+#wb-molds, #wb-inj, #wb-mold-costs, #wb-aux, #wb-pkmat, #wb-hw, #wb-elec, #wb-pp { overflow-x: auto; max-width: 100%; }
+
+h1 { margin: 0 0 12px; font-size: 26px; font-weight: 700; letter-spacing: -0.01em; }
+h2 { margin: 0 0 14px; font-size: 20px; font-weight: 600; }
+h3 { margin: 18px 0 10px; font-size: 16px; font-weight: 600; color: #374151; display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+h3 > small { font-weight: 400; font-size: 13px; color: var(--text-dim); }
+
+.muted { color: var(--text-dim); }
+
+/* ========== Card ========== */
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 22px 24px;
+  margin: 14px 0;
+  box-shadow: var(--shadow-sm);
+}
+.card:first-child { margin-top: 0; }
+
+.hidden { display: none !important; }
+
+/* ========== 表单元素 ========== */
+label { display: block; margin: 8px 0; font-size: 13px; color: #374151; }
+input, select, textarea {
+  padding: 7px 11px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  font-family: inherit;
+  font-size: 13px;
+  background: #fff;
+  color: var(--text);
+  transition: border .15s, box-shadow .15s;
+}
+input:hover, select:hover, textarea:hover { border-color: #cbd5e1; }
+input:focus, select:focus, textarea:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, .15);
+}
+input:disabled, select:disabled, textarea:disabled {
+  background: #f3f4f6;
+  color: var(--text-dim);
+  cursor: not-allowed;
+}
+
+/* ========== 按钮 ========== */
+button {
+  padding: 8px 18px;
+  border: none;
+  background: var(--primary);
+  color: #fff;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+  transition: background .15s, transform .05s, box-shadow .15s;
+}
+button:hover { background: var(--primary-hover); box-shadow: var(--shadow-sm); }
+button:active { transform: translateY(1px); }
+button:disabled { background: #d1d5db; cursor: not-allowed; box-shadow: none; }
+
+button.mini { padding: 5px 12px; font-size: 12px; background: #6b7280; }
+button.mini:hover { background: #4b5563; }
+
+button.danger { background: var(--danger); }
+button.danger:hover { background: var(--danger-hover); }
+
+button.ghost { background: transparent; color: var(--primary); border: 1px solid var(--primary); }
+button.ghost:hover { background: var(--primary-soft); }
+
+.msg { color: var(--danger); min-height: 1em; font-size: 13px; }
+
+/* ========== Badge ========== */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 9px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  vertical-align: middle;
+}
+.b-empty    { background: #f3f4f6; color: #6b7280; }
+.b-filled   { background: #fef3c7; color: #92400e; }
+.b-approved { background: #dcfce7; color: #166534; }
+.b-rejected { background: #fee2e2; color: #991b1b; }
+
+/* ========== 状态条 ========== */
+#status-bar { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 16px; }
+#status-bar .badge { padding: 6px 14px; font-size: 13px; }
+
+/* ========== 工作台表格 ========== */
+.wb-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  background: var(--surface);
+  margin: 10px 0;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+.wb-table thead th {
+  background: #f8fafc;
+  padding: 11px 12px;
+  border-bottom: 2px solid #e2e8f0;
+  font-size: 12px;
+  font-weight: 600;
+  color: #475569;
+  text-align: left;
+  white-space: nowrap;
+  letter-spacing: 0.02em;
+}
+.wb-table tbody td {
+  padding: 8px 10px;
+  border-bottom: 1px solid #f1f5f9;
+  vertical-align: middle;
+}
+.wb-table tbody tr:nth-child(even) { background: #fcfdfe; }
+.wb-table tbody tr:hover { background: #f0f7ff; transition: background .15s; }
+.wb-table tbody tr:last-child td { border-bottom: none; }
+.wb-table td.ro {
+  background: #fafbfc;
+  color: #374151;
+  padding: 8px 12px;
+}
+.wb-table td.hi, .wb-table tr.hi td {
+  background: #eff6ff;
+  font-weight: 600;
+  color: #1e40af;
+}
+.wb-table input, .wb-table textarea {
+  width: 100%;
+  min-width: 0;
+  padding: 6px 9px;
+  font-size: 13px;
+  border: 1px solid #e2e8f0;
+  background: #ffffff;
+  border-radius: 5px;
+  color: #1f2937;
+  transition: border-color .15s, box-shadow .15s;
+}
+.wb-table input:hover, .wb-table textarea:hover { border-color: #cbd5e1; }
+.wb-table input:focus, .wb-table textarea:focus {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, .12);
+  outline: none;
+}
+/* 出货价算价表 */
+.ship-table { max-width: 900px; }
+.ship-table tbody tr.hi td { background: #eff6ff; font-weight: 600; }
+.ship-table td.ro { background: #fafafa; color: #374151; }
+.ship-foot { display: flex; gap: 16px; flex-wrap: wrap; align-items: center; margin: 10px 0; }
+.ship-foot label { display: flex; align-items: center; gap: 8px; margin: 0; }
+
+/* 按产品分组的人工表 */
+.labor-group { border: 1px solid var(--border); border-radius: 8px; padding: 12px 14px; margin: 10px 0; background: #fcfdfe; }
+.labor-group-head { display: flex; gap: 10px; align-items: center; margin-bottom: 8px; }
+.labor-group-head .lg-name { flex: 0 0 220px; font-weight: 600; font-size: 14px; padding: 6px 10px; }
+.labor-total { display: flex; justify-content: space-between; gap: 12px; padding: 10px 16px; margin: 10px 0; background: #dcfce7; color: #166534; font-weight: 600; border-radius: 6px; }
+
+/* 参考表（料价/机型价） */
+.ref-tables { border: 1px solid var(--border); border-radius: 8px; background: var(--surface-soft); padding: 10px 14px; }
+.ref-tables summary.ref-summary { cursor: pointer; font-weight: 600; font-size: 13px; color: #374151; padding: 4px 0; user-select: none; }
+.ref-tables summary.ref-summary:hover { color: var(--primary); }
+.ref-tables .wb-table { font-size: 12px; }
+.ref-tables .wb-table thead th { padding: 6px 8px; font-size: 11px; }
+.ref-tables .wb-table tbody td { padding: 4px 6px; }
+
+/* 行操作按钮（上移/下移/复制/删除） */
+.wb-table td.row-actions { white-space: nowrap; padding: 4px 6px; }
+.wb-table td.row-actions button { line-height: 1.2; }
+
+/* 隐掉 number input 的上下箭头 */
+.wb-table input[type="number"]::-webkit-outer-spin-button,
+.wb-table input[type="number"]::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
+.wb-table input[type="number"] { -moz-appearance: textfield; }
+
+.wb-table input[disabled], .wb-table textarea[disabled] {
+  background: transparent;
+  border-color: transparent;
+  color: #374151;
+  padding-left: 0;
+}
+.wb-footer { margin: 6px 0; font-size: 13px; color: #374151; text-align: right; }
+
+/* ========== 两列网格表单（业务工作台） ========== */
+.wb-grid2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px 22px;
+  background: var(--surface-soft);
+  padding: 14px 18px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-soft);
+}
+.wb-grid2 label { display: flex; align-items: center; gap: 10px; margin: 4px 0; }
+.wb-grid2 label > span { flex: 0 0 140px; color: var(--text-dim); font-size: 13px; }
+.wb-grid2 input, .wb-grid2 select { flex: 1; }
+
+/* ========== 工作台底部操作栏 ========== */
+.wb-bar {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-top: 20px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+}
+.wb-bar .muted { font-size: 13px; }
+
+/* ========== 模具表格 ========== */
+.mold-table tbody tr { min-height: 70px; }
+.mold-table tbody td { vertical-align: top; padding-top: 10px; padding-bottom: 10px; }
+.mold-table textarea {
+  width: 100%;
+  min-height: 40px;
+  font-size: 13px;
+  line-height: 1.4;
+  padding: 5px 8px;
+}
+
+/* ========== 模具图片单元 ========== */
+.mold-img-cell { padding: 6px !important; }
+.cell-imgs { display: flex; flex-wrap: wrap; gap: 4px; align-items: center; justify-content: center; }
+.cell-img {
+  position: relative;
+  width: 52px; height: 52px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  overflow: hidden;
+  background: #fff;
+  transition: transform .15s, box-shadow .15s;
+}
+.cell-img:hover { transform: scale(1.05); box-shadow: var(--shadow-sm); z-index: 2; }
+.cell-img img { width: 100%; height: 100%; object-fit: cover; cursor: zoom-in; }
+.cell-img .img-del {
+  position: absolute; top: 0; right: 0;
+  padding: 0 6px; font-size: 11px; line-height: 16px;
+  border-bottom-left-radius: 4px;
+}
+.cell-img.add {
+  display: flex; align-items: center; justify-content: center;
+  cursor: pointer; color: var(--text-dim); font-size: 16px;
+  background: var(--surface-soft);
+  border-style: dashed;
+}
+.cell-img.add:hover { color: var(--primary); border-color: var(--primary); background: var(--primary-soft); }
+
+/* ========== 修改记录时间线 ========== */
+.audit-list { font-size: 13px; }
+.audit-row {
+  display: grid;
+  grid-template-columns: 160px 80px 100px 130px 1fr;
+  gap: 14px;
+  padding: 8px 4px;
+  border-bottom: 1px solid var(--border-soft);
+  align-items: center;
+}
+.audit-row:hover { background: var(--surface-soft); }
+.audit-row:last-child { border-bottom: none; }
+.audit-at { color: var(--text-dim); font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 12px; }
+.audit-dept { color: #374151; font-weight: 500; }
+.audit-actor { color: var(--primary); }
+.audit-action { color: #111827; }
+.audit-detail { font-size: 12px; color: var(--text-dim); }
+.audit-search { margin-left: auto; width: 260px; padding: 6px 12px; border-radius: 999px; font-size: 13px; }
+.audit-pager { display: flex; justify-content: center; align-items: center; gap: 16px; padding: 12px 0 4px; font-size: 13px; color: var(--text-dim); }
+
+/* ========== 上传模具报价单按钮 ========== */
+h3 .upload-mold-sheet button { background: #475569; }
+h3 .upload-mold-sheet button:hover { background: #334155; }
+
+/* ========== 登录卡片（首页） ========== */
+.login-card {
+  max-width: 420px;
+  margin: 60px auto;
+  padding: 32px 36px;
+}
+.login-card h2 { text-align: center; margin: 0 0 4px; }
+.login-card label { font-weight: 500; color: #374151; margin-top: 12px; }
+.login-card input, .login-card select { width: 100%; margin-top: 4px; padding: 9px 11px; }
+
+/* ========== 用户胶囊（顶栏右侧） ========== */
+#user-chip {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: rgba(255,255,255,.12);
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-size: 13px;
+}
+#user-chip #who-chip { color: #fff; font-weight: 500; margin-right: 8px; }
+#user-chip a { margin-left: 4px; padding: 2px 8px; border-radius: 6px; }
+#user-chip a:hover { background: rgba(255,255,255,.18); text-decoration: none; }
+
+/* ========== 报价单列表 ========== */
+.list-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+.new-quote-form {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+.new-quote-form input { padding: 7px 10px; font-size: 13px; min-width: 110px; }
+.new-quote-form input:nth-child(2) { min-width: 140px; }
+
+/* 进度条 */
+.progress {
+  width: 80px;
+  height: 6px;
+  background: var(--border-soft);
+  border-radius: 999px;
+  overflow: hidden;
+}
+.progress-bar {
+  height: 100%;
+  background: linear-gradient(90deg, #34d399, #10b981);
+  transition: width .25s;
+}
+
+/* 部门 tab 切换 */
+.dept-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 6px;
+  margin-bottom: 16px;
+  box-shadow: var(--shadow-sm);
+}
+.dept-tab {
+  padding: 8px 18px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-dim);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  transition: background .15s, color .15s;
+}
+.dept-tab:hover { background: var(--surface-soft); color: var(--text); }
+.dept-tab.active {
+  background: var(--primary);
+  color: #fff;
+}
+.dept-tab.active .badge { background: rgba(255,255,255,.2); color: #fff; }
+
+/* 紧凑成本汇总（小计/损耗/合计 纵向） */
+.loss-summary {
+  display: inline-flex;
+  flex-direction: column;
+  margin: 6px 0 14px auto;
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 13px;
+  min-width: 280px;
+  box-shadow: var(--shadow-sm);
+}
+.loss-summary .ls-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 14px;
+  border-bottom: 1px solid var(--border-soft);
+}
+.loss-summary .ls-row:last-child { border-bottom: none; }
+.loss-summary .ls-row.hi { background: #dcfce7; color: #166534; font-weight: 600; }
+.loss-summary .ls-label { color: var(--text-dim); }
+.loss-summary .ls-row.hi .ls-label { color: #166534; }
+.loss-summary .ls-val { font-family: ui-monospace, monospace; }
+.loss-summary .ls-title { padding: 6px 14px; background: #f1f5f9; color: #334155; font-weight: 600; font-size: 12px; border-bottom: 1px solid var(--border-soft); }
+
+/* 电子两级表 */
+.hier-table .hier-parent td { font-weight: 500; }
+.hier-child-row > td { background: #f9fafb !important; padding: 8px 16px 12px !important; border-left: 3px solid var(--primary) !important; }
+.hier-children { padding-left: 4px; }
+.hier-children .wb-table { background: #fff; }
+
+/* 其他部门状态概览 */
+.other-dept-list { display: flex; flex-direction: column; gap: 6px; }
+.other-dept-row { display: grid; grid-template-columns: 90px 80px 1fr; gap: 12px; padding: 8px 4px; border-bottom: 1px solid var(--border-soft); align-items: center; font-size: 13px; }
+.other-dept-row:last-child { border-bottom: none; }
+.other-dept-row .dept-name { font-weight: 500; color: #374151; }
+
+/* 搜索框 */
+.search-box { display: flex; align-items: center; gap: 8px; }
+.search-box input {
+  width: 280px;
+  padding: 7px 12px;
+  font-size: 13px;
+  background: #fff;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+}
+.search-box input:focus { border-color: var(--primary); }
+.search-box small { font-size: 12px; white-space: nowrap; }
+
+/* 打开按钮 */
+.open-btn {
+  display: inline-block;
+  padding: 4px 12px;
+  background: var(--primary-soft);
+  color: var(--primary);
+  border-radius: 6px;
+  text-decoration: none;
+  font-size: 13px;
+  font-weight: 500;
+  transition: background .15s;
+}
+.open-btn:hover { background: var(--primary); color: #fff; }

--- a/apps/业务部/内部报价系统/frontend/workbench.js
+++ b/apps/业务部/内部报价系统/frontend/workbench.js
@@ -25,6 +25,20 @@ async function api(p, opts = {}) {
   return r.json();
 }
 
+// 保存 section（带轻量并发提醒）：带上加载时的 filled_at；后端若发现被别人改过会回 conflict
+// 不挡保存，仅弹一次提示；成功后更新本地 filled_at 作为新基线（避免自己的后续保存误报）
+async function putSection(sec, payload, submit) {
+  const r = await api('/sections/' + sec.id, {
+    method: 'PUT',
+    body: JSON.stringify({ payload, submit: !!submit, base_filled_at: sec.filled_at || null }),
+  });
+  if (r) {
+    if (r.filled_at) sec.filled_at = r.filled_at;
+    if (r.conflict) alert(`⚠️ 该部分在你打开后已被「${r.last_by || '他人'}」修改过（${r.last_at || ''}），你的保存已覆盖它。\n请刷新核对，必要时让对方重填。`);
+  }
+  return r;
+}
+
 // ==================== 通用可编辑表格 ====================
 // columns: [{key, label, type?: 'text'|'number'|'textarea', readonly?: bool|fn, calc?: row => number, width?: string}]
 // rows:    数组（直接 mutate 本数组）
@@ -856,30 +870,27 @@ function renderSummaryPane(host, sections, quote, me) {
   // 九、合计 中的 附加税 + 模具分摊 (都已是 RMB，转 HKD)
   const surtaxHkd = num(surtaxManual) / fxRH;
   const moldShareHkd = num(moldShare) / fxRH;
-  renderShipping(host.querySelector('#wb-shipping-sum'), sales, salesHeader, canEditShip, () => {
-    // 自动保存出货价算价到业务 section
+  // 统一保存业务 section（同步本地缓存，避免重渲染按旧 payload 还原）
+  const saveSales = () => {
     if (canEditShip && salesSec) {
-      // 同步本地 sections 缓存，避免汇总重渲染时按旧 payload 还原（如 目标价 被重置回 0）
       salesSec.payload_json = JSON.stringify(sales);
-      api('/sections/' + salesSec.id, { method: 'PUT', body: JSON.stringify({ payload: sales, submit: false }) }).catch(() => {});
+      putSection(salesSec, sales, false).catch(() => {});
     }
-  }, freightMapSum, afterMarkupHkd, surtaxHkd, moldShareHkd);
+  };
+  renderShipping(host.querySelector('#wb-shipping-sum'), sales, salesHeader, canEditShip, saveSales,
+    freightMapSum, afterMarkupHkd, surtaxHkd, moldShareHkd);
   const surtaxInp = host.querySelector('#tot-surtax');
-  if (surtaxInp && (me?.dept === 'sales' || me?.dept === 'engineering')) {
-    surtaxInp.oninput = () => {
-      sales.pricing_summary.surtax = surtaxInp.value === '' ? null : Number(surtaxInp.value);
-    };
+  if (surtaxInp && canEditShip) {
+    surtaxInp.oninput = () => { sales.pricing_summary.surtax = surtaxInp.value === '' ? null : Number(surtaxInp.value); };
+    surtaxInp.onchange = () => { saveSales(); renderSummaryPane(host, sections, quote, me); };  // 失焦持久化 + 刷新显示
   } else if (surtaxInp) {
     surtaxInp.disabled = true;
   }
   // 码点 可编辑（业务/工程）
   const markupInp = host.querySelector('#tot-markup');
-  if (markupInp && (me?.dept === 'sales' || me?.dept === 'engineering')) {
-    markupInp.oninput = () => {
-      sales.shipping = sales.shipping || {};
-      sales.shipping.markup_x = Number(markupInp.value) || 1.2;
-      renderSummaryPane(host, sections, quote, me);
-    };
+  if (markupInp && canEditShip) {
+    markupInp.oninput = () => { sales.shipping = sales.shipping || {}; sales.shipping.markup_x = Number(markupInp.value) || 1.2; };
+    markupInp.onchange = () => { saveSales(); renderSummaryPane(host, sections, quote, me); };  // 失焦持久化+刷新(避免每键重渲染丢焦/录错)
   } else if (markupInp) {
     markupInp.disabled = true;
   }
@@ -964,6 +975,7 @@ function renderSummaryPane(host, sections, quote, me) {
     })(),
     // 杂项 = 印尼运费(手填 HKD) + 附加税 HKD
     misc: num(sales.pricing_summary?.indo_freight) + surtaxHkd,
+    surtax_hkd: surtaxHkd,  // 供减税明细里印尼运费输入框重算 misc 用（避免丢附加税）
     hardware: (hwRaw - _sumByMatch(eng.hardware, isMotor)),  // 五金 HKD（剔除马达项；五金表已 HKD）
     electronic: (elecRaw - _sumByMatch(elecSrc, isMotor)),  // 电子 HKD（剔除马达项；电子表已 HKD）
     injection_labor: sum(mold.injection || [], r => num(r.shot_price)),  // 啤工 = Σ啤价 HKD（只算机时人工，不含原料）
@@ -984,8 +996,8 @@ function renderTaxDeductionBlock(host, salesPayload, salesSec, me, autoFill) {
   // 自动同步前面部门的金额（每次进汇总都覆盖；用户后续可手填覆盖项放 ps.overrides）
   ps.overrides = ps.overrides || {};
   const applyAuto = (tbl, key, val) => {
-    if (val == null || val === 0) return;
-    if (ps.overrides[tbl + '.' + key]) return; // 用户已手动改过
+    if (val == null) return;                    // 仅未计算(undefined/null)时跳过；0 要写回以清掉旧残留值
+    if (ps.overrides[tbl + '.' + key]) return;  // 用户已手动改过
     ps[tbl] = ps[tbl] || {};
     ps[tbl][key] = +val.toFixed(4);
   };
@@ -1219,12 +1231,9 @@ function renderTaxDeductionBlock(host, salesPayload, salesSec, me, autoFill) {
     const indoInp = host.querySelector('#tk-indo-freight');
     if (indoInp) indoInp.oninput = () => {
       ps.indo_freight = Number(indoInp.value) || 0;
-      // 杂项 = 印尼运费 + 附加税；把它写回 t2.misc 并触发 recalc
-      // surtax 自动算时已从外面带进来，这里更新印尼部分 + 触发 recalc
-      const surtax = num(ps.t1.base_price) ? 0 : 0; // 占位 — 附加税值在 autoFill 阶段写入 ps.t2.misc，这里需手动加印尼
-      // 让 misc 反映 = 印尼运费 + 附加税：保留 (misc - 上一次印尼) + 当前印尼
-      ps.t2.misc = (num(ps.t2.misc) - num(ps._last_indo || 0)) + Number(indoInp.value || 0);
-      ps._last_indo = Number(indoInp.value || 0);
+      // 杂项 = 印尼运费 + 附加税(HKD)，单一公式重算，避免之前增量法丢掉附加税
+      // 不设 override：重渲染时 autoFill 会用 indo_freight+surtax 同公式重算，保持一致
+      ps.t2.misc = +((Number(indoInp.value) || 0) + num(autoFill.surtax_hkd)).toFixed(4);
       recalc();
     };
     host.querySelectorAll('input.tk-edit').forEach(inp => {
@@ -1244,7 +1253,7 @@ function renderTaxDeductionBlock(host, salesPayload, salesSec, me, autoFill) {
       const msg = host.querySelector('#tk-msg');
       msg.textContent = '保存中...';
       try {
-        await api('/sections/' + salesSec.id, { method: 'PUT', body: JSON.stringify({ payload: salesPayload, submit: false }) });
+        await putSection(salesSec, salesPayload, false);
         if (salesSec) salesSec.payload_json = JSON.stringify(salesPayload);  // 同步本地缓存
         msg.textContent = '✓ 已保存 ' + new Date().toLocaleTimeString();
       } catch (e) { msg.textContent = '✗ ' + e.message; }
@@ -1339,7 +1348,7 @@ function renderSewing(host, payload, canEdit, onChange, fxRmbHkd) {
       card.innerHTML = `
         <div style="display:flex;gap:10px;align-items:center;margin-bottom:8px">
           <strong style="color:#16a34a">📦 产品：</strong>
-          <input class="sw-gname" data-gi="${gi}" value="${g.name || ''}" placeholder="如：6寸小蜥蜴 / 盾牌" style="flex:1;max-width:300px" ${canEdit ? '' : 'disabled'}/>
+          <input class="sw-gname" data-gi="${gi}" value="${escapeHtml(g.name || '')}" placeholder="如：6寸小蜥蜴 / 盾牌" style="flex:1;max-width:300px" ${canEdit ? '' : 'disabled'}/>
           <label style="font-size:13px">类型
             <select class="sw-gcat" data-gi="${gi}" ${canEdit ? '' : 'disabled'}>
               <option value="车衣" ${cat==='车衣'?'selected':''}>车衣</option>
@@ -1405,9 +1414,9 @@ function renderSewing(host, payload, canEdit, onChange, fxRmbHkd) {
           if (!r.ok) throw new Error(j.error || '解析失败');
           impPreview.innerHTML = `
             <div class="card" style="background:#f0fdf4;border:1px solid #86efac;margin-top:10px">
-              <p>从 <b>${j.sheet_used}</b> 解析到 <b>${j.count}</b> 个产品分组：</p>
+              <p>从 <b>${escapeHtml(j.sheet_used || '')}</b> 解析到 <b>${j.count}</b> 个产品分组：</p>
               <ul style="margin:6px 0;padding-left:22px">
-                ${j.groups.map(g => `<li><b>${g.name}</b> — ${g.items.length} 行 / 人工 ¥${(g.labor_amount||0).toFixed(2)}</li>`).join('')}
+                ${j.groups.map(g => `<li><b>${escapeHtml(g.name)}</b> — ${g.items.length} 行 / 人工 ¥${(g.labor_amount||0).toFixed(2)}</li>`).join('')}
               </ul>
               <div style="margin-top:10px;display:flex;gap:8px">
                 <button id="sw-imp-replace">应用（替换所有产品组）</button>
@@ -1640,15 +1649,15 @@ function renderEngineering(host, payload, canEdit, onChange, fxRmbHkd, fxRmbUsd)
       if (!r.ok) throw new Error(j.error || '解析失败');
       preview.innerHTML = `
         <div class="card" style="background:#f0fdf4;border:1px solid #86efac;">
-          <p>从 <b>${j.sheet_used}</b> 解析到 <b>${j.molds.length}</b> 副模具：</p>
+          <p>从 <b>${escapeHtml(j.sheet_used || '')}</b> 解析到 <b>${j.molds.length}</b> 副模具：</p>
           <table class="wb-table"><thead><tr>
             <th>模号</th><th>名称</th><th>类型</th><th>材质</th>
             <th>出模数</th><th>套数</th><th>周期(秒)</th><th>模具尺寸</th><th>价格RMB</th><th>备注</th>
           </tr></thead><tbody>
           ${j.molds.map(m => `<tr>
-            <td>${m.mold_no || ''}</td><td>${m.name}</td><td>${m.mold_type}</td>
-            <td>${m.material}</td><td>${m.cavity}</td>
-            <td>${m.sets}</td><td>${m.cycle_sec ?? ''}</td><td>${(m.detail && m.detail.mold_size) || ''}</td><td>${m.price_rmb ?? ''}</td><td>${m.note || ''}</td>
+            <td>${escapeHtml(m.mold_no || '')}</td><td>${escapeHtml(m.name || '')}</td><td>${escapeHtml(m.mold_type || '')}</td>
+            <td>${escapeHtml(m.material || '')}</td><td>${escapeHtml(m.cavity || '')}</td>
+            <td>${escapeHtml(m.sets ?? '')}</td><td>${escapeHtml(m.cycle_sec ?? '')}</td><td>${escapeHtml((m.detail && m.detail.mold_size) || '')}</td><td>${escapeHtml(m.price_rmb ?? '')}</td><td>${escapeHtml(m.note || '')}</td>
           </tr>`).join('')}
           </tbody></table>
           <div style="margin-top:10px">
@@ -1883,8 +1892,8 @@ function renderElectronic(host, payload, canEdit, onChange, fxRmbHkd) {
           if (!r.ok) throw new Error(j.error || '解析失败');
           impPreview.innerHTML = `
             <div class="card" style="background:#f0fdf4;border:1px solid #86efac;margin-top:10px">
-              <p>从 <b>${j.sheet_used}</b> 解析到 <b>${j.count}</b> 个零件（${(j.parts || []).reduce((a, p) => a + 1 + (p.children || []).length, 0)} 行明细）</p>
-              ${j.meta && j.meta.product ? `<p class="muted">产品: ${j.meta.product}${j.meta.customer ? ' · 客户: ' + j.meta.customer : ''}${j.meta.date ? ' · 日期: ' + j.meta.date : ''}</p>` : ''}
+              <p>从 <b>${escapeHtml(j.sheet_used || '')}</b> 解析到 <b>${j.count}</b> 个零件（${(j.parts || []).reduce((a, p) => a + 1 + (p.children || []).length, 0)} 行明细）</p>
+              ${j.meta && j.meta.product ? `<p class="muted">产品: ${escapeHtml(j.meta.product)}${j.meta.customer ? ' · 客户: ' + escapeHtml(j.meta.customer) : ''}${j.meta.date ? ' · 日期: ' + escapeHtml(j.meta.date) : ''}</p>` : ''}
               <p class="muted">导入后：会替换电子表 + 自动填充 测试费用 / 包装运输 / 利润% / 抵税差额；导出 Excel 时会附加"电子明细"分表。</p>
               <div style="margin-top:10px;display:flex;gap:8px">
                 <button id="el-imp-apply">应用</button>
@@ -2632,10 +2641,10 @@ function renderAssembly(host, payload, canEdit, onChange, fxRmbHkd) {
         impPreview.innerHTML = `
           <div class="card" style="background:#f0fdf4;border:1px solid #86efac;margin-top:10px">
             <p>解析到 <b>${j.count}</b> 个工序<br>
-            ${m.customer ? `客名: ${m.customer} · ` : ''}${m.quote_no ? `货号: ${m.quote_no} · ` : ''}${m.target_qty ? `目标数: ${m.target_qty}` : ''}</p>
+            ${m.customer ? `客名: ${escapeHtml(m.customer)} · ` : ''}${m.quote_no ? `货号: ${escapeHtml(m.quote_no)} · ` : ''}${m.target_qty ? `目标数: ${escapeHtml(m.target_qty)}` : ''}</p>
             <div style="margin-top:10px;display:flex;gap:8px;align-items:center">
               <label>归到产品组：
-                <input id="asm-imp-name" type="text" value="${m.customer ? '货号 ' + (m.quote_no || '') : '排拉工序'}" style="width:200px"/>
+                <input id="asm-imp-name" type="text" value="${escapeHtml(m.customer ? '货号 ' + (m.quote_no || '') : '排拉工序')}" style="width:200px"/>
               </label>
               <button id="asm-imp-add">作为新组添加</button>
               <button id="asm-imp-cancel" class="mini danger">取消</button>
@@ -2751,9 +2760,9 @@ function renderAssembly(host, payload, canEdit, onChange, fxRmbHkd) {
         impPreview.innerHTML = `
           <div class="card" style="background:#f0fdf4;border:1px solid #86efac;margin-top:10px">
             <p>解析到 <b>${j.count}</b> 个工序<br>
-            ${m.customer ? `客名: ${m.customer} · ` : ''}${m.quote_no ? `货号: ${m.quote_no} · ` : ''}${m.target_qty ? `目标数: ${m.target_qty}` : ''}</p>
+            ${m.customer ? `客名: ${escapeHtml(m.customer)} · ` : ''}${m.quote_no ? `货号: ${escapeHtml(m.quote_no)} · ` : ''}${m.target_qty ? `目标数: ${escapeHtml(m.target_qty)}` : ''}</p>
             <div style="margin-top:10px;display:flex;gap:8px;align-items:center">
-              <label>归到产品组：<input id="pkg-imp-name" type="text" value="${m.quote_no ? '货号 ' + m.quote_no : '排拉工序'}" style="width:200px"/></label>
+              <label>归到产品组：<input id="pkg-imp-name" type="text" value="${escapeHtml(m.quote_no ? '货号 ' + m.quote_no : '排拉工序')}" style="width:200px"/></label>
               <button id="pkg-imp-add">作为新组添加</button>
               <button id="pkg-imp-cancel" class="mini danger">取消</button>
             </div>
@@ -3113,7 +3122,7 @@ function renderShipping(host, payload, header, canEdit, onChange, freightMap, pr
       <table class="wb-table ship-table">
         <thead><tr>
           <th style="width:200px">项</th>
-          ${sc.map((x, i) => `<th>${canEdit ? `<div style="display:flex;gap:4px;align-items:center"><input class="sc-name" data-i="${i}" value="${x.name || ''}" style="flex:1" ${x.is_factory?'disabled':''}>${x.is_factory ? '' : `<button class="mini danger sc-del" data-i="${i}" title="删除该场景" style="padding:2px 7px">×</button>`}</div>` : (x.name || '场景' + (i+1))}</th>`).join('')}
+          ${sc.map((x, i) => `<th>${canEdit ? `<div style="display:flex;gap:4px;align-items:center"><input class="sc-name" data-i="${i}" value="${escapeHtml(x.name || '')}" style="flex:1" ${x.is_factory?'disabled':''}>${x.is_factory ? '' : `<button class="mini danger sc-del" data-i="${i}" title="删除该场景" style="padding:2px 7px">×</button>`}</div>` : escapeHtml(x.name || ('场景' + (i+1)))}</th>`).join('')}
           ${canEdit ? '<th style="width:30px"></th>' : ''}
         </tr></thead>
         <tbody>
@@ -3191,10 +3200,10 @@ function renderSales(host, payload, quote, canEditHeader, canEditPricing, allSec
   host.innerHTML = `
     <h3>报价单表头</h3>
     <div class="wb-grid2">
-      <label>货号 <input id="h-no" value="${quote.quote_no}" disabled /></label>
-      <label>产品名称 <input id="h-pn" value="${quote.product_name || ''}" ${canEditHeader ? '' : 'disabled'} /></label>
-      <label>版本 <input id="h-ver" value="${quote.version || ''}" placeholder="如 V1/改色版" ${canEditHeader ? '' : 'disabled'} /></label>
-      <label>客户 <input id="h-cu" value="${quote.customer || ''}" ${canEditHeader ? '' : 'disabled'} /></label>
+      <label>货号 <input id="h-no" value="${escapeHtml(quote.quote_no)}" disabled /></label>
+      <label>产品名称 <input id="h-pn" value="${escapeHtml(quote.product_name || '')}" ${canEditHeader ? '' : 'disabled'} /></label>
+      <label>版本 <input id="h-ver" value="${escapeHtml(quote.version || '')}" placeholder="如 V1/改色版" ${canEditHeader ? '' : 'disabled'} /></label>
+      <label>客户 <input id="h-cu" value="${escapeHtml(quote.customer || '')}" ${canEditHeader ? '' : 'disabled'} /></label>
       <label>出货数量 <input id="h-qty" type="number" value="${quote.qty || ''}" ${canEditHeader ? '' : 'disabled'} /></label>
       <label>币种
         <select id="h-cy" ${canEditPricing ? '' : 'disabled'}>
@@ -3489,7 +3498,7 @@ async function renderQuotePage() {
             try {
               if (act === 'save' || act === 'submit') {
                 if (!confirm(`确认保存到 ${s.dept_name} section？该部门已有数据会被覆盖。`)) return;
-                await api('/sections/' + s.id, { method: 'PUT', body: JSON.stringify({ payload: sectionPayload, submit: act === 'submit' }) });
+                await putSection(s, sectionPayload, act === 'submit');
               } else if (act === 'approve') {
                 await api('/reviews/' + s.id, { method: 'POST', body: JSON.stringify({ action: 'approve' }) });
               } else if (act === 'reject') {
@@ -3529,7 +3538,7 @@ async function renderQuotePage() {
   // 行为绑定
   const saveSection = async (submit) => {
     try {
-      await api('/sections/' + mySec.id, { method: 'PUT', body: JSON.stringify({ payload, submit }) });
+      await putSection(mySec, payload, submit);
       renderQuotePage();
     } catch (e) { alert(e.message); }
   };

--- a/apps/业务部/内部报价系统/frontend/workbench.js
+++ b/apps/业务部/内部报价系统/frontend/workbench.js
@@ -299,9 +299,9 @@ function renderImageCell(td, m, canEdit, onChange) {
   const wrap = document.createElement('div'); wrap.className = 'cell-imgs';
   (m.images || []).forEach((u, i) => {
     const box = document.createElement('div'); box.className = 'cell-img';
-    box.innerHTML = `<img src="/${u}" />${canEdit ? `<button class="mini danger img-del">×</button>` : ''}`;
+    box.innerHTML = `<img src="${u}" />${canEdit ? `<button class="mini danger img-del">×</button>` : ''}`;
     if (canEdit) box.querySelector('.img-del').onclick = () => { m.images.splice(i, 1); renderImageCell(td, m, canEdit, onChange); onChange(); };
-    box.querySelector('img').onclick = () => window.open('/' + u, '_blank');
+    box.querySelector('img').onclick = () => window.open(u, '_blank');
     wrap.appendChild(box);
   });
   if (canEdit) {

--- a/apps/业务部/内部报价系统/frontend/workbench.js
+++ b/apps/业务部/内部报价系统/frontend/workbench.js
@@ -1,0 +1,3650 @@
+// 5 个部门工作台 + 公用可增删行表格组件 + 汇总计算
+// 数据流：从 /api/quotes/:id 拉到 sections（其他部门已审的 payload_json 也会带过来）
+// → 渲染当前部门工作台 → 编辑后 PUT /api/sections/:id { payload, submit }
+// → 业务页用所有已审 section 计算总价
+
+const $ = (id) => document.getElementById(id);
+
+const STATUS_TXT = { empty: '空', filled: '已填', approved: '已审', rejected: '驳回' };
+const STATUS_CLS = { empty: 'b-empty', filled: 'b-filled', approved: 'b-approved', rejected: 'b-rejected' };
+
+// 权限工具（与 main.js 一致）
+function hasPerm(me, menu, action) {
+  if (!me || !me.perms) return false;
+  const p = me.perms[menu];
+  return !!(p && p['can_' + action]);
+}
+const DEPT_MENU = {
+  sales: '业务部', engineering: '工程部', electronic: '电子部', molding: '啤机部',
+  painting: '喷油部', slush: '搪胶', sewing: '车缝', assembly: '装配部',
+};
+
+async function api(p, opts = {}) {
+  const r = await fetch('/api' + p, { credentials: 'include', headers: { 'Content-Type': 'application/json' }, ...opts });
+  if (!r.ok) throw new Error((await r.json().catch(() => ({}))).error || r.statusText);
+  return r.json();
+}
+
+// ==================== 通用可编辑表格 ====================
+// columns: [{key, label, type?: 'text'|'number'|'textarea', readonly?: bool|fn, calc?: row => number, width?: string}]
+// rows:    数组（直接 mutate 本数组）
+// onChange: 数据变更时回调
+function renderTable(container, columns, rows, opts = {}) {
+  const { readonly = false, onChange = () => {}, footer = null } = opts;
+  container.innerHTML = '';
+
+  const table = document.createElement('table');
+  table.className = 'wb-table';
+  const thead = document.createElement('thead');
+  const tr = document.createElement('tr');
+  tr.innerHTML = '<th style="width:36px">#</th>' +
+    columns.map(c => `<th${c.width ? ` style="width:${c.width}"` : ''}>${c.label}</th>`).join('') +
+    (readonly ? '' : '<th style="width:36px"></th>');
+  thead.appendChild(tr);
+  table.appendChild(thead);
+
+  const tbody = document.createElement('tbody');
+  function rebuild() {
+    tbody.innerHTML = '';
+    rows.forEach((row, idx) => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `<td>${idx + 1}</td>`;
+      const calcCells = []; // [{ td, fn }] — 行内所有计算列，用于实时刷新
+      const refreshCalcs = () => calcCells.forEach(({ td, fn }) => { td.textContent = formatNum(fn(row)); });
+      columns.forEach(c => {
+        const td = document.createElement('td');
+        const ro = typeof c.readonly === 'function' ? c.readonly(row) : (c.readonly || readonly);
+        let val = row[c.key];
+        if (c.calc) val = c.calc(row);
+        if (val === undefined || val === null) val = '';
+        if (ro) {
+          td.className = 'ro';
+          td.textContent = formatNum(val);
+          if (c.calc) calcCells.push({ td, fn: c.calc });
+        } else if (c.type === 'textarea') {
+          const ta = document.createElement('textarea');
+          ta.rows = 2; ta.value = val;
+          ta.style.resize = 'vertical';
+          const autoSize = () => { ta.style.height = 'auto'; ta.style.height = (ta.scrollHeight + 2) + 'px'; };
+          ta.oninput = () => { row[c.key] = ta.value; autoSize(); refreshCalcs(); onChange(); };
+          td.appendChild(ta);
+          setTimeout(autoSize, 0);
+        } else if (c.type === 'select') {
+          const sel = document.createElement('select');
+          const opts = typeof c.options === 'function' ? c.options(row) : (c.options || []);
+          // 允许空选项
+          const blank = document.createElement('option');
+          blank.value = ''; blank.textContent = '';
+          sel.appendChild(blank);
+          opts.forEach(o => {
+            const op = document.createElement('option');
+            op.value = o; op.textContent = o;
+            if (val === o) op.selected = true;
+            sel.appendChild(op);
+          });
+          if (!opts.includes(val) && val) {
+            // 当前值不在选项里，仍保留（避免清空）
+            const op = document.createElement('option');
+            op.value = val; op.textContent = val; op.selected = true;
+            sel.appendChild(op);
+          }
+          sel.onchange = () => { row[c.key] = sel.value; refreshCalcs(); onChange(); };
+          td.appendChild(sel);
+        } else {
+          const inp = document.createElement('input');
+          inp.type = c.type === 'number' ? 'number' : 'text';
+          if (c.type === 'number') inp.step = 'any';
+          inp.value = val;
+          inp.oninput = () => {
+            row[c.key] = c.type === 'number' ? (inp.value === '' ? null : Number(inp.value)) : inp.value;
+            refreshCalcs();
+            onChange();
+          };
+          td.appendChild(inp);
+        }
+        tr.appendChild(td);
+      });
+      if (!readonly) {
+        const td = document.createElement('td'); td.className = 'row-actions';
+        const mkBtn = (label, title, fn) => {
+          const b = document.createElement('button');
+          b.textContent = label; b.className = 'mini'; b.title = title;
+          b.style.padding = '2px 6px'; b.style.marginRight = '2px';
+          b.onclick = fn;
+          return b;
+        };
+        // 上移
+        if (idx > 0) td.appendChild(mkBtn('↑', '上移', () => {
+          [rows[idx - 1], rows[idx]] = [rows[idx], rows[idx - 1]]; rebuild(); onChange();
+        }));
+        // 下移
+        if (idx < rows.length - 1) td.appendChild(mkBtn('↓', '下移', () => {
+          [rows[idx + 1], rows[idx]] = [rows[idx], rows[idx + 1]]; rebuild(); onChange();
+        }));
+        // 复制此行（拆分用）→ 在下方插入一份副本
+        td.appendChild(mkBtn('⎘', '在下方插入副本（用于拆分）', () => {
+          rows.splice(idx + 1, 0, JSON.parse(JSON.stringify(rows[idx]))); rebuild(); onChange();
+        }));
+        // 删除
+        const delBtn = mkBtn('×', '删除', () => { rows.splice(idx, 1); rebuild(); onChange(); });
+        delBtn.className = 'mini danger';
+        td.appendChild(delBtn);
+        tr.appendChild(td);
+      }
+      tbody.appendChild(tr);
+    });
+  }
+  rebuild();
+  table.appendChild(tbody);
+  container.appendChild(table);
+
+  if (footer) {
+    const f = document.createElement('div'); f.className = 'wb-footer'; f.innerHTML = footer();
+    container.appendChild(f);
+  }
+
+  if (!readonly) {
+    const addBtn = document.createElement('button');
+    addBtn.textContent = '+ 增加行'; addBtn.className = 'mini';
+    addBtn.onclick = () => { rows.push({}); rebuild(); onChange(); };
+    container.appendChild(addBtn);
+  }
+  return { rebuild };
+}
+
+// 辅助/包装材料 类别 — 减税明细各外购项按此类别统计
+const MAT_CATEGORIES = ['吸塑', '彩盒/内咭', '电池', '利宝', '电镀', '其他外购'];
+
+function formatNum(v) {
+  if (typeof v === 'number' && !Number.isNaN(v)) return v.toFixed(Math.abs(v) < 1 ? 4 : 2);
+  return String(v ?? '');
+}
+function num(v) { return Number(v) || 0; }
+function sum(arr, fn) { return arr.reduce((a, r) => a + (fn(r) || 0), 0); }
+
+// ==================== 子小计计算 ====================
+// 自由表（electronics / aux_materials）：行 amount = qty × unit_price；
+// 子小计行（is_subtotal=true）不参与父级再加；普通行参与
+function computeRow(row) {
+  if (row.is_subtotal) return num(row.amount);
+  return num(row.qty) * num(row.unit_price);
+}
+function freeTableSubtotal(rows) {
+  // 非 is_subtotal 行才计入
+  return sum(rows.filter(r => !r.is_subtotal), computeRow);
+}
+function applyLoss(subtotal, pct) {
+  return subtotal;  // 已全面取消损耗
+}
+
+// ==================== 工程：模具部分（表格布局，对齐 sheet1 / 导出格式） ====================
+function renderMolds(container, molds, onChange, canEdit, fxRmbHkd) {
+  container.innerHTML = '';
+  const table = document.createElement('table'); table.className = 'wb-table mold-table';
+  table.innerHTML = `<thead><tr>
+    <th style="width:40px">序号</th>
+    <th style="width:160px">模具名称</th>
+    <th style="width:70px">模号</th>
+    <th style="width:120px">模胚类型</th>
+    <th style="width:100px">模具结构</th>
+    <th style="width:70px">材质</th>
+    <th style="width:70px">颜色</th>
+    <th style="width:80px">出模数</th>
+    <th style="width:60px">套数</th>
+    <th style="width:90px">净重(g)</th>
+    <th style="width:80px">周期(秒)</th>
+    <th style="width:110px">模具尺寸</th>
+    <th style="width:240px">图  片</th>
+    <th style="width:120px">模具价格 RMB</th>
+    <th style="width:120px">模价 HKD</th>
+    <th>备  注</th>
+    ${canEdit ? '<th style="width:40px"></th>' : ''}
+  </tr></thead><tbody></tbody>`;
+  const tbody = table.querySelector('tbody');
+
+  const fields = [
+    ['name', 'textarea'],
+    ['mold_no', 'text'],
+    ['mold_type', 'textarea'],
+    ['structure', 'text'],
+    ['material', 'text'], ['color', 'text'], ['cavity', 'text'], ['sets', 'number'],
+    ['weight_g', 'number'],
+    ['cycle_sec', 'number'],
+    ['mold_size', 'text', 'detail'],
+    null, // 图片列
+    ['price_rmb', 'number'],
+    ['price_hkd', 'calc_hkd'],  // 模价 HKD = 模价RMB ÷ 汇率（只读）
+    ['note', 'textarea'],
+  ];
+  const fxv = num(fxRmbHkd) || 0.85;  // RMB→HKD 汇率
+
+  // 数据迁移：备注内容提取为模胚类型（仅当模胚类型为空时，避免覆盖导入的模胚型号如 CI 3040）
+  molds.forEach(m => {
+    if (m.note && !String(m.mold_type || '').trim()) { m.mold_type = m.note; m.note = ''; }
+  });
+
+  molds.forEach((m, idx) => {
+    const tr = document.createElement('tr');
+    // 序号
+    const tdNo = document.createElement('td'); tdNo.className = 'ro'; tdNo.textContent = idx + 1; tr.appendChild(tdNo);
+
+    fields.forEach((f) => {
+      const td = document.createElement('td');
+      if (f === null) {
+        // 图片单元格
+        td.className = 'mold-img-cell';
+        renderImageCell(td, m, canEdit, onChange);
+      } else {
+        const [k, type, group] = f;
+        const obj = group ? (m[group] = m[group] || {}) : m;
+        const get = () => obj[k];
+        const set = (v) => { obj[k] = v; };
+        if (type === 'calc_hkd') {
+          td.className = 'ro'; td.textContent = formatNum(num(m.price_rmb) / fxv);
+        } else if (!canEdit) {
+          td.className = 'ro'; td.style.whiteSpace = 'pre-wrap'; td.textContent = formatNum(get() ?? '');
+        } else if (type === 'textarea') {
+          const ta = document.createElement('textarea');
+          ta.rows = 3; ta.value = get() ?? '';
+          ta.style.resize = 'vertical';
+          const autoSize = () => { ta.style.height = 'auto'; ta.style.height = (ta.scrollHeight + 2) + 'px'; };
+          ta.oninput = () => { set(ta.value); autoSize(); onChange(); };
+          td.appendChild(ta);
+          setTimeout(autoSize, 0);
+        } else {
+          const inp = document.createElement('input');
+          inp.type = type === 'number' ? 'number' : 'text';
+          if (type === 'number') inp.step = 'any';
+          inp.value = get() ?? '';
+          inp.oninput = () => {
+            set(type === 'number' ? (inp.value === '' ? null : Number(inp.value)) : inp.value);
+            onChange();
+          };
+          td.appendChild(inp);
+        }
+      }
+      tr.appendChild(td);
+    });
+
+    if (canEdit) {
+      const td = document.createElement('td');
+      const b = document.createElement('button'); b.textContent = '×'; b.className = 'mini danger';
+      b.onclick = () => { molds.splice(idx, 1); renderMolds(container, molds, onChange, canEdit); onChange(); };
+      td.appendChild(b); tr.appendChild(td);
+    }
+    tbody.appendChild(tr);
+  });
+
+  // 小计：RMB / HKD 同行，分别对齐 价格RMB / 价格HKD 列
+  const rmbTotal = sum(molds, m => num(m.price_rmb));
+  const hkdTotal = rmbTotal / fxv;
+  const extra = canEdit ? '<td></td>' : '';
+  const trSub = document.createElement('tr'); trSub.className = 'hi';
+  trSub.innerHTML = `<td colspan="13" style="text-align:right">小计 <span class="muted" style="font-weight:normal;font-size:12px">(汇率 ${fxv})</span></td>
+    <td>${formatNum(rmbTotal)}</td><td>${formatNum(hkdTotal)}</td><td></td>${extra}`;
+  tbody.appendChild(trSub);
+
+  container.appendChild(table);
+  if (canEdit) {
+    const add = document.createElement('button');
+    add.textContent = '+ 新增模具行'; add.className = 'mini';
+    add.style.marginTop = '8px';
+    add.onclick = () => { molds.push({ images: [] }); renderMolds(container, molds, onChange, canEdit); onChange(); };
+    container.appendChild(add);
+  }
+}
+
+function renderImageCell(td, m, canEdit, onChange) {
+  td.innerHTML = '';
+  const wrap = document.createElement('div'); wrap.className = 'cell-imgs';
+  (m.images || []).forEach((u, i) => {
+    const box = document.createElement('div'); box.className = 'cell-img';
+    box.innerHTML = `<img src="/${u}" />${canEdit ? `<button class="mini danger img-del">×</button>` : ''}`;
+    if (canEdit) box.querySelector('.img-del').onclick = () => { m.images.splice(i, 1); renderImageCell(td, m, canEdit, onChange); onChange(); };
+    box.querySelector('img').onclick = () => window.open('/' + u, '_blank');
+    wrap.appendChild(box);
+  });
+  if (canEdit) {
+    const lbl = document.createElement('label'); lbl.className = 'cell-img add';
+    lbl.innerHTML = '+<input type="file" accept="image/*" hidden />';
+    lbl.querySelector('input').onchange = async (e) => {
+      const f = e.target.files[0]; if (!f) return;
+      try {
+        const fd = new FormData(); fd.append('file', f);
+        const r = await fetch('/api/uploads/mold-image', { method: 'POST', credentials: 'include', body: fd });
+        const j = await r.json();
+        if (!r.ok) throw new Error(j.error);
+        m.images = m.images || []; m.images.push(j.url);
+        renderImageCell(td, m, canEdit, onChange); onChange();
+      } catch (err) { alert('上传失败: ' + err.message); }
+    };
+    wrap.appendChild(lbl);
+  }
+  td.appendChild(wrap);
+}
+
+// ==================== 电子部分：两级表（顶层 + 可展开子明细） ====================
+function elecRowAmount(r) {
+  if (Array.isArray(r.children) && r.children.length > 0) {
+    return sum(r.children, ch => num(ch.qty) * num(ch.unit_price));
+  }
+  return num(r.qty) * num(r.unit_price);
+}
+
+function renderHierElectronics(container, rows, onChange, canEdit, fxRmbHkd) {
+  const fx = num(fxRmbHkd) || 0.85;
+  container.innerHTML = '';
+  const table = document.createElement('table'); table.className = 'wb-table hier-table';
+  table.innerHTML = `<thead><tr>
+    <th style="width:30px"></th>
+    <th style="width:40px">#</th>
+    <th>零件名称</th>
+    <th>规格</th>
+    <th style="width:70px">用量</th>
+    <th style="width:90px">单价 HKD</th>
+    <th style="width:90px">金额 HKD</th>
+    <th style="width:80px">税点 %</th>
+    <th>备注</th>
+    ${canEdit ? '<th style="width:36px"></th>' : ''}
+  </tr></thead><tbody></tbody>`;
+  const tbody = table.querySelector('tbody');
+  if (!Array.isArray(rows)) rows = [];
+
+  rows.forEach((row, idx) => {
+    row.children = row.children || [];
+    const hasChildren = row.children.length > 0;
+    const tr = document.createElement('tr'); tr.className = 'hier-parent';
+
+    // 展开 / 收起按钮
+    const tdExp = document.createElement('td'); tdExp.className = 'ro';
+    if (canEdit || hasChildren) {
+      const btn = document.createElement('button'); btn.className = 'mini'; btn.textContent = row._open ? '▼' : '▶';
+      btn.title = '展开/收起子明细'; btn.style.padding = '2px 6px';
+      btn.onclick = () => { row._open = !row._open; renderHierElectronics(container, rows, onChange, canEdit); };
+      tdExp.appendChild(btn);
+    }
+    tr.appendChild(tdExp);
+
+    // 序号
+    const tdNo = document.createElement('td'); tdNo.className = 'ro'; tdNo.textContent = idx + 1; tr.appendChild(tdNo);
+
+    // 名称 / 规格
+    const cellTexts = ['name', 'spec'];
+    cellTexts.forEach(k => {
+      const td = document.createElement('td');
+      if (canEdit) {
+        const inp = document.createElement('input'); inp.type = 'text'; inp.value = row[k] ?? '';
+        inp.oninput = () => { row[k] = inp.value; onChange(); }; td.appendChild(inp);
+      } else { td.className = 'ro'; td.textContent = row[k] ?? ''; }
+      tr.appendChild(td);
+    });
+
+    // 用量 / 单价 / 金额
+    const tdQty = document.createElement('td');
+    const tdUp = document.createElement('td');
+    const tdAmt = document.createElement('td'); tdAmt.className = 'ro';
+    const refreshAmt = () => { tdAmt.textContent = formatNum(elecRowAmount(row)); };
+    if (canEdit && !hasChildren) {
+      const inpQ = document.createElement('input'); inpQ.type = 'number'; inpQ.step = 'any'; inpQ.value = row.qty ?? '';
+      inpQ.oninput = () => { row.qty = inpQ.value === '' ? null : Number(inpQ.value); refreshAmt(); onChange(); };
+      tdQty.appendChild(inpQ);
+      const inpP = document.createElement('input'); inpP.type = 'number'; inpP.step = 'any'; inpP.value = row.unit_price ?? '';
+      inpP.oninput = () => { row.unit_price = inpP.value === '' ? null : Number(inpP.value); refreshAmt(); onChange(); };
+      tdUp.appendChild(inpP);
+    } else {
+      // 有子项时 用量/单价 由子项推导（用量保留，单价 = 金额 / 用量）
+      tdQty.className = 'ro'; tdQty.textContent = formatNum(row.qty ?? '');
+      const amt = elecRowAmount(row);
+      const up = num(row.qty) > 0 ? amt / num(row.qty) : amt;
+      tdUp.className = 'ro'; tdUp.textContent = formatNum(up);
+    }
+    refreshAmt();
+    tr.appendChild(tdQty); tr.appendChild(tdUp); tr.appendChild(tdAmt);
+
+    // 备注列已隐藏（电子部 总表只显示 HKD 含税价）
+    // 税点：含税 / 不含税 下拉（切换时 单价 HKD = 对应 RMB ÷ 汇率）
+    const tdTax = document.createElement('td');
+    const TAX_OPTS = ['含税', '不含税'];
+    const taxVal = TAX_OPTS.includes(row.tax_label) ? row.tax_label : '含税';
+    row.tax_label = taxVal;
+    if (canEdit) {
+      const sel = document.createElement('select');
+      TAX_OPTS.forEach(o => {
+        const op = document.createElement('option'); op.value = o; op.textContent = o;
+        if (o === taxVal) op.selected = true;
+        sel.appendChild(op);
+      });
+      sel.onchange = () => {
+        row.tax_label = sel.value;
+        const rmb = sel.value === '含税' ? row._unit_price_taxed : row._unit_price_pretax;
+        if (rmb != null) row.unit_price = +(rmb / fx).toFixed(6);
+        onChange();
+        renderHierElectronics(container, rows, onChange, canEdit, fxRmbHkd);
+      };
+      tdTax.appendChild(sel);
+    } else { tdTax.className = 'ro'; tdTax.textContent = taxVal; }
+    tr.appendChild(tdTax);
+
+    // 备注（自由文本）
+    const tdNote = document.createElement('td');
+    if (canEdit) {
+      const inp = document.createElement('input'); inp.type = 'text'; inp.value = row.note ?? '';
+      inp.oninput = () => { row.note = inp.value; onChange(); };
+      tdNote.appendChild(inp);
+    } else { tdNote.className = 'ro'; tdNote.textContent = row.note ?? ''; }
+    tr.appendChild(tdNote);
+
+    // 删除
+    if (canEdit) {
+      const td = document.createElement('td');
+      const b = document.createElement('button'); b.textContent = '×'; b.className = 'mini danger';
+      b.onclick = () => { rows.splice(idx, 1); renderHierElectronics(container, rows, onChange, canEdit); onChange(); };
+      td.appendChild(b); tr.appendChild(td);
+    }
+    tbody.appendChild(tr);
+
+    // 展开后渲染子项
+    if (row._open) {
+      const trChild = document.createElement('tr'); trChild.className = 'hier-child-row';
+      const td = document.createElement('td'); td.colSpan = canEdit ? 9 : 8;
+      td.appendChild(renderHierChildren(row.children, () => { refreshAmt(); onChange(); }, canEdit));
+      trChild.appendChild(td);
+      tbody.appendChild(trChild);
+    }
+  });
+  container.appendChild(table);
+
+  if (canEdit) {
+    const btn = document.createElement('button'); btn.className = 'mini'; btn.textContent = '+ 新增电子件';
+    btn.style.marginTop = '8px';
+    btn.onclick = () => { rows.push({ name: '', qty: 1, unit_price: 0, children: [] }); renderHierElectronics(container, rows, onChange, canEdit); onChange(); };
+    container.appendChild(btn);
+  }
+}
+
+function renderHierChildren(children, onParentChange, canEdit) {
+  const wrap = document.createElement('div'); wrap.className = 'hier-children';
+  function rebuild() {
+    wrap.innerHTML = '';
+    buildContent();
+  }
+  function buildContent() {
+  const t = document.createElement('table'); t.className = 'wb-table';
+  t.innerHTML = `<thead><tr>
+    <th style="width:40px">#</th>
+    <th>子项名称</th>
+    <th>规格</th>
+    <th style="width:70px">用量</th>
+    <th style="width:90px">单价</th>
+    <th style="width:90px">金额</th>
+    <th>备注</th>
+    ${canEdit ? '<th style="width:36px"></th>' : ''}
+  </tr></thead><tbody></tbody>`;
+  const tb = t.querySelector('tbody');
+  children.forEach((c, ci) => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td class="ro">${ci + 1}</td>`;
+    const tdAmt = document.createElement('td'); tdAmt.className = 'ro';
+    const refresh = () => { tdAmt.textContent = formatNum(num(c.qty) * num(c.unit_price)); };
+    ['name', 'spec'].forEach(k => {
+      const td = document.createElement('td');
+      if (canEdit) { const i = document.createElement('input'); i.value = c[k] ?? ''; i.oninput = () => { c[k] = i.value; onParentChange(); }; td.appendChild(i); }
+      else { td.className = 'ro'; td.textContent = c[k] ?? ''; }
+      tr.appendChild(td);
+    });
+    const tdQ = document.createElement('td');
+    if (canEdit) { const i = document.createElement('input'); i.type='number'; i.step='any'; i.value = c.qty ?? ''; i.oninput = () => { c.qty = i.value===''?null:Number(i.value); refresh(); onParentChange(); }; tdQ.appendChild(i); }
+    else { tdQ.className='ro'; tdQ.textContent = formatNum(c.qty ?? ''); }
+    const tdP = document.createElement('td');
+    if (canEdit) { const i = document.createElement('input'); i.type='number'; i.step='any'; i.value = c.unit_price ?? ''; i.oninput = () => { c.unit_price = i.value===''?null:Number(i.value); refresh(); onParentChange(); }; tdP.appendChild(i); }
+    else { tdP.className='ro'; tdP.textContent = formatNum(c.unit_price ?? ''); }
+    refresh();
+    const tdN = document.createElement('td');
+    if (canEdit) { const i = document.createElement('input'); i.value = c.note ?? ''; i.oninput = () => { c.note = i.value; onParentChange(); }; tdN.appendChild(i); }
+    else { tdN.className='ro'; tdN.textContent = c.note ?? ''; }
+    tr.appendChild(tdQ); tr.appendChild(tdP); tr.appendChild(tdAmt); tr.appendChild(tdN);
+    if (canEdit) {
+      const td = document.createElement('td');
+      const b = document.createElement('button'); b.textContent='×'; b.className='mini danger';
+      b.onclick = () => { children.splice(ci, 1); onParentChange(); rebuild(); };
+      td.appendChild(b); tr.appendChild(td);
+    }
+    tb.appendChild(tr);
+  });
+  // 合计行
+  const trTot = document.createElement('tr'); trTot.className = 'hi';
+  trTot.innerHTML = `<td colspan="5" style="text-align:right">合计</td>
+    <td>${formatNum(sum(children, c => num(c.qty) * num(c.unit_price)))}</td><td></td>${canEdit?'<td></td>':''}`;
+  tb.appendChild(trTot);
+  wrap.appendChild(t);
+  if (canEdit) {
+    const btn = document.createElement('button'); btn.className='mini'; btn.textContent='+ 新增子项'; btn.style.marginTop='6px';
+    btn.onclick = () => { children.push({ name:'', qty:1, unit_price:0 }); rebuild(); onParentChange(); };
+    wrap.appendChild(btn);
+  }
+  }
+  buildContent();
+  return wrap;
+}
+
+function renderElecExtra(host, payload, onChange, canEdit, fxRmbHkd) {
+  const fx = num(fxRmbHkd) || 0.85;
+  const x = payload.electronics_extra;
+  // 默认初始化新字段
+  ['bonding_cost', 'smt_cost', 'labor_cost'].forEach(k => { if (x[k] == null) x[k] = 0; });
+  // 零件成本 优先用 细表（导入明细）；没有细表才回退用 总表
+  const computePartsFromDoc = () => {
+    const doc = payload.electronics_doc;
+    if (!doc || !doc.parts || !doc.parts.length) return null;
+    return sum(doc.parts, p => num(p.qty) * num(p.unit_price)
+      + sum(p.children || [], c => num(c.qty) * num(c.unit_price)));
+  };
+  const partsRaw = computePartsFromDoc() ?? sum(payload.electronics || [], elecRowAmount);
+  const partsAfterLoss = partsRaw;  // 不计损耗
+  const costBeforeTax = partsAfterLoss + num(x.bonding_cost) + num(x.smt_cost) + num(x.labor_cost)
+    + num(x.test_repair) + num(x.packing_shipping); // 成本合计(不含税)
+  const profitPrice = costBeforeTax * (1 + num(x.profit_pct)/100); // 含利润价
+  const taxPayableAuto = num(x.tax_diff) * 0.1; // 应交税负 = 抵税差额 × 10%
+  x.tax_payable = taxPayableAuto;
+  const taxed = profitPrice + num(x.tax_diff) + taxPayableAuto; // 含税核价
+  host.innerHTML = `
+    <div class="card" style="background:#f9fafb;margin-top:12px">
+      <h3 style="margin-top:0">电子 成本汇总（RMB）</h3>
+      <div class="wb-grid2">
+        <label><span>零件成本</span><input value="${formatNum(partsAfterLoss)}" disabled></label>
+        <label><span>邦定成本</span><input id="elx-bond" type="number" step="any" value="${x.bonding_cost}" ${canEdit?'':'disabled'}></label>
+        <label><span>贴片成本</span><input id="elx-smt" type="number" step="any" value="${x.smt_cost}" ${canEdit?'':'disabled'}></label>
+        <label><span>人工成本</span><input id="elx-labor" type="number" step="any" value="${x.labor_cost}" ${canEdit?'':'disabled'}></label>
+        <label><span>测试费用</span><input id="elx-test" type="number" step="any" value="${x.test_repair}" ${canEdit?'':'disabled'}></label>
+        <label><span>包装运输</span><input id="elx-pack" type="number" step="any" value="${x.packing_shipping}" ${canEdit?'':'disabled'}></label>
+        <label><span><b>成本合计（不含税）</b></span><input value="${formatNum(costBeforeTax)}" disabled style="font-weight:600;background:#fef3c7"></label>
+        <label><span>利润 %</span><input id="elx-profit" type="number" step="any" value="${x.profit_pct}" ${canEdit?'':'disabled'}></label>
+        <label><span><b>含利润价</b></span><input value="${formatNum(profitPrice)}" disabled style="font-weight:600;background:#fef3c7"></label>
+        <label><span></span></label>
+        <label><span>抵税差额</span><input id="elx-taxdiff" type="number" step="any" value="${x.tax_diff}" ${canEdit?'':'disabled'}></label>
+        <label><span>应交税负 <small class="muted">= 抵税差额 × 10%</small></span><input id="elx-taxpay" value="${formatNum(x.tax_payable)}" disabled></label>
+        <label><span><b>含税核价 RMB</b></span><input value="${formatNum(taxed)}" disabled style="font-weight:700;background:#dcfce7;color:#166534"></label>
+        <label><span><b>含税核价 HKD</b></span><input value="${formatNum(taxed / fx)} (汇率 ${fx})" disabled style="font-weight:700;background:#dcfce7;color:#166534"></label>
+      </div>
+    </div>`;
+  // 引用所有只读结果字段，输入时局部刷新（不重建整块，避免输入框失焦）
+  const inputs = host.querySelectorAll('.wb-grid2 input[disabled]');
+  // 顺序对应 grid 中的 6 个 disabled input：成本合计(零件+人工)、成本合计(不含税)、含利润价、含税核价 RMB、含税核价 HKD
+  // 直接按 DOM 顺序索引：0=零件+人工 1=不含税 2=含利润 3=含税RMB 4=含税HKD
+  function refreshComputed() {
+    const partsRaw2 = computePartsFromDoc() ?? sum(payload.electronics || [], elecRowAmount);
+    const partsLoss2 = partsRaw2;  // 不计损耗
+    const cost2 = partsLoss2 + num(x.bonding_cost) + num(x.smt_cost) + num(x.labor_cost)
+      + num(x.test_repair) + num(x.packing_shipping);
+    const profit2 = cost2 * (1 + num(x.profit_pct)/100);
+    x.tax_payable = num(x.tax_diff) * 0.1;
+    const taxed2 = profit2 + num(x.tax_diff) + x.tax_payable;
+    inputs[0].value = formatNum(partsLoss2);  // 零件成本
+    inputs[1].value = formatNum(cost2);       // 不含税
+    inputs[2].value = formatNum(profit2);     // 含利润价
+    inputs[3].value = formatNum(x.tax_payable); // 应交税负 (auto)
+    inputs[4].value = formatNum(taxed2);      // 含税核价 RMB
+    inputs[5].value = `${formatNum(taxed2 / fx)} (汇率 ${fx})`;
+  }
+  if (canEdit) {
+    const bind = (id, key) => { host.querySelector(id).oninput = (e) => { x[key] = e.target.value === '' ? null : Number(e.target.value); refreshComputed(); onChange(); }; };
+    bind('#elx-bond', 'bonding_cost');
+    bind('#elx-smt', 'smt_cost');
+    bind('#elx-labor', 'labor_cost');
+    bind('#elx-test', 'test_repair');
+    bind('#elx-pack', 'packing_shipping');
+    bind('#elx-profit', 'profit_pct');
+    bind('#elx-taxdiff', 'tax_diff');
+  }
+}
+
+// 通用：小计/损耗/合计 紧凑竖排（返回 refresh fn）
+function renderLossSummary(host, title, getRawSum, getLossPct, fxRmbHkd, currency) {
+  const fx = num(fxRmbHkd) || 0.85;
+  const isHkd = currency === 'HKD';
+  const card = document.createElement('div'); card.className = 'loss-summary';
+  host.appendChild(card);
+  function paint() {
+    const raw = typeof getRawSum === 'function' ? getRawSum() : num(getRawSum);
+    const loss = typeof getLossPct === 'function' ? getLossPct() : num(getLossPct);
+    const total = raw * (1 + loss/100);
+    const primary = isHkd
+      ? `<div class="ls-row hi"><span class="ls-label">合计 HKD</span><span class="ls-val">${formatNum(total)}</span></div>`
+      : `<div class="ls-row hi"><span class="ls-label">合计 RMB</span><span class="ls-val">${formatNum(total)}</span></div>
+         <div class="ls-row hi"><span class="ls-label">合计 HKD</span><span class="ls-val">${formatNum(total / fx)} <small class="muted">(汇率 ${fx})</small></span></div>`;
+    card.innerHTML = `
+      ${title ? `<div class="ls-title">${title}</div>` : ''}
+      <div class="ls-row"><span class="ls-label">小计</span><span class="ls-val">${formatNum(raw)}</span></div>
+      ${loss ? `<div class="ls-row"><span class="ls-label">损耗</span><span class="ls-val">${loss.toFixed(2)}%</span></div>` : ''}
+      ${primary}`;
+  }
+  paint();
+  return paint;
+}
+
+function renderHwExtra(host, payload, onChange, canEdit, fxRmbHkd) {
+  host.innerHTML = '';
+  return renderLossSummary(host, '五金 成本汇总',
+    () => sum(payload.hardware || [], r => num(r.qty) * num(r.unit_price)),
+    () => 0, fxRmbHkd, 'HKD');  // 五金不计损耗；五金表为港币
+}
+
+// ==================== 部门工作台 ====================
+function renderMoldCosts(host, mc, onChange, canEdit) {
+  function paint() {
+    const sumRmb = sum(mc.items, r => num(r.price_rmb));
+    const fx = num(mc.fx_rmb_usd) || 7.75;
+    const sumUsd = sumRmb / fx;
+    const customerUsd = num(mc.customer_subsidy_usd);
+    const netUsd = sumUsd - customerUsd;
+    const qty = Math.max(num(mc.amortization_qty), 1);
+    const perPcsRmb = sumRmb / qty;
+    const perPcsUsd = netUsd / qty;
+
+    host.innerHTML = `
+      <table class="wb-table" style="max-width:680px">
+        <thead><tr>
+          <th style="width:200px">模具名称</th>
+          <th style="width:140px">模价 (RMB)</th>
+          <th style="width:140px">模价 (USD)</th>
+          ${canEdit ? '<th style="width:36px"></th>' : ''}
+        </tr></thead>
+        <tbody>
+          ${mc.items.map((r, i) => `
+            <tr>
+              <td>${canEdit ? `<input class="mc-name" data-i="${i}" value="${r.name || ''}">` : (r.name || '')}</td>
+              <td>${canEdit ? `<input class="mc-rmb" data-i="${i}" type="number" step="any" value="${r.price_rmb ?? 0}">` : formatNum(num(r.price_rmb))}</td>
+              <td class="ro">${formatNum(num(r.price_rmb) / fx)}</td>
+              ${canEdit ? `<td><button class="mini danger mc-del" data-i="${i}">×</button></td>` : ''}
+            </tr>`).join('')}
+          <tr class="hi"><td>模具总计</td><td>${formatNum(sumRmb)}</td><td>${formatNum(sumUsd)}</td>${canEdit ? '<td></td>' : ''}</tr>
+          <tr><td>客补贴模费美金</td><td></td><td>${canEdit ? `<input id="mc-sub" type="number" step="any" value="${mc.customer_subsidy_usd ?? 0}">` : formatNum(customerUsd)}</td>${canEdit ? '<td></td>' : ''}</tr>
+          <tr class="hi"><td>模费按 <input id="mc-qty" type="number" step="any" value="${mc.amortization_qty}" style="width:90px" ${canEdit?'':'disabled'}> 套产品分摊</td><td>${formatNum(perPcsRmb)}</td><td>${formatNum((sumUsd - customerUsd) / qty)}</td>${canEdit ? '<td></td>' : ''}</tr>
+        </tbody>
+      </table>
+      ${canEdit ? `<div style="margin-top:8px;display:flex;gap:10px;align-items:center">
+        <button class="mini" id="mc-add">+ 增加费用行</button>
+        <label style="font-size:13px;color:#6b7280">RMB→USD 汇率 <input id="mc-fx" type="number" step="any" value="${mc.fx_rmb_usd}" style="width:80px"></label>
+      </div>` : ''}
+    `;
+
+    if (!canEdit) return;
+    host.querySelectorAll('.mc-name').forEach(el => el.oninput = () => { mc.items[+el.dataset.i].name = el.value; onChange(); });
+    host.querySelectorAll('.mc-rmb').forEach(el => {
+      el.oninput = () => { mc.items[+el.dataset.i].price_rmb = el.value === '' ? null : Number(el.value); onChange(); };
+      el.onblur = () => paint();
+    });
+    host.querySelectorAll('.mc-del').forEach(el => el.onclick = () => { mc.items.splice(+el.dataset.i, 1); onChange(); paint(); });
+    host.querySelector('#mc-sub').oninput = (e) => { mc.customer_subsidy_usd = num(e.target.value); onChange(); };
+    host.querySelector('#mc-sub').onblur = () => paint();
+    host.querySelector('#mc-qty').oninput = (e) => { mc.amortization_qty = num(e.target.value); onChange(); };
+    host.querySelector('#mc-qty').onblur = () => paint();
+    host.querySelector('#mc-fx').oninput = (e) => { mc.fx_rmb_usd = num(e.target.value); onChange(); };
+    host.querySelector('#mc-fx').onblur = () => paint();
+    host.querySelector('#mc-add').onclick = () => { mc.items.push({ name: '', price_rmb: 0 }); onChange(); paint(); };
+  }
+  paint();
+}
+
+// ============== 汇总面板 ==============
+function renderSummaryPane(host, sections, quote, me) {
+  const get = (dept) => {
+    const s = sections.find(x => x.dept === dept);
+    return s && s.payload_json ? JSON.parse(s.payload_json) : {};
+  };
+  const eng = get('engineering');
+  const mold = get('molding');
+  const pnt = get('painting');
+  const asm = get('assembly');
+  const sales = get('sales');
+  const slush = get('slush');
+  const sewing = get('sewing');
+  const electronic = get('electronic');
+  const fxRH = num(sales.header?.fx_rmb_hkd) || 0.85;
+  const fxHU = num(sales.header?.fx_hkd_usd) || 7.8;
+
+  // 电子明细：优先用「电子部」section，回退工程部（与导出一致）
+  const elecSrc = (electronic.electronics && electronic.electronics.length) ? electronic.electronics : (eng.electronics || []);
+
+  // 各部门关键合计
+  const moldTotal = sum(eng.molds || [], m => num(m.price_rmb));
+  const elecRaw = sum(elecSrc, elecRowAmount);  // 不算损耗（与导出同源：电子部优先）
+  const hwRaw = sum(eng.hardware || [], r => num(r.qty)*num(r.unit_price));  // 五金不计损耗（与导出一致）
+  const auxRaw = sum(eng.aux_materials || [], r => num(r.qty)*num(r.unit_price));  // 不计损耗
+  const pkmatRaw = sum(eng.packaging_materials || [], r => num(r.qty)*num(r.unit_price));  // 不计损耗
+  const _injLossM = 1 + num(mold.injection_loss_pct ?? 3) / 100;  // 注塑料损耗（默认3%）
+  const injTotal = sum(mold.injection || [], r => num(r.weight_g) * _injLossM * num(r.material_unit_price) + num(r.shot_price));
+  const injRaw = injTotal / _injLossM; // 留作兼容（部分老逻辑可能引用）
+  const blowTotal = sum(mold.blow_items || [], r => {
+    const mat = num(r.weight_g)*num(r.material_price_lb)/454;
+    return (mat + num(r.blow_labor) + num(r.flash)) * (num(r.profit_x) || 1);
+  });
+  const ppTotal = sum(pnt.painting_items || [], r => ['clamp','pad','spray','edge','oil'].reduce((s,k)=>s+num(r[k+'_qty'])*num(r[k+'_unit']),0));  // 不计损耗
+  const slushTotal = sum(slush.slush_items || [], r => num(r.unit_price_hkd)*num(r.qty));
+  const asmLaborTotal = sum(asm.assembly_labor || [], r => num(r.unit_price)*num(r.qty));
+  const pkLaborTotal = sum(asm.packaging_labor || [], r => num(r.unit_price)*num(r.qty));
+  // 新版 排拉工序 组装 + 包装 — 每组合计 = 基数 × 人数 ÷ 该组生产量
+  const _asmBase = num(asm.assembly_base_rate ?? 310);
+  const stepGroupTotal = (groups) => sum(groups || [], g =>
+    sum(g.steps || [], s => _asmBase * num(s.count) / Math.max(num(g.qty), 1)));
+  const asmStepTotal = stepGroupTotal(asm.assembly_step_groups);
+  const pkgStepTotal = stepGroupTotal(asm.packaging_step_groups);
+  const combinedAsmHkd = asmLaborTotal + pkLaborTotal + asmStepTotal + pkgStepTotal;  // 装配人工为港币(基数310 HKD)
+
+  const rows = [
+    { label: '工程 — 模具总价', rmb: moldTotal, unit: '套数总和' },
+    { label: '工程 — 电子', rmb: elecRaw, unit: '不计损耗' },
+    { label: '工程 — 五金', rmb: hwRaw, unit: '不计损耗' },
+    { label: '工程 — 辅助材料', rmb: auxRaw, unit: '不计损耗' },
+    { label: '工程 — 包装材料', rmb: pkmatRaw, unit: '不计损耗' },
+    { label: '啤机 — 注塑合计', hkd: injTotal, unit: 'HK$/PCS' },
+    { label: '啤机 — 吹气合计', hkd: blowTotal, unit: 'HK$/PCS' },
+    { label: '喷油 — 二次加工', rmb: ppTotal, unit: '不计损耗' },
+    { label: '搪胶合计', hkd: slushTotal, unit: 'HK$' },
+    { label: '装配 — 组装人工', rmb: asmLaborTotal, unit: '元/PCS' },
+    { label: '装配 — 包装人工', rmb: pkLaborTotal, unit: '元/PCS' },
+  ];
+
+  // 九、合计 数据
+  const pricing = sales.pricing || {};
+  // 运输费 = 减税明细 顶部手填的 印尼运费 (HKD) — 注意 toHkd 会再除一次汇率，所以这里存成 RMB 等价
+  const shipping = num(sales.pricing_summary?.indo_freight) * fxRH;
+  const hwTotal = hwRaw;
+  const electronicTotal = elecRaw;
+  // 注塑是 HKD，先换算 RMB（其他都是 RMB）
+  const injTotalRmb = injTotal * fxRH;
+  // 模具分摊：从工程"模具费用"表取 套产品分摊 (sum(items.price_rmb) / amortization_qty)
+  const mc = eng.mold_costs || {};
+  const moldCostSumRmb = sum(mc.items || [], r => num(r.price_rmb));
+  const moldAmortQty = Math.max(num(mc.amortization_qty) || num(pricing.mold_amortization_qty) || num(quote.qty), 1);
+  const moldShare = moldCostSumRmb / moldAmortQty;
+  const slushTotalRmb = slushTotal * fxRH;
+  const sewingGroupAmount = (g) => sum(g.items || [], r => num(r.usage) * num(r.mat_price) * (num(r.markup) || 1)) + num(g.labor_amount);
+  const sewingTotalRmb = sum(sewing.sewing_groups || [], sewingGroupAmount);  // 不再乘损耗，与 UI 配套合计 一致
+  // 按 category 分车衣/车发
+  const sewingHairRmb = sum((sewing.sewing_groups || []).filter(g => g.category === '车发'), sewingGroupAmount);
+  const sewingClothRmb = sewingTotalRmb - sewingHairRmb;
+  // 多纸箱 + 多平卡：Σ((箱价i + Σ平卡价i_j) / qty_i) × 汇率
+  const ccc = eng.carton_calc || {};
+  const cartonList = (ccc.cartons && ccc.cartons.length) ? ccc.cartons : (ccc.cl ? [{
+    cl: ccc.cl, cw: ccc.cw, ch: ccc.ch, qty: ccc.qty,
+    flat_cards: ccc.flat_card ? [{ l: ccc.cl, w: ccc.cw }] : [],
+  }] : []);
+  const cartonRmb = cartonList.reduce((s, b) => {
+    const boxPrice = (num(b.cl) + num(b.cw) + 2) * (num(b.cw) + num(b.ch) + 1) * 2 * 2.8 / 1000;
+    const flatSum = (b.flat_cards || []).reduce((a, f) => a + (num(f.l) + 1) * (num(f.w) + 1) * 2 / 1000, 0);
+    const q = Math.max(num(b.qty), 1);
+    return s + (boxPrice + flatSum) / q;
+  }, 0) * fxRH;
+
+  // 附加税：用户手填，存到 sales.pricing_summary.surtax
+  sales.pricing_summary = sales.pricing_summary || {};
+  const surtaxManual = num(sales.pricing_summary.surtax);
+
+  // cost 包含搪胶/车缝/纸箱；附加税 + 模具分摊 在 markup 外面单独加
+  const blowRmb = blowTotal * fxRH;
+  // 电子/五金/辅助/包装 四表均为港币(HKD)，换算回 RMB 加入成本：×汇率
+  // 电子/五金/辅助/包装/二次加工(喷油) 均为港币(HKD)，换算回 RMB：×汇率
+  const cost = injTotalRmb + blowRmb + (electronicTotal + hwTotal + auxRaw + pkmatRaw + ppTotal + combinedAsmHkd) * fxRH + shipping + slushTotalRmb + sewingTotalRmb + cartonRmb;  // 装配人工(排拉合计)也是港币，×汇率还原 RMB
+  // 出厂价底价：cost × markups（不含附加税 + 模具分摊）
+  const factoryRmb = cost;
+  const factoryHkd = factoryRmb / fxRH;
+  // 出货底价：含附加税 + 模具分摊（盐田40柜/5吨车的底价）
+  const priceRmb = factoryRmb + moldShare + surtaxManual;
+  const priceHkd = priceRmb / fxRH;
+  // 九、合计 整行换成 HKD（RMB ÷ 汇率）
+  const fxH = fxRH || 0.85;
+  const toHkd = (rmb) => num(rmb) / fxH;
+  const markupX = num(sales.shipping?.markup_x) || 1.2;
+  const afterMarkupHkd = factoryHkd * markupX;
+  // 出货底价 改为基于 码点后价（HKD）+ 模具分摊 + 附加税
+  const priceHkdMarked = afterMarkupHkd + toHkd(moldShare) + toHkd(surtaxManual);
+  const totalsCols = [
+    ['注塑+吹气', toHkd(injTotalRmb + blowTotal * fxRH)], ['二次加工', ppTotal], ['电子五金', electronicTotal + hwTotal],
+    ['辅助材料', auxRaw], ['包装材料', pkmatRaw], ['组装人工', asmLaborTotal + asmStepTotal], ['包装/混装人工', pkLaborTotal + pkgStepTotal],
+    ['印尼运费', toHkd(shipping)],
+    ['搪胶', toHkd(slushTotalRmb)], ['车缝', toHkd(sewingTotalRmb)], ['纸箱', toHkd(cartonRmb)],
+    ['出厂价 HKD', factoryHkd, 'sub-hkd'],
+    ['码点', markupX, 'mult'],
+    ['码点后价 HKD', afterMarkupHkd, 'sub-hkd'],
+    ['模具分摊', toHkd(moldShare)], ['附加税0.4%', surtaxManual, 'input'],
+    ['出货底价 HKD', priceHkdMarked, 'hkd'],
+  ];
+
+  host.innerHTML = `
+    <h2>📊 九、合计（自动汇总）</h2>
+    <div style="overflow-x:auto;margin-bottom:20px">
+      <table class="wb-table" style="font-size:12px">
+        <thead><tr>${totalsCols.map(([h]) => `<th style="background:#F0DBA1;color:#1F2937;font-weight:600;padding:6px 8px;white-space:nowrap">${h}</th>`).join('')}</tr></thead>
+        <tbody><tr>${totalsCols.map(([_, v, level]) => {
+          if (level === 'input') {
+            return `<td style="background:#FDF8E7;padding:4px;text-align:right;white-space:nowrap"><input id="tot-surtax" type="number" step="any" value="${v ?? ''}" style="width:80px;text-align:right;border:1px solid #d1c89f;background:#fff;padding:2px 4px;font-weight:600"/></td>`;
+          }
+          const palette = {
+            sub:      '#FEF9C3',   // 出厂价 RMB
+            'sub-hkd':'#FEF3C7',   // 出厂价 HKD
+            total:    '#F0DBA1',   // 出货底价 RMB
+            hkd:      '#F0DBA1',   // 出货底价 HKD
+          };
+          const bg = palette[level] || '#FDF8E7';
+          // 码点 = 倍数（无货币符号）；其他 HKD
+          if (level === 'mult') {
+            return `<td style="background:#FEF9C3;padding:4px;text-align:right;white-space:nowrap">× <input id="tot-markup" type="number" step="any" value="${v ?? 1.2}" style="width:60px;text-align:right;border:1px solid #d1c89f;background:#fff;padding:2px 4px;font-weight:700"/></td>`;
+          }
+          return `<td style="background:${bg};font-weight:${level?'700':'600'};padding:6px 8px;text-align:right;white-space:nowrap">HK$${formatNum(v)}</td>`;
+        }).join('')}</tr></tbody>
+      </table>
+    </div>
+    <h2 style="margin-top:24px">🚚 出货价算价</h2>
+    <div id="wb-shipping-sum"></div>
+    <div id="tax-deduction-block" style="margin-top:24px"></div>`;
+  // 出货价算价（来自业务 section）
+  const salesSec = sections.find(x => x.dept === 'sales');
+  const salesHeader = sales.header || {};
+  sales.shipping = sales.shipping || { scenarios: [], freight_pct: 48, lifting_pct: 52, markup_x: 1.2, divisor: 0.98, target_usd: 0 };
+  const engPayloadSum = sections.find(s => s.dept === 'engineering');
+  const engPayloadObj = engPayloadSum && engPayloadSum.payload_json ? JSON.parse(engPayloadSum.payload_json) : {};
+  const eCartonSum = engPayloadObj.carton_calc || {};
+  sales.freight_calc = sales.freight_calc || {
+    cap_10t: 1166, cap_5t: 750, cap_40: 1980, cap_20: 883,
+    hk40: 8000, hk20: 7100, yt40: 7200, yt20: 6000,
+    hk10t: 14900, yt10t: 11500, hk5t: 12500, yt5t: 11000,
+  };
+  const freightCalcSum = sales.freight_calc;
+  const freightMapSum = computeFreightMap(freightCalcSum, eCartonSum);
+  const canEditShip = me?.dept === 'sales' || me?.dept === 'engineering';
+  // 九、合计 中的 附加税 + 模具分摊 (都已是 RMB，转 HKD)
+  const surtaxHkd = num(surtaxManual) / fxRH;
+  const moldShareHkd = num(moldShare) / fxRH;
+  renderShipping(host.querySelector('#wb-shipping-sum'), sales, salesHeader, canEditShip, () => {
+    // 自动保存出货价算价到业务 section
+    if (canEditShip && salesSec) {
+      // 同步本地 sections 缓存，避免汇总重渲染时按旧 payload 还原（如 目标价 被重置回 0）
+      salesSec.payload_json = JSON.stringify(sales);
+      api('/sections/' + salesSec.id, { method: 'PUT', body: JSON.stringify({ payload: sales, submit: false }) }).catch(() => {});
+    }
+  }, freightMapSum, afterMarkupHkd, surtaxHkd, moldShareHkd);
+  const surtaxInp = host.querySelector('#tot-surtax');
+  if (surtaxInp && (me?.dept === 'sales' || me?.dept === 'engineering')) {
+    surtaxInp.oninput = () => {
+      sales.pricing_summary.surtax = surtaxInp.value === '' ? null : Number(surtaxInp.value);
+    };
+  } else if (surtaxInp) {
+    surtaxInp.disabled = true;
+  }
+  // 码点 可编辑（业务/工程）
+  const markupInp = host.querySelector('#tot-markup');
+  if (markupInp && (me?.dept === 'sales' || me?.dept === 'engineering')) {
+    markupInp.oninput = () => {
+      sales.shipping = sales.shipping || {};
+      sales.shipping.markup_x = Number(markupInp.value) || 1.2;
+      renderSummaryPane(host, sections, quote, me);
+    };
+  } else if (markupInp) {
+    markupInp.disabled = true;
+  }
+  const taxHost = host.querySelector('#tax-deduction-block');
+  // 注塑料按材质分进/国内料：POM / PVC = 国内料；其他 = 进口料 — 全部 HKD
+  const injLossM = 1 + num(mold.injection_loss_pct ?? 3) / 100;  // 注塑料损耗（默认3%）
+  let domesticMatHkd = 0, importMatHkd = 0;
+  (mold.injection || []).forEach(r => {
+    const rawUnitHkd = num(r.weight_g) * injLossM * num(r.material_unit_price);  // 原料单价 HK$
+    const mat = String(r.material || '').toUpperCase().trim();
+    if (/^(POM|PVC|C[- ]?PVC)/i.test(mat)) domesticMatHkd += rawUnitHkd;
+    else if (mat) importMatHkd += rawUnitHkd;
+  });
+
+  // 分类关键字（用于无显式类别时兜底）
+  const _isBat = (s) => /电池|battery/i.test(String(s || ''));
+  const _isLib = (s) => /利宝|贴纸|libao|sticker/i.test(String(s || ''));
+  const _isPlate = (s) => /电镀|plating/i.test(String(s || ''));
+  const _isCarton = (s) => /纸箱|carton/i.test(String(s || ''));
+  // 马达：电子/五金里含 "马达" / "motor" 的行（电子/五金表不设类别下拉，仍按关键字）
+  const isMotor = (s) => /马达|motor/i.test(String(s || ''));
+  const isBlister = (s) => /吸塑|blister/i.test(String(s || ''));
+  const _sumByMatch = (rows, matchFn) => sum(rows || [], r =>
+    (matchFn(r.name) || matchFn(r.spec)) ? num(r.qty) * num(r.unit_price) : 0);
+  // 马达：电子部分用 elecSrc（电子部优先），与导出同源
+  const motorRmb = _sumByMatch(elecSrc, isMotor) + _sumByMatch(eng.hardware, isMotor);
+
+  // 二、包装/外购：按行的显式「类别」统计，无类别时按关键字兜底
+  const pkmatRows = eng.packaging_materials || [];
+  const auxRows = eng.aux_materials || [];
+  // tbl='aux'|'pk'：返回行所属类别（合法 MAT_CATEGORIES 之一），纸箱返回 null（单独计），否则按表默认兜底
+  const _catOf = (r, tbl) => {
+    if (r.category && MAT_CATEGORIES.includes(r.category)) return r.category;
+    const a = r.name, b = r.spec;
+    if (isBlister(a) || isBlister(b)) return '吸塑';
+    if (_isBat(a) || _isBat(b)) return '电池';
+    if (_isLib(a) || _isLib(b)) return '利宝';
+    if (_isPlate(a) || _isPlate(b)) return '电镀';
+    if (_isCarton(a) || _isCarton(b)) return null;  // 纸箱另算
+    return tbl === 'aux' ? '其他外购' : '彩盒/内咭';
+  };
+  const _amt = (r) => num(r.qty) * num(r.unit_price);
+  const _catSum = (cat) => sum(pkmatRows.filter(r => _catOf(r, 'pk') === cat), _amt)
+    + sum(auxRows.filter(r => _catOf(r, 'aux') === cat), _amt);
+  // 吸塑：辅助/包装按类别 + 电子/五金里关键字命中的吸塑行
+  const blisterRmb = _catSum('吸塑') + _sumByMatch(elecSrc, isBlister) + _sumByMatch(eng.hardware, isBlister);
+  const batteryRmb = _catSum('电池');
+  const libaoRmb = _catSum('利宝');
+  const platingRmb = _catSum('电镀');
+  const colorBoxRmb = _catSum('彩盒/内咭');
+  const otherBuyRmb = _catSum('其他外购');
+
+  // 自动从各部门拉取的金额 — 全部 HKD（一、出厂货价核）
+  const autoFill = {
+    imp_mat: importMatHkd,                   // 进口料 HKD
+    dom_mat: domesticMatHkd,                 // 国内料 HKD
+    blow: blowTotal,                         // 吹气 HKD
+    slush: slushTotal,                       // 搪胶 HKD
+    sewing_hair: sewingHairRmb / fxRH,       // 车发 HKD
+    sewing_cloth: sewingClothRmb / fxRH,     // 车衣 HKD
+    motor: motorRmb,                         // 马达 HKD（电子/五金已 HKD，不除汇率）
+    suction: blisterRmb,                     // 吸塑 HKD（包装已 HKD）
+    code_before: markupX,                    // 未减税前码数 = 九、合计 码点
+    color_box: colorBoxRmb,                  // 彩盒/内咭/内卡 HKD（包装已 HKD）
+    other_buy: otherBuyRmb,                  // 其他外购 = 辅助材料剩余 HKD（辅助已 HKD）
+    battery: batteryRmb,                     // 电池 HKD（包装已 HKD）
+    libao: libaoRmb,                         // 利宝 HKD（辅助已 HKD）
+    plating: platingRmb,                     // 电镀 HKD（包装已 HKD）
+    carton: toHkd(cartonRmb),                // 纸箱 HKD（来自工程纸箱计算）
+    // 运费 / 吊柜费 → 盐田40柜 场景对应值（HKD）
+    freight: (() => {
+      const yt40 = (sales.shipping?.scenarios || []).find(x => /盐田.*40/i.test(x.name || ''));
+      if (!yt40) return 0;
+      const rate = num(yt40._freight_rate);
+      return rate * num(sales.shipping?.freight_pct ?? 48) / 100;
+    })(),
+    cabinet: (() => {
+      const yt40 = (sales.shipping?.scenarios || []).find(x => /盐田.*40/i.test(x.name || ''));
+      if (!yt40) return 0;
+      const rate = num(yt40._freight_rate);
+      return rate * num(sales.shipping?.lifting_pct ?? 52) / 100;
+    })(),
+    // 杂项 = 印尼运费(手填 HKD) + 附加税 HKD
+    misc: num(sales.pricing_summary?.indo_freight) + surtaxHkd,
+    hardware: (hwRaw - _sumByMatch(eng.hardware, isMotor)),  // 五金 HKD（剔除马达项；五金表已 HKD）
+    electronic: (elecRaw - _sumByMatch(elecSrc, isMotor)),  // 电子 HKD（剔除马达项；电子表已 HKD）
+    injection_labor: sum(mold.injection || [], r => num(r.shot_price)),  // 啤工 = Σ啤价 HKD（只算机时人工，不含原料）
+    painting_labor: ppTotal * 0.7,    // 喷油工 = 喷油总额 70%（喷油已 HKD，不除汇率）
+    paint_material: ppTotal * 0.3,    // 油漆 = 喷油总额 30%（喷油已 HKD）
+    assembly_labor: combinedAsmHkd,   // 装配工 = 旧组装+旧包装+新排拉(装配)+新排拉(包装)（已 HKD，不除汇率）
+    base_price: afterMarkupHkd,              // 货价 = 码点后价 HKD
+  };
+  renderTaxDeductionBlock(taxHost, sales, salesSec, me, autoFill);
+}
+
+// ============== 汇总 · 减税明细 4 表 ==============
+function renderTaxDeductionBlock(host, salesPayload, salesSec, me, autoFill) {
+  const canEdit = me && (me.dept === 'sales' || me.dept === 'engineering');
+  salesPayload.pricing_summary = salesPayload.pricing_summary || {};
+  const ps = salesPayload.pricing_summary;
+  autoFill = autoFill || {};
+  // 自动同步前面部门的金额（每次进汇总都覆盖；用户后续可手填覆盖项放 ps.overrides）
+  ps.overrides = ps.overrides || {};
+  const applyAuto = (tbl, key, val) => {
+    if (val == null || val === 0) return;
+    if (ps.overrides[tbl + '.' + key]) return; // 用户已手动改过
+    ps[tbl] = ps[tbl] || {};
+    ps[tbl][key] = +val.toFixed(4);
+  };
+  applyAuto('t1', 'base_price', autoFill.base_price);
+  applyAuto('t1', 'imp_mat', autoFill.imp_mat);
+  applyAuto('t1', 'dom_mat', autoFill.dom_mat);
+  applyAuto('t1', 'blow', autoFill.blow);
+  applyAuto('t1', 'slush', autoFill.slush);
+  applyAuto('t1', 'sewing_hair', autoFill.sewing_hair);
+  applyAuto('t1', 'sewing_cloth', autoFill.sewing_cloth);
+  applyAuto('t1', 'hardware', autoFill.hardware);
+  applyAuto('t1', 'electronic', autoFill.electronic);
+  applyAuto('t1', 'motor', autoFill.motor);
+  applyAuto('t1', 'suction', autoFill.suction);
+  applyAuto('t2', 'code_before', autoFill.code_before);
+  applyAuto('t2', 'color_box', autoFill.color_box);
+  applyAuto('t2', 'battery', autoFill.battery);
+  applyAuto('t2', 'libao', autoFill.libao);
+  applyAuto('t2', 'plating', autoFill.plating);
+  applyAuto('t2', 'other_buy', autoFill.other_buy);
+  applyAuto('t2', 'carton', autoFill.carton);
+  applyAuto('t2', 'freight', autoFill.freight);
+  applyAuto('t2', 'cabinet', autoFill.cabinet);
+  applyAuto('t2', 'misc', autoFill.misc);
+  applyAuto('t3', 'injection_labor', autoFill.injection_labor);
+  applyAuto('t3', 'painting_labor', autoFill.painting_labor);
+  applyAuto('t3', 'paint_material', autoFill.paint_material);
+  applyAuto('t3', 'assembly_labor', autoFill.assembly_labor);
+  // 表1 出厂货价核
+  ps.t1 = ps.t1 || { base_price: 0, imp_mat: 0, dom_mat: 0, blow: 0, slush: 0, sewing_hair: 0, sewing_cloth: 0, hardware: 0, electronic: 0, motor: 0, suction: 0 };
+  // 表2 包装/外购
+  ps.t2 = ps.t2 || { color_box: 0, inner_card: 0, code_before: 0, code_after: 0, battery: 0, libao: 0, plating: 0, other_buy: 0, carton: 0, freight: 0, cabinet: 0, misc: 0 };
+  // 旧数据迁移：彩盒 + 内咭 合并到 color_box，inner_card 清零
+  if (ps.t2.inner_card) {
+    ps.t2.color_box = num(ps.t2.color_box) + num(ps.t2.inner_card);
+    ps.t2.inner_card = 0;
+  }
+  // 表3 人工 & 成本汇总（仅 abs/人工 是手填，其他由 t1+t2 + 自动算）
+  ps.t3 = ps.t3 || { abs_cost: 0, injection_labor: 0, painting_labor: 0, paint_material: 0, assembly_labor: 0 };
+  // 表4 减税明细：每类 amount + rate%
+  // 减税率默认值（按实际减税口径）
+  const RATE_DEFAULTS = {
+    rmb_buy: 0,       // 人民币外购件成本（总额参考，不参与减税）
+    tax13: 0,         // 含税13%类成本（成本基数参考，不参与减税；减税在"含税13%类"列）
+    labor13: 11.5,    // 人工类13%
+    carton: 10,       // 纸箱类
+    tax1: 0.99,       // 含税1%
+    slush3: 3,        // 搪胶类3%
+    sewhair13: 11.5,  // 车发类13%
+    sewcloth13: 11.5, // 车衣类13%
+    suction6: 6,      // 吸塑类6%
+    freight9: 8.26,   // 运费含税9%
+    tax13b: 11.5,     // 含税13%类
+  };
+  ps.t4 = ps.t4 || {};
+  Object.keys(RATE_DEFAULTS).forEach(k => {
+    ps.t4[k] = ps.t4[k] || { amt: 0, rate: RATE_DEFAULTS[k] };
+    // 若 rate 还是旧默认值（13/1/9 等），且用户没手动覆盖过，更新为新默认
+    if (!ps.overrides || !ps.overrides['t4r.' + k]) {
+      ps.t4[k].rate = RATE_DEFAULTS[k];
+    }
+  });
+
+  const t1Cols = [
+    ['base_price', '货价'], ['imp_mat', '进口料'], ['dom_mat', '国内料'], ['blow', '吹气'], ['slush', '搪胶'],
+    ['sewing_hair', '车发'], ['sewing_cloth', '车衣'], ['hardware', '五金'], ['electronic', '电子'], ['motor', '马达'], ['suction', '吸塑'],
+  ];
+  const t2Cols = [
+    ['color_box', '彩盒/内咭'], ['code_before', '未减税前码数'], ['code_after', '减税后码数'],
+    ['battery', '电池'], ['libao', '利宝'], ['plating', '电镀'], ['other_buy', '其他外购'],
+    ['carton', '纸箱'], ['freight', '运费'], ['cabinet', '吊柜费'], ['misc', '杂项'],
+  ];
+  const t4Cols = [
+    ['rmb_buy', '人民币外购件成本'], ['tax13', '含税13%类成本'], ['labor13', '人工类13%'], ['carton', '纸箱类'],
+    ['tax1', '含税1%'], ['slush3', '搪胶类3%'], ['sewhair13', '车发类13%'], ['sewcloth13', '车衣类13%'],
+    ['suction6', '吸塑类6%'], ['freight9', '运费类9%'], ['tax13b', '含税13%类'],
+  ];
+  // 参考列：只显示成本金额，无税率、不参与减税（避免与明细列重复）
+  const T4_NO_RATE = new Set(['rmb_buy', 'tax13']);
+
+  const ro = canEdit ? '' : 'readonly';
+  const cls = canEdit ? 'tk-edit' : 'tk-edit tk-ro';
+
+  function buildTable(title, cols, dataKey) {
+    const headRow = cols.map(([k, lbl]) => `<th>${lbl}</th>`).join('');
+    const valRow = cols.map(([k, lbl]) => `<td><input class="${cls}" type="number" step="0.0001" data-tbl="${dataKey}" data-key="${k}" value="${num(ps[dataKey][k]) || ''}" ${ro}/></td>`).join('');
+    return `<div class="tk-block"><div class="tk-title">${title}</div>
+      <div class="tk-scroll"><table class="tk-table"><thead><tr>${headRow}</tr></thead><tbody><tr>${valRow}</tr></tbody></table></div></div>`;
+  }
+
+  function buildT4() {
+    const headRow = t4Cols.map(([k, lbl]) => `<th>${lbl}</th>`).join('')
+      + '<th class="tk-sum">合计减税</th>'
+      + '<th class="tk-sum" style="background:#dcfce7">减税后成本</th>';
+    const amtRow = t4Cols.map(([k]) => `<td><input class="${cls}" type="number" step="0.0001" data-tbl="t4a" data-key="${k}" value="${num(ps.t4[k].amt) || ''}" ${ro} title="金额"/></td>`).join('')
+      + '<td></td><td></td>';
+    const rateRow = t4Cols.map(([k]) => T4_NO_RATE.has(k) ? '<td></td>'
+      : `<td><input class="${cls}" type="number" step="0.01" data-tbl="t4r" data-key="${k}" value="${num(ps.t4[k].rate) || ''}" ${ro} title="税率%"/>%</td>`).join('')
+      + '<td></td><td></td>';
+    const dedRow = t4Cols.map(([k]) => T4_NO_RATE.has(k) ? '<td class="tk-calc">—</td>'
+      : `<td class="tk-calc" id="tk-ded-${k}" title="减税额=金额×税率">0.0000</td>`).join('')
+      + '<td class="tk-sum" id="tk-total-ded">0.00</td>'
+      + '<td class="tk-sum" id="tk-after-ded" style="background:#dcfce7;color:#166534;font-weight:700">0.00</td>';
+    return `<div class="tk-block"><div class="tk-title">四、减税明细 <small class="muted">（1=金额，2=税率%，3=减税额=金额×税率；合计减税=Σ减税额；减税后成本 = 总成本 − 合计减税）</small></div>
+      <div class="tk-scroll"><table class="tk-table"><thead><tr>${headRow}</tr></thead><tbody>
+        <tr>${amtRow}</tr>
+        <tr>${rateRow}</tr>
+        <tr>${dedRow}</tr>
+      </tbody></table></div></div>`;
+  }
+
+  function buildT3() {
+    return `<div class="tk-block"><div class="tk-title">三、人工 & 成本汇总</div>
+      <div class="tk-scroll"><table class="tk-table">
+        <thead><tr>
+          <th>啤工</th><th>喷油工</th><th>油漆</th><th>装配工</th>
+          <th style="background:#fef3c7">不含人工成本</th>
+          <th>人工比例</th><th>毛利</th><th>毛利率</th><th>利润</th><th>利润率</th><th>总成本</th>
+        </tr></thead>
+        <tbody><tr>
+          <td><input class="${cls}" type="number" step="0.0001" data-tbl="t3" data-key="injection_labor" value="${num(ps.t3.injection_labor) || ''}" ${ro}/></td>
+          <td><input class="${cls}" type="number" step="0.0001" data-tbl="t3" data-key="painting_labor" value="${num(ps.t3.painting_labor) || ''}" ${ro}/></td>
+          <td><input class="${cls}" type="number" step="0.0001" data-tbl="t3" data-key="paint_material" value="${num(ps.t3.paint_material) || ''}" ${ro}/></td>
+          <td><input class="${cls}" type="number" step="0.0001" data-tbl="t3" data-key="assembly_labor" value="${num(ps.t3.assembly_labor) || ''}" ${ro}/></td>
+          <td class="tk-calc" id="tk-no-labor" style="background:#fef3c7;font-weight:600">0.0000</td>
+          <td class="tk-calc" id="tk-labor-pct">0.0%</td>
+          <td class="tk-calc" id="tk-gross">0.0000</td>
+          <td class="tk-calc" id="tk-gross-pct">0.0%</td>
+          <td class="tk-calc" id="tk-profit">0.0000</td>
+          <td class="tk-calc" id="tk-profit-pct">0.0%</td>
+          <td class="tk-calc" id="tk-total-cost">0.0000</td>
+        </tr></tbody>
+      </table></div></div>`;
+  }
+
+  // 印尼运费手填（HKD）— 用于 杂项自动算
+  ps.indo_freight = ps.indo_freight ?? 0;
+  host.innerHTML = `<h2>🧾 减税明细 / 成本汇总</h2>
+    <div style="display:flex;gap:14px;align-items:center;margin:6px 0 10px;padding:8px 12px;background:#fef9c3;border-radius:6px;font-size:13px">
+      <label>📦 印尼运费 (HKD) <input id="tk-indo-freight" type="number" step="0.0001" value="${num(ps.indo_freight) || ''}" style="width:100px" ${ro}/></label>
+      <small class="muted">杂项 = 印尼运费 + 附加税</small>
+    </div>
+    <style>
+      .tk-block{margin-top:16px}
+      .tk-title{font-weight:600;margin-bottom:6px;color:#44403c}
+      .tk-scroll{overflow-x:auto;border:1px solid #e7e5e4;border-radius:6px}
+      .tk-table{border-collapse:collapse;width:100%;font-size:12px}
+      .tk-table th,.tk-table td{border:1px solid #e7e5e4;padding:4px 6px;text-align:center;white-space:nowrap}
+      .tk-table th{background:#f5f5f4;color:#44403c;font-weight:600}
+      .tk-table td input.tk-edit{width:90px;text-align:right;border:1px solid transparent;background:transparent;padding:2px 4px}
+      .tk-table td input.tk-edit:hover,.tk-table td input.tk-edit:focus{border-color:#a8a29e;background:#fff}
+      .tk-table td input.tk-ro{background:#fafaf9}
+      .tk-calc{background:#fef3c7;font-weight:600;color:#92400e}
+      .tk-sum{background:#dcfce7;font-weight:700;color:#166534}
+      .tk-save{margin-top:14px}
+    </style>
+    ${buildTable('一、出厂货价核', t1Cols, 't1')}
+    ${buildTable('二、包装 / 外购', t2Cols, 't2')}
+    ${buildT3()}
+    ${buildT4()}
+    ${canEdit ? `<div class="tk-save"><button id="tk-btn-save">💾 保存减税明细</button> <span id="tk-msg" class="muted"></span></div>` : ''}`;
+
+  function recalc() {
+    const sum = (obj) => Object.values(obj).reduce((s, v) => s + num(v), 0);
+    // 不含人工成本 = 表1（除货价）+ 表2（除码数）+ 啤工（包含 进口料/吹气/搪胶/吸塑/运费/吊柜费 等）
+    const t1NoBase = { ...ps.t1 }; delete t1NoBase.base_price;
+    const t2Cost = { ...ps.t2 }; delete t2Cost.code_before; delete t2Cost.code_after;
+    const noLaborCost = sum(t1NoBase) + sum(t2Cost) + num(ps.t3.injection_labor);
+    // 人民币外购件成本 = 国内料+车发+车衣+五金+电子+马达 + 彩盒/内咭+电池+利宝+电镀+其他外购+纸箱+杂项 + 油漆
+    const rmbBuyCost =
+      num(ps.t1.dom_mat) + num(ps.t1.sewing_hair) + num(ps.t1.sewing_cloth)
+      + num(ps.t1.hardware) + num(ps.t1.electronic) + num(ps.t1.motor)
+      + num(ps.t2.color_box) + num(ps.t2.battery) + num(ps.t2.libao)
+      + num(ps.t2.plating) + num(ps.t2.other_buy) + num(ps.t2.carton) + num(ps.t2.misc)
+      + num(ps.t3.paint_material);
+    const laborCost = num(ps.t3.painting_labor) + num(ps.t3.paint_material) + num(ps.t3.assembly_labor);
+    const totalCost = noLaborCost + laborCost;
+    const basePrice = num(ps.t1.base_price);
+    const gross = basePrice - noLaborCost;
+    const profit = basePrice - totalCost;
+    const grossPct = basePrice ? gross / basePrice : 0;
+    const profitPct = basePrice ? profit / basePrice : 0;
+    const laborPct = basePrice ? laborCost / basePrice : 0;
+    // 四、减税明细 各列自动填
+    const setT4Amt = (key, val) => {
+      if (ps.overrides['t4a.' + key]) return;
+      ps.t4[key].amt = +num(val).toFixed(4);
+      const inp = host.querySelector(`input[data-tbl="t4a"][data-key="${key}"]`);
+      if (inp && document.activeElement !== inp) inp.value = ps.t4[key].amt || '';
+    };
+    setT4Amt('rmb_buy', rmbBuyCost);                                           // 人民币外购件成本
+    setT4Amt('tax13', num(ps.t2.libao) + num(ps.t2.other_buy));                 // 含税13%类成本 = 利宝 + 其他外购
+    setT4Amt('carton', num(ps.t2.carton));                                     // 纸箱类 = 纸箱
+    setT4Amt('slush3', num(ps.t1.slush));                                      // 搪胶类3% = 搪胶
+    setT4Amt('sewhair13', num(ps.t1.sewing_hair));                             // 车发类13% = 车发
+    setT4Amt('sewcloth13', num(ps.t1.sewing_cloth));                           // 车衣类13% = 车衣
+    setT4Amt('suction6', num(ps.t1.suction));                                  // 吸塑类6% = 吸塑
+    setT4Amt('freight9', num(ps.t2.freight));                                  // 运费含税9% = 运费
+    setT4Amt('labor13', num(ps.t3.injection_labor) + num(ps.t3.painting_labor) + num(ps.t3.assembly_labor));// 人工类13% = 啤工 + 喷油工 + 装配工
+    setT4Amt('tax1', num(ps.t2.plating));                                      // 含税1% = 电镀
+    setT4Amt('tax13b', num(ps.t2.libao) + num(ps.t2.other_buy));               // 含税13%类 = 含税13%类成本
+    // 表4：每行 减税额 = 金额 × 税率%；参考列(无税率)不计；填入减税额行 + 合计
+    const totalDed = t4Cols.reduce((s, [k]) => {
+      if (T4_NO_RATE.has(k)) return s;  // 人民币外购件成本/含税13%类成本：参考列，不参与减税
+      const ded = num(ps.t4[k].amt) * num(ps.t4[k].rate) / 100;
+      const cell = host.querySelector('#tk-ded-' + k);
+      if (cell) cell.textContent = formatNum(ded);
+      return s + ded;
+    }, 0);
+
+    const setTxt = (id, v) => { const e = host.querySelector('#' + id); if (e) e.textContent = v; };
+    setTxt('tk-labor-pct', (laborPct * 100).toFixed(1) + '%');
+    setTxt('tk-gross', formatNum(gross));
+    setTxt('tk-gross-pct', (grossPct * 100).toFixed(1) + '%');
+    setTxt('tk-profit', formatNum(profit));
+    setTxt('tk-profit-pct', (profitPct * 100).toFixed(1) + '%');
+    setTxt('tk-no-labor', formatNum(noLaborCost));
+    setTxt('tk-total-cost', formatNum(totalCost));
+    setTxt('tk-total-ded', formatNum(totalDed));
+    const afterDed = totalCost - totalDed;
+    setTxt('tk-after-ded', formatNum(afterDed));
+    // 减税后码数 = 货价 / 减税后成本 → 写回 t2.code_after 输入框
+    const codeAfter = afterDed > 0 ? basePrice / afterDed : 0;
+    ps.t2.code_after = +codeAfter.toFixed(4);
+    const codeAfterInp = host.querySelector('input[data-tbl="t2"][data-key="code_after"]');
+    if (codeAfterInp && document.activeElement !== codeAfterInp) codeAfterInp.value = ps.t2.code_after || '';
+  }
+  recalc();
+
+  if (canEdit) {
+    const indoInp = host.querySelector('#tk-indo-freight');
+    if (indoInp) indoInp.oninput = () => {
+      ps.indo_freight = Number(indoInp.value) || 0;
+      // 杂项 = 印尼运费 + 附加税；把它写回 t2.misc 并触发 recalc
+      // surtax 自动算时已从外面带进来，这里更新印尼部分 + 触发 recalc
+      const surtax = num(ps.t1.base_price) ? 0 : 0; // 占位 — 附加税值在 autoFill 阶段写入 ps.t2.misc，这里需手动加印尼
+      // 让 misc 反映 = 印尼运费 + 附加税：保留 (misc - 上一次印尼) + 当前印尼
+      ps.t2.misc = (num(ps.t2.misc) - num(ps._last_indo || 0)) + Number(indoInp.value || 0);
+      ps._last_indo = Number(indoInp.value || 0);
+      recalc();
+    };
+    host.querySelectorAll('input.tk-edit').forEach(inp => {
+      inp.oninput = () => {
+        const tbl = inp.dataset.tbl, key = inp.dataset.key;
+        const v = parseFloat(inp.value) || 0;
+        if (tbl === 't1' || tbl === 't2' || tbl === 't3') {
+          ps[tbl][key] = v;
+          ps.overrides[tbl + '.' + key] = true;
+        }
+        else if (tbl === 't4a') { ps.t4[key].amt = v; ps.overrides['t4a.' + key] = true; }
+        else if (tbl === 't4r') { ps.t4[key].rate = v; ps.overrides['t4r.' + key] = true; }
+        recalc();
+      };
+    });
+    host.querySelector('#tk-btn-save').onclick = async () => {
+      const msg = host.querySelector('#tk-msg');
+      msg.textContent = '保存中...';
+      try {
+        await api('/sections/' + salesSec.id, { method: 'PUT', body: JSON.stringify({ payload: salesPayload, submit: false }) });
+        if (salesSec) salesSec.payload_json = JSON.stringify(salesPayload);  // 同步本地缓存
+        msg.textContent = '✓ 已保存 ' + new Date().toLocaleTimeString();
+      } catch (e) { msg.textContent = '✗ ' + e.message; }
+    };
+  }
+}
+
+// ============== 搪胶部门（占位） ==============
+function renderSlush(host, payload, canEdit, onChange, fxRmbHkd) {
+  payload.slush_items = payload.slush_items || [];
+  host.innerHTML = `<h3>二·C、搪胶产品报价</h3><div class="muted">字段待定，先占位。下方为草拟表格：</div>
+    <div id="wb-slush-table" style="margin-top:8px"></div>`;
+  const cols = [
+    { key: 'item_code', label: '产品编号', width: '110px' },
+    { key: 'name', label: '胶件名称', width: '120px' },
+    { key: 'material', label: '材料', width: '100px' },
+    { key: 'weight_g', label: '料重(g)', type: 'number', width: '80px' },
+    { key: 'daily_output', label: '日产量24H', type: 'number', width: '100px' },
+    { key: 'qty', label: '用量(PC)', type: 'number', width: '70px' },
+    { key: 'unit_price_hkd', label: '单价 HKD', type: 'number', width: '100px' },
+    { key: 'total_hkd', label: '总价 HKD', readonly: true, calc: r => num(r.unit_price_hkd) * num(r.qty), width: '90px' },
+    { key: 'note', label: '备注' },
+  ];
+  const wrappedOnChange = (() => { const fns = []; const w = () => { fns.forEach(f => f()); onChange(); }; w._fns = fns; return w; })();
+  renderTable(host.querySelector('#wb-slush-table'), cols, payload.slush_items, { readonly: !canEdit, onChange: wrappedOnChange });
+
+  // 搪胶单价本来就是 HKD，不再做 RMB→HKD 转换；只展示 HKD + 反向算 RMB 供参考
+  const fx = num(fxRmbHkd) || 0.85;
+  const card = document.createElement('div'); card.className = 'loss-summary';
+  host.appendChild(card);
+  const refresh = () => {
+    const totalHkd = sum(payload.slush_items || [], r => num(r.unit_price_hkd) * num(r.qty));
+    card.innerHTML = `
+      <div class="ls-row hi"><span class="ls-label">合计 HKD</span><span class="ls-val">${formatNum(totalHkd)}</span></div>
+      <div class="ls-row"><span class="ls-label">合计 RMB <small class="muted">(汇率 ${fx})</small></span><span class="ls-val">${formatNum(totalHkd * fx)}</span></div>`;
+  };
+  refresh();
+  wrappedOnChange._fns.push(refresh);
+}
+
+// ============== 车缝部门 ==============
+function renderSewing(host, payload, canEdit, onChange, fxRmbHkd) {
+  payload.sewing_groups = payload.sewing_groups || [];
+  payload.sewing_loss_pct = payload.sewing_loss_pct ?? 1;
+  const fx = num(fxRmbHkd) || 0.85;
+
+  const itemCols = [
+    { key: 'fabric', label: '布料名称', type: 'textarea', width: '240px' },
+    { key: 'part', label: '部位', width: '90px' },
+    { key: 'craft', label: '工艺', type: 'select', options: ['电绣'], width: '80px' },
+    { key: 'pieces', label: '裁片数', type: 'number', width: '70px' },
+    { key: 'usage', label: '用量/码', type: 'number', width: '90px' },
+    { key: 'mat_price', label: '物料价 (RMB)', type: 'number', width: '100px' },
+    { key: 'price', label: '价钱 (RMB)', readonly: true,
+      calc: r => num(r.usage) * num(r.mat_price), width: '90px' },
+    { key: 'markup', label: '码点', type: 'number', width: '70px' },
+    { key: 'total', label: '总价钱 (RMB)', readonly: true,
+      calc: r => num(r.usage) * num(r.mat_price) * (num(r.markup) || 1), width: '100px' },
+    { key: 'note', label: '备注' },
+  ];
+
+  const totalsBox = document.createElement('div'); totalsBox.className = 'loss-summary';
+  const wrappedOnChange = (() => { const fns = []; const w = () => { fns.forEach(f => f()); onChange(); refreshTotals(); }; w._fns = fns; return w; })();
+
+  function refreshTotals() {
+    const groupTotal = (g) =>
+      sum(g.items || [], r => num(r.usage) * num(r.mat_price) * (num(r.markup) || 1))
+      + num(g.labor_amount);
+    const allRMB = sum(payload.sewing_groups, groupTotal);
+    totalsBox.innerHTML = `
+      <div class="ls-row"><span class="ls-label">配套合计</span><span class="ls-val">${formatNum(allRMB)} RMB</span></div>
+      <div class="ls-row hi"><span class="ls-label">合计 RMB</span><span class="ls-val">${formatNum(allRMB)}</span></div>
+      <div class="ls-row hi"><span class="ls-label">合计 HKD</span><span class="ls-val">${formatNum(allRMB / fx)} <small class="muted">(汇率 ${fx})</small></span></div>`;
+  }
+
+  function render() {
+    host.innerHTML = `<h3>车缝产品报价（按产品分组）
+      ${canEdit ? '<button class="mini" id="sw-add-group" style="margin-left:10px">+ 新增产品组</button>' : ''}
+      ${canEdit ? '<button class="mini" id="sw-import" type="button" style="margin-left:6px">📄 导入车缝报价单</button><input id="sw-file" type="file" accept=".xls,.xlsx" style="display:none"/>' : ''}
+    </h3>
+    <div id="sw-import-preview"></div>
+    <div id="sw-groups"></div>`;
+    const groupsHost = host.querySelector('#sw-groups');
+
+    payload.sewing_groups.forEach((g, gi) => {
+      g.items = g.items || [];
+      const card = document.createElement('div');
+      card.className = 'labor-group';
+      card.style.cssText = 'border:1px solid #e7e5e4;border-radius:8px;padding:12px;margin-top:10px;background:#fafaf9';
+      const cat = g.category || '车衣';
+      g.category = cat;
+      card.innerHTML = `
+        <div style="display:flex;gap:10px;align-items:center;margin-bottom:8px">
+          <strong style="color:#16a34a">📦 产品：</strong>
+          <input class="sw-gname" data-gi="${gi}" value="${g.name || ''}" placeholder="如：6寸小蜥蜴 / 盾牌" style="flex:1;max-width:300px" ${canEdit ? '' : 'disabled'}/>
+          <label style="font-size:13px">类型
+            <select class="sw-gcat" data-gi="${gi}" ${canEdit ? '' : 'disabled'}>
+              <option value="车衣" ${cat==='车衣'?'selected':''}>车衣</option>
+              <option value="车发" ${cat==='车发'?'selected':''}>车发</option>
+            </select>
+          </label>
+          ${canEdit ? `<button class="mini danger sw-gdel" data-gi="${gi}">删除</button>` : ''}
+        </div>
+        <div class="sw-items"></div>
+        <div style="margin-top:8px;display:flex;gap:14px;align-items:center;flex-wrap:wrap">
+          <span class="muted">本组小计：<b class="sw-gsum">0</b> RMB</span>
+          <span class="sw-emb-badge" style="display:none;font-size:12px;font-weight:600;color:#16a34a;background:#dcfce7;border-radius:10px;padding:2px 8px"></span>
+        </div>`;
+      groupsHost.appendChild(card);
+
+      renderTable(card.querySelector('.sw-items'), itemCols, g.items, { readonly: !canEdit, onChange: wrappedOnChange });
+
+      const refreshGroup = () => {
+        const t = sum(g.items, r => num(r.usage) * num(r.mat_price) * (num(r.markup) || 1)) + num(g.labor_amount);
+        card.querySelector('.sw-gsum').textContent = formatNum(t);
+        const embN = (g.items || []).filter(r => r.craft === '电绣').length;
+        const badge = card.querySelector('.sw-emb-badge');
+        if (badge) { badge.style.display = embN ? '' : 'none'; badge.textContent = embN ? `🧵 含电绣 ${embN} 行` : ''; }
+      };
+      refreshGroup();
+      wrappedOnChange._fns.push(refreshGroup);
+    });
+
+    host.appendChild(totalsBox);
+    refreshTotals();
+
+    if (!canEdit) return;
+    host.querySelectorAll('.sw-gname').forEach(inp => inp.oninput = () => {
+      payload.sewing_groups[+inp.dataset.gi].name = inp.value; onChange();
+    });
+    host.querySelectorAll('.sw-gcat').forEach(sel => sel.onchange = () => {
+      payload.sewing_groups[+sel.dataset.gi].category = sel.value; onChange();
+    });
+    host.querySelectorAll('.sw-gdel').forEach(btn => btn.onclick = () => {
+      const gi = +btn.dataset.gi;
+      if (!confirm(`删除产品组"${payload.sewing_groups[gi].name || '未命名'}"？`)) return;
+      payload.sewing_groups.splice(gi, 1); onChange(); render();
+    });
+    const addBtn = host.querySelector('#sw-add-group');
+    if (addBtn) addBtn.onclick = () => {
+      payload.sewing_groups.push({ name: '', items: [], labor_amount: 0 });
+      onChange(); render();
+    };
+
+    // 导入车缝报价单 xlsx
+    const impBtn = host.querySelector('#sw-import');
+    const impFile = host.querySelector('#sw-file');
+    const impPreview = host.querySelector('#sw-import-preview');
+    if (impBtn && impFile) {
+      impBtn.onclick = () => impFile.click();
+      impFile.onchange = async (e) => {
+        const f = e.target.files[0]; if (!f) return;
+        impPreview.innerHTML = '<i class="muted" style="padding:8px;display:block">正在解析…</i>';
+        try {
+          const fd = new FormData(); fd.append('file', f);
+          const r = await fetch('/api/uploads/sewing-sheet', { method: 'POST', credentials: 'include', body: fd });
+          const j = await r.json();
+          if (!r.ok) throw new Error(j.error || '解析失败');
+          impPreview.innerHTML = `
+            <div class="card" style="background:#f0fdf4;border:1px solid #86efac;margin-top:10px">
+              <p>从 <b>${j.sheet_used}</b> 解析到 <b>${j.count}</b> 个产品分组：</p>
+              <ul style="margin:6px 0;padding-left:22px">
+                ${j.groups.map(g => `<li><b>${g.name}</b> — ${g.items.length} 行 / 人工 ¥${(g.labor_amount||0).toFixed(2)}</li>`).join('')}
+              </ul>
+              <div style="margin-top:10px;display:flex;gap:8px">
+                <button id="sw-imp-replace">应用（替换所有产品组）</button>
+                <button id="sw-imp-append" class="mini">追加到现有列表</button>
+                <button id="sw-imp-cancel" class="mini danger">取消</button>
+              </div>
+            </div>`;
+          const toGroup = (g) => ({
+            name: g.name,
+            items: (g.items || []).map(it => ({
+              fabric: it.material || '',
+              part: it.part || '',
+              craft: /电绣|绣花|embroider/i.test(String(it.material || '') + ' ' + String(it.note || '')) ? '电绣' : '',
+              pieces: 1,
+              usage: it.qty || 0,
+              mat_price: it.unit_price || 0,
+              markup: it.markup || 1,
+              note: it.note || '',
+            })),
+            labor_amount: g.labor_amount || 0,
+          });
+          impPreview.querySelector('#sw-imp-replace').onclick = () => {
+            payload.sewing_groups = j.groups.map(toGroup);
+            impPreview.innerHTML = ''; impFile.value = ''; onChange(); render();
+          };
+          impPreview.querySelector('#sw-imp-append').onclick = () => {
+            payload.sewing_groups = (payload.sewing_groups || []).concat(j.groups.map(toGroup));
+            impPreview.innerHTML = ''; impFile.value = ''; onChange(); render();
+          };
+          impPreview.querySelector('#sw-imp-cancel').onclick = () => { impPreview.innerHTML = ''; impFile.value = ''; };
+        } catch (err) {
+          impPreview.innerHTML = `<div class="card" style="background:#fef2f2;border:1px solid #fecaca;margin-top:10px">解析失败：${err.message}</div>`;
+        }
+      };
+    }
+  }
+  render();
+}
+
+function renderCartonCalc(host, c, canEdit, onChange) {
+  // 迁移：旧单纸箱 -> cartons[0]，每个纸箱内嵌 flat_cards[]
+  if (!c.cartons) {
+    c.cartons = [{
+      name: '主纸箱', cl: c.cl || 0, cw: c.cw || 0, ch: c.ch || 0,
+      ka_label: c.ka_label || 'K=A', qty: c.qty || 1,
+      flat_cards: [{ name: '主平卡', l: c.cl || 0, w: c.cw || 0 }],
+    }];
+  }
+  // 确保每个 carton 都有 flat_cards 数组
+  c.cartons.forEach(b => { if (!b.flat_cards) b.flat_cards = []; });
+  // 删除老的顶层 flat_cards
+  delete c.flat_cards;
+
+  const cuftOf = (b) => num(b.cl) * num(b.cw) * num(b.ch) / 1728;
+  const boxPriceOf = (b) => (num(b.cl) + num(b.cw) + 2) * (num(b.cw) + num(b.ch) + 1) * 2 * 2.8 / 1000;
+  const flatPriceOf = (f) => (num(f.l) + 1) * (num(f.w) + 1) * 2 / 1000;
+
+  function render() {
+    // 同步首个纸箱回旧字段（运费计算/出口表使用）
+    const b0 = c.cartons[0];
+    if (b0) {
+      c.cl = b0.cl; c.cw = b0.cw; c.ch = b0.ch; c.qty = b0.qty;
+      c.cuft = cuftOf(b0);
+      c.box_price = +boxPriceOf(b0).toFixed(4);
+      c.flat_card = b0.flat_cards[0] ? +flatPriceOf(b0.flat_cards[0]).toFixed(4) : 0;
+    }
+
+    const cartonsHtml = c.cartons.map((b, i) => {
+      const fcRows = b.flat_cards.map((f, j) => `
+        <tr>
+          <td><input data-bi="${i}" data-fj="${j}" data-k="name" type="text" value="${f.name || ''}" ${canEdit?'':'disabled'} style="width:90px"/></td>
+          <td><input data-bi="${i}" data-fj="${j}" data-k="l" type="number" step="any" value="${f.l || ''}" ${canEdit?'':'disabled'} style="width:80px"/></td>
+          <td><input data-bi="${i}" data-fj="${j}" data-k="w" type="number" step="any" value="${f.w || ''}" ${canEdit?'':'disabled'} style="width:80px"/></td>
+          <td style="text-align:right;color:#0f766e;font-weight:600">${flatPriceOf(f).toFixed(2)}</td>
+          ${canEdit ? `<td><button class="mini danger" data-del-f="${i}-${j}">×</button></td>` : ''}
+        </tr>`).join('');
+
+      return `
+        <div style="border:1px solid #e7e5e4;border-radius:8px;padding:10px;margin-bottom:12px;background:#fff">
+          <div style="display:flex;gap:10px;align-items:center;margin-bottom:8px">
+            <strong style="color:#7c2d12">📦</strong>
+            <input data-bi="${i}" data-k="name" type="text" value="${b.name || ''}" placeholder="纸箱名称" ${canEdit?'':'disabled'} style="width:130px;font-weight:600"/>
+            <span class="muted">L</span><input data-bi="${i}" data-k="cl" type="number" step="any" value="${b.cl || ''}" ${canEdit?'':'disabled'} style="width:80px"/>
+            <span class="muted">W</span><input data-bi="${i}" data-k="cw" type="number" step="any" value="${b.cw || ''}" ${canEdit?'':'disabled'} style="width:80px"/>
+            <span class="muted">H</span><input data-bi="${i}" data-k="ch" type="number" step="any" value="${b.ch || ''}" ${canEdit?'':'disabled'} style="width:80px"/>
+            <span class="muted">inch</span>
+            ${canEdit ? `<button class="mini danger" data-del-b="${i}" style="margin-left:auto">删除纸箱</button>` : ''}
+          </div>
+          <div style="display:flex;gap:18px;align-items:center;padding:8px 10px;background:#fef3c7;border-radius:6px;margin-bottom:10px">
+            <span><b>CU.FT</b> <span style="color:#7c2d12;font-weight:700">${cuftOf(b).toFixed(2)}</span></span>
+            <span><b>箱价</b> <span style="color:#7c2d12;font-weight:700">HK$ ${boxPriceOf(b).toFixed(2)}</span></span>
+            <span><b>数量</b> <input data-bi="${i}" data-k="qty" type="number" step="1" value="${b.qty || ''}" ${canEdit?'':'disabled'} style="width:60px"/></span>
+          </div>
+          <div style="margin-bottom:4px;color:#78716c;font-size:12px">📄 配的平卡 (inch)</div>
+          <table class="wb-table" style="font-size:13px;margin-bottom:6px">
+            <thead><tr><th>名称</th><th>L</th><th>W</th><th>平卡价(HK$)</th>${canEdit?'<th></th>':''}</tr></thead>
+            <tbody>${fcRows || `<tr><td colspan="${canEdit?5:4}" class="muted" style="text-align:center">暂无平卡</td></tr>`}</tbody>
+          </table>
+          ${canEdit ? `<button class="mini" data-add-f="${i}">+ 增加平卡</button>` : ''}
+        </div>`;
+    }).join('');
+
+    host.innerHTML = `
+      <div style="border:1px solid #e7e5e4;border-radius:8px;padding:12px;background:#fafaf9;max-width:980px">
+        <div style="font-weight:600;margin-bottom:10px;color:#44403c">📦 纸箱计算</div>
+
+        <div style="margin-bottom:6px;color:#78716c;font-size:13px">产品尺寸 CM</div>
+        <table class="wb-table" style="font-size:13px;margin-bottom:14px;max-width:340px">
+          <thead><tr><th style="width:80px">L</th><th style="width:80px">W</th><th style="width:80px">H</th></tr></thead>
+          <tbody><tr>
+            <td><input id="cc-pl" type="number" step="any" value="${c.pl || ''}" ${canEdit?'':'disabled'} style="width:80px"/></td>
+            <td><input id="cc-pw" type="number" step="any" value="${c.pw || ''}" ${canEdit?'':'disabled'} style="width:80px"/></td>
+            <td><input id="cc-ph" type="number" step="any" value="${c.ph || ''}" ${canEdit?'':'disabled'} style="width:80px"/></td>
+          </tr></tbody>
+        </table>
+
+        ${cartonsHtml}
+        ${canEdit ? '<button class="mini" id="cc-add-b">+ 增加纸箱</button>' : ''}
+      </div>`;
+
+    if (!canEdit) return;
+    // 产品尺寸
+    ['pl','pw','ph'].forEach(k => {
+      const el = host.querySelector('#cc-' + k);
+      el.oninput = () => { c[k] = Number(el.value) || 0; onChange(); };
+    });
+    // 纸箱字段
+    host.querySelectorAll('input[data-bi]:not([data-fj])').forEach(el => {
+      el.oninput = () => {
+        const i = +el.dataset.bi, k = el.dataset.k;
+        c.cartons[i][k] = el.type === 'number' ? (el.value === '' ? 0 : Number(el.value)) : el.value;
+        onChange(); render();
+      };
+    });
+    // 平卡字段
+    host.querySelectorAll('input[data-fj]').forEach(el => {
+      el.oninput = () => {
+        const i = +el.dataset.bi, j = +el.dataset.fj, k = el.dataset.k;
+        c.cartons[i].flat_cards[j][k] = el.type === 'number' ? (el.value === '' ? 0 : Number(el.value)) : el.value;
+        onChange(); render();
+      };
+    });
+    // 删纸箱
+    host.querySelectorAll('[data-del-b]').forEach(btn => btn.onclick = () => {
+      if (!confirm('删除该纸箱（含所有平卡）？')) return;
+      c.cartons.splice(+btn.dataset.delB, 1); onChange(); render();
+    });
+    // 加纸箱
+    const addB = host.querySelector('#cc-add-b');
+    if (addB) addB.onclick = () => {
+      c.cartons.push({ name: '纸箱'+(c.cartons.length+1), cl:0, cw:0, ch:0, qty:1, ka_label:'K=A', flat_cards: [] });
+      onChange(); render();
+    };
+    // 删平卡
+    host.querySelectorAll('[data-del-f]').forEach(btn => btn.onclick = () => {
+      const [i, j] = btn.dataset.delF.split('-').map(Number);
+      c.cartons[i].flat_cards.splice(j, 1); onChange(); render();
+    });
+    // 加平卡
+    host.querySelectorAll('[data-add-f]').forEach(btn => btn.onclick = () => {
+      const i = +btn.dataset.addF;
+      c.cartons[i].flat_cards.push({ name: '平卡'+(c.cartons[i].flat_cards.length+1), l: c.cartons[i].cl || 0, w: c.cartons[i].cw || 0 });
+      onChange(); render();
+    });
+  }
+  render();
+}
+
+function renderEngineering(host, payload, canEdit, onChange, fxRmbHkd, fxRmbUsd) {
+  payload.molds = payload.molds || [];
+  payload.electronics = payload.electronics || [];
+  payload.hardware = payload.hardware || [];
+  payload.aux_materials = payload.aux_materials || [];
+  payload.packaging_materials = payload.packaging_materials || [];
+  payload.packaging_loss_pct = payload.packaging_loss_pct ?? 1;
+  payload.electronics_loss_pct = payload.electronics_loss_pct ?? 1;
+  payload.hardware_loss_pct = payload.hardware_loss_pct ?? 1;
+  payload.aux_loss_pct = payload.aux_loss_pct ?? 1;
+  payload.mold_costs = payload.mold_costs || {
+    items: [
+      { name: '模具费用', price_rmb: 0 },
+      { name: '超声模费用', price_rmb: 0 },
+      { name: '喷油模具', price_rmb: 0 },
+    ],
+    customer_subsidy_usd: 0,
+    amortization_qty: 20000,
+    fx_rmb_usd: 7.75,
+  };
+  payload.electronics_extra = payload.electronics_extra || { test_repair: 0, packing_shipping: 0, profit_pct: 10, tax_diff: 0, tax_payable: 0 };
+  ['profit_pct', 'tax_diff', 'tax_payable'].forEach(k => { if (payload.electronics_extra[k] == null) payload.electronics_extra[k] = k === 'profit_pct' ? 10 : 0; });
+
+  host.innerHTML = `
+    <h3>一、模具部分
+      ${canEdit ? `<small><label class="upload-mold-sheet" style="display:inline-block;margin-left:12px">
+        <button class="mini" type="button" onclick="this.parentElement.querySelector('input').click()">📄 上传模具报价单 (xlsx)</button>
+        <input type="file" accept=".xls,.xlsx" hidden id="mold-sheet-input" />
+      </label></small>` : ''}
+    </h3>
+    <div id="mold-sheet-preview"></div>
+    <div id="wb-molds"></div>
+
+    <h3>生产模具费用</h3>
+    <div id="wb-mold-costs"></div>
+
+    <h3>四、五金</h3>
+    <div id="wb-hw"></div>
+    <div id="wb-hw-extra"></div>
+
+    <h3>五、辅助材料</h3>
+    <div id="wb-aux"></div>
+
+    <h3>六、包装材料</h3>
+    <div id="wb-pkmat"></div>
+    <div id="wb-carton-calc" style="margin-top:14px"></div>
+  `;
+
+  renderMolds(host.querySelector('#wb-molds'), payload.molds, onChange, canEdit);
+  renderMoldCosts(host.querySelector('#wb-mold-costs'), payload.mold_costs, onChange, canEdit, fxRmbUsd);
+
+  // 上传模具报价单 → 解析 → 预览 → 应用
+  const fileInp = host.querySelector('#mold-sheet-input');
+  if (fileInp) fileInp.onchange = async (e) => {
+    const f = e.target.files[0]; if (!f) return;
+    const preview = host.querySelector('#mold-sheet-preview');
+    preview.innerHTML = '<i class="muted">正在解析…</i>';
+    try {
+      const fd = new FormData(); fd.append('file', f);
+      const r = await fetch('/api/uploads/mold-sheet', { method: 'POST', credentials: 'include', body: fd });
+      const j = await r.json();
+      if (!r.ok) throw new Error(j.error || '解析失败');
+      preview.innerHTML = `
+        <div class="card" style="background:#f0fdf4;border:1px solid #86efac;">
+          <p>从 <b>${j.sheet_used}</b> 解析到 <b>${j.molds.length}</b> 副模具：</p>
+          <table class="wb-table"><thead><tr>
+            <th>模号</th><th>名称</th><th>类型</th><th>材质</th>
+            <th>出模数</th><th>套数</th><th>周期(秒)</th><th>模具尺寸</th><th>价格RMB</th><th>备注</th>
+          </tr></thead><tbody>
+          ${j.molds.map(m => `<tr>
+            <td>${m.mold_no || ''}</td><td>${m.name}</td><td>${m.mold_type}</td>
+            <td>${m.material}</td><td>${m.cavity}</td>
+            <td>${m.sets}</td><td>${m.cycle_sec ?? ''}</td><td>${(m.detail && m.detail.mold_size) || ''}</td><td>${m.price_rmb ?? ''}</td><td>${m.note || ''}</td>
+          </tr>`).join('')}
+          </tbody></table>
+          <div style="margin-top:10px">
+            <button id="btn-apply-replace">应用（替换全部模具）</button>
+            <button id="btn-apply-append" class="mini">追加到现有列表</button>
+            <button id="btn-apply-cancel" class="mini danger">取消</button>
+          </div>
+          ${j.images_extracted ? `<p style="color:#16a34a;margin-top:8px">✓ 自动抽取了 ${j.images_extracted} 张图片并归到对应模具行。</p>` : ''}
+          ${j.images_hint ? `<p class="muted" style="margin-top:8px">ℹ️ ${j.images_hint}</p>` : ''}
+          ${j.images_extract_error ? `<p style="color:#dc2626;margin-top:8px">图片抽取失败: ${j.images_extract_error}</p>` : ''}
+        </div>`;
+      preview.querySelector('#btn-apply-replace').onclick = () => {
+        payload.molds = j.molds.map(m => ({ ...m, images: m.images || [] }));
+        preview.innerHTML = ''; fileInp.value = '';
+        renderEngineering(host, payload, canEdit, onChange, undefined, fxRmbUsd);
+        onChange();
+      };
+      preview.querySelector('#btn-apply-append').onclick = () => {
+        payload.molds = (payload.molds || []).concat(j.molds.map(m => ({ ...m, images: m.images || [] })));
+        preview.innerHTML = ''; fileInp.value = '';
+        renderEngineering(host, payload, canEdit, onChange, undefined, fxRmbUsd);
+        onChange();
+      };
+      preview.querySelector('#btn-apply-cancel').onclick = () => { preview.innerHTML = ''; fileInp.value = ''; };
+    } catch (err) {
+      preview.innerHTML = `<div class="card" style="background:#fef2f2;border:1px solid #fecaca">解析失败：${err.message}</div>`;
+    }
+  };
+
+  const freeCols = [
+    { key: 'name', label: '零件名称' },
+    { key: 'spec', label: '规格' },
+    { key: 'qty', label: '用量', type: 'number', width: '80px' },
+    { key: 'unit_price', label: '单价 HKD', type: 'number', width: '100px' },
+    { key: 'amount', label: '金额 HKD', readonly: true, calc: r => num(r.qty) * num(r.unit_price), width: '90px' },
+    { key: 'tax_pct', label: '税点 %', type: 'number', width: '90px' },
+    { key: 'note', label: '备注' },
+  ];
+  // 辅助材料：在五金列基础上插入「类别」列（减税明细按类别统计）
+  const auxCols = [
+    { key: 'name', label: '零件名称' },
+    { key: 'spec', label: '规格' },
+    { key: 'category', label: '类别', type: 'select', options: MAT_CATEGORIES, width: '120px' },
+    { key: 'qty', label: '用量', type: 'number', width: '80px' },
+    { key: 'unit_price', label: '单价 HKD', type: 'number', width: '100px' },
+    { key: 'amount', label: '金额 HKD', readonly: true, calc: r => num(r.qty) * num(r.unit_price), width: '90px' },
+    { key: 'tax_pct', label: '税点 %', type: 'number', width: '90px' },
+    { key: 'note', label: '备注' },
+  ];
+  const refreshes = [];
+  const wrappedOnChange = () => { refreshes.forEach(f => f()); onChange(); };
+
+  // 电子部分已移到 电子部 tab（renderElectronic）
+  renderTable(host.querySelector('#wb-hw'), freeCols, payload.hardware, { readonly: !canEdit, onChange: wrappedOnChange });
+  refreshes.push(renderHwExtra(host.querySelector('#wb-hw-extra'), payload, wrappedOnChange, canEdit, fxRmbHkd));
+  renderTable(host.querySelector('#wb-aux'), auxCols, payload.aux_materials, { readonly: !canEdit, onChange: wrappedOnChange });
+  refreshes.push(renderLossSummary(host.querySelector('#wb-aux'), '辅助材料 成本汇总',
+    () => sum(payload.aux_materials || [], r => num(r.qty) * num(r.unit_price)),
+    () => 0, fxRmbHkd, 'HKD'));  // 不计损耗；辅助材料为港币
+
+  // 六、包装材料
+  const pkCols = [
+    { key: 'name', label: '零件名称' },
+    { key: 'spec', label: '规格', type: 'textarea' },
+    { key: 'category', label: '类别', type: 'select', options: MAT_CATEGORIES, width: '120px' },
+    { key: 'qty', label: '用量', type: 'number', width: '80px' },
+    { key: 'unit_price', label: '单价 HKD', type: 'number', width: '100px' },
+    { key: 'amount', label: '成品金额 HKD', readonly: true, calc: r => num(r.qty) * num(r.unit_price), width: '90px' },
+    { key: 'tax_pct', label: '税点 %', type: 'number', width: '90px' },
+    { key: 'note', label: '备注' },
+  ];
+  renderTable(host.querySelector('#wb-pkmat'), pkCols, payload.packaging_materials, { readonly: !canEdit, onChange: wrappedOnChange });
+  refreshes.push(renderLossSummary(host.querySelector('#wb-pkmat'), '六、包装材料 成本汇总',
+    () => sum(payload.packaging_materials || [], r => num(r.qty) * num(r.unit_price)),
+    () => 0, fxRmbHkd, 'HKD'));  // 不计损耗；包装材料为港币
+  payload.carton_calc = payload.carton_calc || { pl: 0, pw: 0, ph: 0, cl: 0, cw: 0, ch: 0, box_price: 0, qty: 1, ka_label: 'K=A', flat_card: 0 };
+  renderCartonCalc(host.querySelector('#wb-carton-calc'), payload.carton_calc, canEdit, wrappedOnChange);
+
+}
+
+// ============ 电子部 ============
+function renderElectronic(host, payload, canEdit, onChange, fxRmbHkd) {
+  payload.electronics = payload.electronics || [];
+  payload.electronics_loss_pct = payload.electronics_loss_pct ?? 1;
+  payload.electronics_extra = payload.electronics_extra || { test_repair: 0, packing_shipping: 0, profit_pct: 10, tax_diff: 0, tax_payable: 0 };
+  ['profit_pct', 'tax_diff', 'tax_payable'].forEach(k => { if (payload.electronics_extra[k] == null) payload.electronics_extra[k] = k === 'profit_pct' ? 10 : 0; });
+
+  host.innerHTML = `
+    <h3>电子部分
+    ${canEdit ? '<button class="mini" id="el-import" type="button" style="margin-left:10px">📄 导入电子报价单</button><input id="el-file" type="file" accept=".xls,.xlsx" style="display:none"/>' : ''}
+    ${canEdit && payload.electronics_doc ? '<button class="mini" id="el-summarize" type="button" style="margin-left:6px">🔄 由明细汇总成 IC + PACB</button>' : ''}
+    ${payload.electronics_doc ? `<small style="margin-left:8px;color:#16a34a">✓ 已导入 ${payload.electronics_doc.parts_count} 行 (${payload.electronics_doc.imported_at || ''})</small>` : ''}
+    </h3>
+    <div id="el-import-preview"></div>
+    <h4 style="margin-top:14px;color:#475569">总表（报价明细 用）</h4>
+    <div id="wb-elec"></div>
+    <div id="wb-elec-detail"></div>
+    <div id="wb-elec-extra"></div>
+  `;
+  const refreshes = [];
+  const wrappedOnChange = () => { refreshes.forEach(f => f()); onChange(); };
+  renderHierElectronics(host.querySelector('#wb-elec'), payload.electronics, wrappedOnChange, canEdit, fxRmbHkd);
+  // 总表 小计 卡片（仅 IC + PACB电子 等当前 electronics 数组的合计）
+  const sumHost = document.createElement('div');
+  host.querySelector('#wb-elec').appendChild(sumHost);
+  const paintSummarySubtotal = () => {
+    const total = sum(payload.electronics || [], elecRowAmount);
+    sumHost.className = 'loss-summary';
+    sumHost.innerHTML = `
+      <div class="ls-title">总表 小计</div>
+      <div class="ls-row hi"><span class="ls-label">合计 HKD</span><span class="ls-val">${formatNum(total)}</span></div>
+    `;
+  };
+  paintSummarySubtotal();
+  refreshes.push(paintSummarySubtotal);
+  // 细表（导入的 16 行明细）展开/折叠区
+  const detailHost = host.querySelector('#wb-elec-detail');
+  if (payload.electronics_doc && payload.electronics_doc.parts && payload.electronics_doc.parts.length) {
+    const doc = payload.electronics_doc;
+    detailHost.innerHTML = `
+      <details style="margin-top:14px" ${doc._open ? 'open' : ''}>
+        <summary style="cursor:pointer;color:#475569;font-weight:600;padding:6px 0">
+          📋 细表（导入的 ${doc.parts_count} 行明细 — 会写进 电子明细 sheet）
+        </summary>
+        <table class="wb-table" style="margin-top:8px;font-size:13px">
+          <thead><tr>
+            <th style="width:50px">#</th>
+            <th style="width:120px">零件名称</th>
+            <th>规格</th>
+            <th style="width:80px">用量</th>
+            <th style="width:90px">单价 RMB</th>
+            <th style="width:90px">合计 RMB</th>
+            <th style="width:120px">备注</th>
+          </tr></thead>
+          <tbody id="elec-detail-tbody"></tbody>
+        </table>
+      </details>`;
+    const tbody = detailHost.querySelector('#elec-detail-tbody');
+    let n = 0;
+    const renderDetailRow = (i, p, isChild) => {
+      n++;
+      const tr = document.createElement('tr');
+      const ro = canEdit ? '' : 'disabled';
+      tr.innerHTML = `
+        <td class="ro">${n}</td>
+        <td><input value="${(p.name || '').replace(/"/g, '&quot;')}" data-pi="${i}" data-k="name" ${ro} /></td>
+        <td><input value="${(p.spec || '').replace(/"/g, '&quot;')}" data-pi="${i}" data-k="spec" ${ro} /></td>
+        <td><input type="number" step="any" value="${num(p.qty)}" data-pi="${i}" data-k="qty" ${ro} style="width:75px"/></td>
+        <td><input type="number" step="any" value="${num(p.unit_price)}" data-pi="${i}" data-k="unit_price" ${ro} style="width:85px"/></td>
+        <td class="ro">${formatNum(num(p.qty) * num(p.unit_price))}</td>
+        <td><input value="${(p.note || '').replace(/"/g, '&quot;')}" data-pi="${i}" data-k="note" ${ro} /></td>`;
+      if (isChild) tr.style.background = '#f8fafc';
+      tbody.appendChild(tr);
+    };
+    doc.parts.forEach((p, i) => {
+      renderDetailRow(i, p, false);
+      (p.children || []).forEach((c, ci) => {
+        // 子项以特殊索引标记 i.子index
+        const tr = document.createElement('tr');
+        n++;
+        tr.style.background = '#f8fafc';
+        const ro = canEdit ? '' : 'disabled';
+        tr.innerHTML = `
+          <td class="ro">${n}</td>
+          <td></td>
+          <td><input value="${(c.spec || '').replace(/"/g, '&quot;')}" data-pi="${i}" data-ci="${ci}" data-k="spec" ${ro} /></td>
+          <td><input type="number" step="any" value="${num(c.qty)}" data-pi="${i}" data-ci="${ci}" data-k="qty" ${ro} style="width:75px"/></td>
+          <td><input type="number" step="any" value="${num(c.unit_price)}" data-pi="${i}" data-ci="${ci}" data-k="unit_price" ${ro} style="width:85px"/></td>
+          <td class="ro">${formatNum(num(c.qty) * num(c.unit_price))}</td>
+          <td><input value="${(c.note || '').replace(/"/g, '&quot;')}" data-pi="${i}" data-ci="${ci}" data-k="note" ${ro} /></td>`;
+        tbody.appendChild(tr);
+      });
+    });
+    if (canEdit) {
+      tbody.querySelectorAll('input').forEach(inp => {
+        inp.oninput = (e) => {
+          const pi = +inp.dataset.pi, ci = inp.dataset.ci, k = inp.dataset.k;
+          const target = ci != null ? doc.parts[pi].children[+ci] : doc.parts[pi];
+          target[k] = (k === 'qty' || k === 'unit_price') ? num(e.target.value) : e.target.value;
+          onChange();
+        };
+      });
+      // 展开折叠状态记忆
+      detailHost.querySelector('details').ontoggle = (e) => { doc._open = e.target.open; };
+    }
+  } else {
+    detailHost.innerHTML = '<p class="muted" style="margin-top:10px;font-size:13px">尚未导入电子细表 — 点上方"📄 导入电子报价单"</p>';
+  }
+  renderElecExtra(host.querySelector('#wb-elec-extra'), payload, wrappedOnChange, canEdit, fxRmbHkd);
+  if (canEdit) {
+    // 由明细一键汇总成 IC + PACB电子 两行
+    const sumBtn = host.querySelector('#el-summarize');
+    if (sumBtn) sumBtn.onclick = () => {
+      const doc = payload.electronics_doc;
+      if (!doc || !doc.parts) { alert('没有导入的明细数据'); return; }
+      if (payload.electronics && payload.electronics.length > 2 && !confirm('当前总表有 ' + payload.electronics.length + ' 行，确认重置为 IC + PACB电子 两行（手填数据会丢失）？')) return;
+      const ex = doc.extras || {};
+      const taxedPrice = num(ex.taxed_price) || 0;
+      const profitPrice = num(ex.profit_price) || 0;
+      const icPart = (doc.parts || []).find(p => /IC/i.test(p.name || ''));
+      const icPrice = icPart ? num(icPart.qty) * num(icPart.unit_price) : 0;
+      const fxHere = num((payload._fx_rmb_hkd) || fxRmbHkd) || 0.85;
+      const pacbTaxedRMB = Math.max(0, taxedPrice - icPrice);
+      payload.electronics = [
+        { name: 'IC', spec: icPart ? icPart.spec : '', qty: 1,
+          unit_price: +(icPrice / fxHere).toFixed(6),
+          _unit_price_taxed: icPrice, _unit_price_pretax: icPrice,
+          tax_label: '含税', note: '' },
+        { name: 'PACB电子', spec: '含 PCB+电阻+电容+人工 等其余明细汇总', qty: 1,
+          unit_price: +(pacbTaxedRMB / fxHere).toFixed(6),
+          _unit_price_taxed: pacbTaxedRMB,
+          _unit_price_pretax: Math.max(0, profitPrice - icPrice),
+          tax_label: '含税', note: '' },
+      ];
+      onChange();
+      renderElectronic(host, payload, canEdit, onChange, fxRmbHkd);
+    };
+
+    // 导入
+    const impBtn = host.querySelector('#el-import');
+    const impFile = host.querySelector('#el-file');
+    const impPreview = host.querySelector('#el-import-preview');
+    if (impBtn && impFile) {
+      impBtn.onclick = () => impFile.click();
+      impFile.onchange = async (e) => {
+        const f = e.target.files[0]; if (!f) return;
+        impPreview.innerHTML = '<i class="muted" style="padding:8px;display:block">正在解析…</i>';
+        try {
+          const fd = new FormData(); fd.append('file', f);
+          const r = await fetch('/api/uploads/electronic-sheet', { method: 'POST', credentials: 'include', body: fd });
+          const j = await r.json();
+          if (!r.ok) throw new Error(j.error || '解析失败');
+          impPreview.innerHTML = `
+            <div class="card" style="background:#f0fdf4;border:1px solid #86efac;margin-top:10px">
+              <p>从 <b>${j.sheet_used}</b> 解析到 <b>${j.count}</b> 个零件（${(j.parts || []).reduce((a, p) => a + 1 + (p.children || []).length, 0)} 行明细）</p>
+              ${j.meta && j.meta.product ? `<p class="muted">产品: ${j.meta.product}${j.meta.customer ? ' · 客户: ' + j.meta.customer : ''}${j.meta.date ? ' · 日期: ' + j.meta.date : ''}</p>` : ''}
+              <p class="muted">导入后：会替换电子表 + 自动填充 测试费用 / 包装运输 / 利润% / 抵税差额；导出 Excel 时会附加"电子明细"分表。</p>
+              <div style="margin-top:10px;display:flex;gap:8px">
+                <button id="el-imp-apply">应用</button>
+                <button id="el-imp-cancel" class="mini danger">取消</button>
+              </div>
+            </div>`;
+          impPreview.querySelector('#el-imp-apply').onclick = () => {
+            // 导入应用后总表重置为 IC + PACB电子 两行（值从明细汇总，导入后可手改）
+            const ex2 = j.extras || {};
+            const taxedPrice = num(ex2.taxed_price) || 0;
+            const profitPrice = num(ex2.profit_price) || 0;
+            const icPart = (j.parts || []).find(p => /IC/i.test(p.name || ''));
+            const icPrice = icPart ? num(icPart.qty) * num(icPart.unit_price) : 0;
+            payload.electronics = [
+              { name: 'IC', spec: icPart ? icPart.spec : '', qty: 1,
+                unit_price: icPrice,
+                _unit_price_taxed: icPrice, _unit_price_pretax: icPrice,
+                note: '含税' },
+              { name: 'PACB电子', spec: '含 PCB+电阻+电容+人工 等其余明细汇总', qty: 1,
+                unit_price: Math.max(0, taxedPrice - icPrice),
+                _unit_price_taxed: Math.max(0, taxedPrice - icPrice),
+                _unit_price_pretax: Math.max(0, profitPrice - icPrice),
+                note: '含税' },
+            ];
+            if (j.extras) {
+              payload.electronics_extra = payload.electronics_extra || {};
+              ['test_repair', 'packing_shipping', 'profit_pct', 'tax_diff', 'tax_payable', 'bonding_cost', 'smt_cost', 'labor_cost'].forEach(k => {
+                if (j.extras[k] != null) payload.electronics_extra[k] = j.extras[k];
+              });
+            }
+            // 保存原始 parts/extras 供导出
+            payload.electronics_doc = {
+              parts: j.parts, extras: j.extras, meta: j.meta || {},
+              parts_count: j.count,
+              imported_at: new Date().toISOString().slice(0, 10),
+            };
+            impPreview.innerHTML = ''; impFile.value = '';
+            onChange();
+            renderElectronic(host, payload, canEdit, onChange, fxRmbHkd);
+          };
+          impPreview.querySelector('#el-imp-cancel').onclick = () => { impPreview.innerHTML = ''; impFile.value = ''; };
+        } catch (err) {
+          impPreview.innerHTML = `<div class="card" style="background:#fef2f2;border:1px solid #fecaca;margin-top:10px">解析失败：${err.message}</div>`;
+        }
+      };
+    }
+  }
+}
+
+// 啤机部 机型价表默认值（HK$/台 班 — 来自客户报价单）
+const DEFAULT_MACHINE_PRICES = [
+  { model: '4A-6A',     normal: '80T',    price: 940 },
+  { model: '7A-9A',     normal: '60-80T', price: 1050 },
+  { model: '10A-12A',   normal: '120T',   price: 1160 },
+  { model: '14A-16A',   normal: '150T',   price: 1490 },
+  { model: '20A',       normal: '200T',   price: 1920 },
+  { model: '24A',       normal: '260T',   price: 1920 },
+  { model: '30-32A',    normal: '320T',   price: 2220 },
+  { model: '44A',       normal: '490T',   price: 2500 },
+  { model: '46A-49.9A', normal: '',       price: 2800 },
+  { model: '60A-65A',   normal: '500T',   price: 3090 },
+  { model: '80A',       normal: '',       price: 3590 },
+  { model: '81.3A',     normal: '',       price: 3600 },
+  { model: '105A',      normal: '800T',   price: 4500 },
+];
+
+// 按 机型 在机型价表里找最匹配
+function lookupMachinePrice(model, prices) {
+  if (!model || !prices || !prices.length) return null;
+  const t = String(model).replace(/\s+/g, '').toUpperCase();
+  // 精确匹配（区间，如 4A-6A → 把 t==4A or 5A or 6A 都识别）
+  const tNum = parseFloat(t);
+  for (const p of prices) {
+    const m = String(p.model).toUpperCase().replace(/\s+/g, '');
+    const rangeMatch = m.match(/^([\d.]+)A-([\d.]+)A$/);
+    if (rangeMatch) {
+      const lo = +rangeMatch[1], hi = +rangeMatch[2];
+      if (!isNaN(tNum) && tNum >= lo && tNum <= hi) return p;
+    }
+    if (m === t) return p;
+  }
+  // 退而求其次：包含
+  return prices.find(p => t.includes(String(p.model).toUpperCase().replace(/\s+/g,''))) || null;
+}
+
+// 啤机部料价表默认值（HK$/Lb，2026 年）
+const DEFAULT_MATERIAL_PRICES = [
+  { name: 'ABS', model: '750SW', price: 8.50 },
+  { name: '透明ABS', model: 'TR558/920', price: 12.50 },
+  { name: 'HIPS', model: 'HI425', price: 7.80 },
+  { name: 'GP', model: 'MW-1', price: 7.80 },
+  { name: '1#PP', model: 'JM350/K8009', price: 6.80 },
+  { name: '1#PP', model: '7032 E3', price: 6.80 },
+  { name: '透明PP', model: '5090T', price: 7.80 },
+  { name: 'POM', model: 'F3003/M9044', price: 16.50 },
+  { name: 'POM', model: 'PM820/DM220', price: 21.50 },
+  { name: 'PVC', model: '普通透明', price: 9.00 },
+  { name: 'PVC', model: '普通本白', price: 8.00 },
+  { name: 'LDPE', model: 'G812', price: 7.80 },
+  { name: 'HDPE', model: 'HMA016', price: 8.00 },
+  { name: 'TPR', model: '本白橡胶料', price: 15.00 },
+  { name: 'TPR', model: '透明橡胶料', price: 17.00 },
+  { name: 'K料', model: 'KR-03NW', price: 15.00 },
+  { name: 'PC料', model: '2605', price: 12.50 },
+];
+
+// 按 材质/颜色 在料价表里找最匹配的单价（优先匹配 name+model 都命中，否则只匹配 name）
+// 仅在 材质 + 料型 同时匹配时返回价格；缺一个都返回 null
+function lookupMaterialPrice(material, grade, prices) {
+  if (!prices || !prices.length) return null;
+  if (!material || !grade) return null;  // 必须两者都有
+  const m = String(material).replace(/\s+/g, '').toUpperCase();
+  const g = String(grade).replace(/\s+/g, '').toUpperCase();
+  return prices.find(p => {
+    const pn = String(p.name || '').replace(/\s+/g, '').toUpperCase();
+    const pm = String(p.model || '').replace(/\s+/g, '').toUpperCase();
+    return pn === m && pm === g;
+  }) || null;
+}
+
+function renderMolding(host, payload, canEdit, onChange, refMolds, fxRmbHkd, userRole) {
+  payload.injection = payload.injection || [];
+  payload.injection_loss_pct = payload.injection_loss_pct ?? 1;
+  payload.blow_items = payload.blow_items || [];
+  // 参考表：先用本报价单已存的；没有则用全局缓存；都没有用 hardcoded 默认
+  // 全局缓存：window.__refs.material_prices / .machine_prices
+  window.__refs = window.__refs || {};
+  payload.material_prices = payload.material_prices && payload.material_prices.length
+    ? payload.material_prices
+    : (window.__refs.material_prices && window.__refs.material_prices.length
+       ? JSON.parse(JSON.stringify(window.__refs.material_prices))
+       : JSON.parse(JSON.stringify(DEFAULT_MATERIAL_PRICES)));
+  payload.machine_prices = payload.machine_prices && payload.machine_prices.length
+    ? payload.machine_prices
+    : (window.__refs.machine_prices && window.__refs.machine_prices.length
+       ? JSON.parse(JSON.stringify(window.__refs.machine_prices))
+       : JSON.parse(JSON.stringify(DEFAULT_MACHINE_PRICES)));
+  // 后台异步拉全局参考表，若本地为空（hardcoded fallback）则替换并刷新
+  if (!window.__refs._loaded) {
+    window.__refs._loaded = true;
+    Promise.all([
+      api('/refs/material_prices').then(r => r.data || []).catch(() => []),
+      api('/refs/machine_prices').then(r => r.data || []).catch(() => []),
+    ]).then(([mat, mac]) => {
+      if (mat.length) window.__refs.material_prices = mat;
+      if (mac.length) window.__refs.machine_prices = mac;
+    });
+  }
+  // 回填"普通机"列：若已有数据但 normal 字段缺失，按 DEFAULT_MACHINE_PRICES 同机型填上
+  payload.machine_prices.forEach(row => {
+    if (row.normal == null || row.normal === '') {
+      const d = DEFAULT_MACHINE_PRICES.find(x => x.model === row.model);
+      if (d && d.normal) row.normal = d.normal;
+    }
+  });
+
+  // 首次进入时若注塑表为空且工程已有模具，自动拉一次
+  if (canEdit && payload.injection.length === 0 && refMolds && refMolds.length) {
+    payload.injection = refMolds.map(m => ({
+      mold_no: m.mold_no || '', name: m.name,
+      material: m.material || '',
+      material_grade: '',
+      color: m.color || '',
+      cavity: m.cavity || '',
+      weight_g: m.weight_g ?? null,
+      cycle_sec: m.cycle_sec ?? null,
+      sets: m.sets || 1,
+    }));
+  }
+
+  const canEditPrices = canEdit && (userRole === 'supervisor' || userRole === 'admin');
+  host.innerHTML = `
+    <h3>二、注塑部分 <small>料损耗 %
+      <input id="inj-loss" type="number" step="any" style="width:60px" value="${payload.injection_loss_pct ?? 3}" ${canEdit ? '' : 'disabled'} />
+    </small>
+    ${canEdit && refMolds && refMolds.length ? `<small style="margin-left:12px"><button id="btn-sync-mold" class="mini" type="button">📥 从工程拉取/同步模具 (${refMolds.length})</button></small>` : ''}
+    ${canEdit ? `<small style="margin-left:8px"><button id="btn-auto-price" class="mini" type="button">🔄 自动按材质套料价</button></small>` : ''}
+    ${canEdit ? `<small style="margin-left:6px"><button id="btn-auto-shot" class="mini" type="button">🔄 自动按机型套啤价</button></small>` : ''}
+    </h3>
+    <div id="wb-inj"></div>
+    <div id="wb-inj-summary"></div>
+
+    <h3>二·B、吹气部分 <small class="muted">(单价含港币)</small></h3>
+    <div id="wb-blow"></div>
+
+    <details class="ref-tables" style="margin-top:18px">
+      <summary class="ref-summary">📋 参考表（料价 / 机型价）${canEditPrices ? ' · 主管可改' : ''}</summary>
+      ${canEditPrices ? '<div style="margin-top:8px"><button id="btn-pull-refs" class="mini" type="button">🔄 同步全局参考表到本单</button> <small class="muted">用最新的全局参考表覆盖本单</small></div>' : ''}
+      <div style="margin-top:10px;display:grid;grid-template-columns:1fr 1fr;gap:16px">
+        <div>
+          <h4 style="margin:0 0 6px;font-size:13px;color:#475569">料价表 <small class="muted">(HK$/Lb, 1 Lb≈454 g)</small></h4>
+          <div id="wb-material-prices"></div>
+        </div>
+        <div>
+          <h4 style="margin:0 0 6px;font-size:13px;color:#475569">机型价表 <small class="muted">(HK$/台班)</small></h4>
+          <div id="wb-machine-prices"></div>
+        </div>
+      </div>
+    </details>
+  `;
+
+  // 料价表
+  const mpCols = [
+    { key: 'name', label: '料名', width: '90px' },
+    { key: 'model', label: '型号', width: '170px' },
+    { key: 'price', label: 'HK$/Lb', type: 'number', width: '100px' },
+    { key: 'price_per_g', label: 'HK$/g', readonly: true, calc: r => num(r.price) / 454, width: '100px' },
+  ];
+  // 参考表改动：同步到全局 (debounced)
+  let refSaveTimer = null;
+  const saveRefDebounced = (key, data) => {
+    clearTimeout(refSaveTimer);
+    refSaveTimer = setTimeout(() => {
+      api('/refs/' + key, { method: 'PUT', body: JSON.stringify({ data }) }).catch(() => {});
+      window.__refs[key] = JSON.parse(JSON.stringify(data));
+    }, 500);
+  };
+  const onMatChange = () => { onChange(); saveRefDebounced('material_prices', payload.material_prices); };
+  const onMachChange = () => { onChange(); saveRefDebounced('machine_prices', payload.machine_prices); };
+  renderTable(host.querySelector('#wb-material-prices'), mpCols, payload.material_prices, { readonly: !canEditPrices, onChange: onMatChange });
+
+  // 机型价表
+  const machCols = [
+    { key: 'model', label: '机型', width: '140px' },
+    { key: 'normal', label: '普通机', width: '110px' },
+    { key: 'price', label: 'HK$/台班', type: 'number', width: '120px' },
+  ];
+  renderTable(host.querySelector('#wb-machine-prices'), machCols, payload.machine_prices, { readonly: !canEditPrices, onChange: onMachChange });
+
+  // 同步全局参考表 → 本单
+  const pullBtn = host.querySelector('#btn-pull-refs');
+  if (pullBtn) pullBtn.onclick = async () => {
+    if (!confirm('用全局参考表覆盖本单的料价表 + 机型价表？\n（仅影响本报价单，不会动其他报价单）')) return;
+    try {
+      const [mat, mac] = await Promise.all([
+        api('/refs/material_prices').then(r => r.data || []),
+        api('/refs/machine_prices').then(r => r.data || []),
+      ]);
+      if (mat.length) payload.material_prices = JSON.parse(JSON.stringify(mat));
+      if (mac.length) payload.machine_prices = JSON.parse(JSON.stringify(mac));
+      onChange();
+      renderMolding(host, payload, canEdit, onChange, refMolds, fxRmbHkd, userRole);
+      alert('✓ 已同步：' + mat.length + ' 料价 + ' + mac.length + ' 机型');
+    } catch (e) { alert('拉取失败：' + e.message); }
+  };
+
+  if (canEdit) {
+    const syncBtn = host.querySelector('#btn-sync-mold');
+    if (syncBtn) syncBtn.onclick = () => {
+      if (!confirm(`将根据工程已填的 ${refMolds.length} 副模具同步注塑表。已填行（按"模具名称"匹配）会保留其他字段，新增的会追加，工程已删除的会移除。继续？`)) return;
+      const byName = new Map(payload.injection.map(r => [r.name, r]));
+      payload.injection = refMolds.map(m => {
+        const existing = byName.get(m.name) || {};
+        return {
+          ...existing,
+          mold_no: m.mold_no || existing.mold_no || '',
+          name: m.name,
+          material: m.material || existing.material || '',
+          material_grade: existing.material_grade || '',
+          color: m.color || existing.color || '',
+          cavity: m.cavity || existing.cavity || '',
+          weight_g: m.weight_g ?? existing.weight_g ?? null,
+          cycle_sec: m.cycle_sec ?? existing.cycle_sec ?? null,
+          sets: existing.sets ?? (m.sets || 1),
+        };
+      });
+      onChange(); renderMolding(host, payload, canEdit, onChange, refMolds, fxRmbHkd, userRole);
+    };
+    const autoBtn = host.querySelector('#btn-auto-price');
+    if (autoBtn) autoBtn.onclick = () => {
+      let hit = 0, miss = [];
+      for (const row of payload.injection) {
+        // 材质 + 料型 都匹配才提取
+        const m = lookupMaterialPrice(row.material, row.material_grade, payload.material_prices);
+        if (m) { row.material_unit_price = +(m.price / 454).toFixed(5); hit++; }
+        else {
+          const key = [row.material, row.material_grade].filter(Boolean).join(' ').trim();
+          if (key) miss.push(key);
+        }
+      }
+      onChange(); renderMolding(host, payload, canEdit, onChange, refMolds, fxRmbHkd, userRole);
+      alert(`已套料价：成功 ${hit} 行${miss.length ? ' / 未匹配 ' + miss.length + ' 行: ' + [...new Set(miss)].join(', ') : ''}`);
+    };
+    const autoShot = host.querySelector('#btn-auto-shot');
+    if (autoShot) autoShot.onclick = () => {
+      let hit = 0, miss = [];
+      for (const row of payload.injection) {
+        const m = lookupMachinePrice(row.machine_model, payload.machine_prices);
+        const sets = num(row.sets) || 1;
+        const target = num(row.target) || 0;
+        if (m && target > 0) {
+          row.shot_price = +(num(m.price) / sets / target).toFixed(4);
+          if (m.normal) row.machine = m.normal;  // 同步"机台"（=普通机）
+          hit++;
+        } else if (row.machine_model) {
+          miss.push(`${row.machine_model}${target<=0?'(无目标数)':''}`);
+        }
+      }
+      // 即使没目标数也尽量填机台
+      for (const row of payload.injection) {
+        if (!row.machine && row.machine_model) {
+          const m = lookupMachinePrice(row.machine_model, payload.machine_prices);
+          if (m && m.normal) row.machine = m.normal;
+        }
+      }
+      onChange(); renderMolding(host, payload, canEdit, onChange, refMolds, fxRmbHkd, userRole);
+      alert(`已套啤价：成功 ${hit} 行${miss.length ? ' / 未处理 ' + miss.length + ' 行: ' + [...new Set(miss)].join(', ') : ''}\n公式：机型价 ÷ 套数 ÷ 目标数`);
+    };
+  }
+
+  // 颜色判断：Pantone (如 675C / 231C / 7547C) 或含 色/白/黑/灰 等
+  const isColorToken = (s) => /^\d{2,4}[A-Z]{1,2}$/.test(s) || /色|白|黑|灰|红|蓝|绿|黄|紫|棕|金|银/.test(s);
+
+  // 旧数据迁移：material_color → material / material_grade / color
+  (payload.injection || []).forEach(r => {
+    if (r.material_color && !r.material && !r.material_grade && !r.color) {
+      const parts = String(r.material_color).trim().split(/\s+/);
+      if (parts.length >= 3) {
+        r.material = parts[0];
+        const tail = parts[parts.length - 1];
+        const mid = parts.slice(1, -1).join(' ');
+        // 末段是颜色（Pantone 或 含色字）→ 中段是料型；否则中+末合并为料型
+        if (isColorToken(tail)) { r.material_grade = mid; r.color = tail; }
+        else { r.material_grade = parts.slice(1).join(' '); r.color = ''; }
+      } else if (parts.length === 2) {
+        r.material = parts[0];
+        if (isColorToken(parts[1])) r.color = parts[1];
+        else r.material_grade = parts[1];
+      } else if (parts.length === 1) {
+        r.material = parts[0];
+      }
+    }
+    // 二次修正：若 grade 看起来是颜色而 color 为空 → 把 grade 挪到 color
+    if (r.material_grade && !r.color && isColorToken(r.material_grade)) {
+      r.color = r.material_grade;
+      r.material_grade = '';
+    }
+  });
+
+  const cols = [
+    { key: 'name', label: '模具名称', type: 'textarea', width: '220px' },
+    { key: 'mold_no', label: '模号', width: '70px' },
+    { key: 'material', label: '材质', width: '70px' },
+    { key: 'material_grade', label: '料型', width: '120px', type: 'select',
+      options: (row) => {
+        const mat = String(row.material || '').trim().toUpperCase();
+        if (!mat) return [];
+        return (payload.material_prices || [])
+          .filter(p => String(p.name || '').trim().toUpperCase() === mat)
+          .map(p => p.model).filter(Boolean);
+      }
+    },
+    { key: 'color', label: '颜色', width: '70px' },
+    { key: 'weight_g', label: '啤净重(g)', type: 'number', width: '90px' },
+    { key: 'weight_loss_g', label: `料损耗 ${num(payload.injection_loss_pct ?? 3)}%`, readonly: true, width: '90px',
+      calc: r => num(r.weight_g) * (1 + num(payload.injection_loss_pct ?? 3)/100) },
+    { key: 'material_unit_price', label: '料价 HK$/g', type: 'number', width: '110px' },
+    { key: 'raw_unit', label: '原料单价 HK$', readonly: true, width: '100px',
+      calc: r => num(r.weight_g) * (1 + num(payload.injection_loss_pct ?? 3)/100) * num(r.material_unit_price) },
+    { key: 'machine', label: '机台', width: '70px' },
+    { key: 'shot_price', label: '啤价(HK$/啤)', type: 'number', width: '100px' },
+    { key: 'cavity', label: '出模数', width: '80px' },
+    { key: 'sets', label: '套数', type: 'number', width: '60px' },
+    { key: 'machine_model', label: '机型', width: '70px' },
+    { key: 'target', label: '目标数', type: 'number', width: '80px' },
+    { key: 'cycle_sec', label: '周期(秒)', type: 'number', width: '80px' },
+    { key: 'finished_amt', label: '成品金额 HK$', readonly: true, width: '100px',
+      calc: r => num(r.weight_g) * (1 + num(payload.injection_loss_pct ?? 3)/100) * num(r.material_unit_price) + num(r.shot_price) },
+    { key: 'note', label: '备注' },
+  ];
+  const wrappedOnChange = (() => { const fns = []; const w = () => { fns.forEach(f => f()); onChange(); }; w._fns = fns; return w; })();
+  renderTable(host.querySelector('#wb-inj'), cols, payload.injection, { readonly: !canEdit, onChange: wrappedOnChange });
+
+  // 二、注塑 成本汇总 — 分项求和：原料单价 / 啤价 / 成品金额
+  const injCard = host.querySelector('#wb-inj-summary');
+  const paintInj = () => {
+    const fxv = num(fxRmbHkd) || 0.85;
+    const rows = payload.injection || [];
+    const lossM = 1 + num(payload.injection_loss_pct ?? 3) / 100;  // 料损耗（默认3%）
+    const rawSum = sum(rows, r => num(r.weight_g) * lossM * num(r.material_unit_price));
+    const shotSum = sum(rows, r => num(r.shot_price));
+    const finishedSum = rawSum + shotSum;
+    injCard.className = 'loss-summary';
+    injCard.innerHTML = `
+      <div class="ls-title">二、注塑 成本汇总</div>
+      <div class="ls-row"><span class="ls-label">原料单价 总</span><span class="ls-val">${formatNum(rawSum)}</span></div>
+      <div class="ls-row"><span class="ls-label">啤价 总</span><span class="ls-val">${formatNum(shotSum)}</span></div>
+      <div class="ls-row hi"><span class="ls-label">成品金额 总 HK$</span><span class="ls-val">${formatNum(finishedSum)}</span></div>
+      <div class="ls-row hi"><span class="ls-label">合计 RMB</span><span class="ls-val">${formatNum(finishedSum / fxv)} <small class="muted">(汇率 ${fxv})</small></span></div>
+    `;
+  };
+  paintInj();
+  wrappedOnChange._fns.push(paintInj);
+  const lossInp = host.querySelector('#inj-loss');
+  if (canEdit && lossInp) lossInp.oninput = (e) => { payload.injection_loss_pct = num(e.target.value); wrappedOnChange(); renderMolding(host, payload, canEdit, onChange, refMolds, fxRmbHkd, userRole); };
+
+  // 吹气部分
+  renderBlowItems(host.querySelector('#wb-blow'), payload.blow_items, wrappedOnChange, canEdit);
+}
+
+// 吹气产品报价表（每行 = 一个 货名）
+function renderBlowItems(container, rows, onChange, canEdit) {
+  container.innerHTML = '';
+  const table = document.createElement('table'); table.className = 'wb-table';
+  table.innerHTML = `<thead><tr>
+    <th style="width:40px">#</th>
+    <th style="width:120px">货名</th>
+    <th style="width:120px">日产量/22H</th>
+    <th style="width:110px">用料</th>
+    <th style="width:90px">预估料重 g</th>
+    <th style="width:90px">料价 HK$/lb</th>
+    <th style="width:100px">产品料价</th>
+    <th style="width:80px">吹工</th>
+    <th style="width:80px">披锋</th>
+    <th style="width:90px">小计</th>
+    <th style="width:80px">利润 ×</th>
+    <th style="width:100px">合计 HK$</th>
+    <th style="width:90px">出数</th>
+    <th>模价 (¥)</th>
+    ${canEdit ? '<th style="width:36px"></th>' : ''}
+  </tr></thead><tbody></tbody>`;
+  const tbody = table.querySelector('tbody');
+
+  const calc = (r) => {
+    const matCost = num(r.weight_g) * num(r.material_price_lb) / 454;
+    const sub = matCost + num(r.blow_labor) + num(r.flash);
+    const total = sub * (num(r.profit_x) || 1);
+    return { matCost, sub, total };
+  };
+
+  rows.forEach((r, idx) => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td class="ro">${idx + 1}</td>`;
+    const refs = {};
+    const updateCalc = () => {
+      const c = calc(r);
+      refs.matCost.textContent = formatNum(c.matCost);
+      refs.sub.textContent = formatNum(c.sub);
+      refs.total.textContent = formatNum(c.total);
+    };
+    const mk = (k, type) => {
+      const td = document.createElement('td');
+      if (!canEdit) { td.className = 'ro'; td.textContent = formatNum(r[k] ?? ''); }
+      else {
+        const inp = document.createElement('input');
+        inp.type = type === 'number' ? 'number' : 'text';
+        if (type === 'number') inp.step = 'any';
+        inp.value = r[k] ?? '';
+        inp.oninput = () => { r[k] = type === 'number' ? (inp.value === '' ? null : Number(inp.value)) : inp.value; updateCalc(); onChange(); };
+        td.appendChild(inp);
+      }
+      return td;
+    };
+    tr.appendChild(mk('name', 'text'));
+    tr.appendChild(mk('capacity', 'text'));
+    tr.appendChild(mk('material', 'text'));
+    tr.appendChild(mk('weight_g', 'number'));
+    tr.appendChild(mk('material_price_lb', 'number'));
+    refs.matCost = document.createElement('td'); refs.matCost.className = 'ro';
+    tr.appendChild(refs.matCost);
+    tr.appendChild(mk('blow_labor', 'number'));
+    tr.appendChild(mk('flash', 'number'));
+    refs.sub = document.createElement('td'); refs.sub.className = 'ro';
+    tr.appendChild(refs.sub);
+    tr.appendChild(mk('profit_x', 'number'));
+    refs.total = document.createElement('td'); refs.total.className = 'ro hi';
+    tr.appendChild(refs.total);
+    tr.appendChild(mk('cavity_note', 'text'));
+    tr.appendChild(mk('mold_price_note', 'text'));
+    if (canEdit) {
+      const td = document.createElement('td');
+      const b = document.createElement('button'); b.textContent = '×'; b.className = 'mini danger';
+      b.onclick = () => { rows.splice(idx, 1); renderBlowItems(container, rows, onChange, canEdit); onChange(); };
+      td.appendChild(b); tr.appendChild(td);
+    }
+    updateCalc();
+    tbody.appendChild(tr);
+  });
+
+  container.appendChild(table);
+  // 合计 HK$
+  const totalDiv = document.createElement('div');
+  totalDiv.className = 'loss-summary';
+  totalDiv.style.marginTop = '8px';
+  const blowTotal = sum(rows, r => {
+    const mat = num(r.weight_g) * num(r.material_price_lb) / 454;
+    return (mat + num(r.blow_labor) + num(r.flash)) * (num(r.profit_x) || 1);
+  });
+  totalDiv.innerHTML = `<div class="ls-title">二·B、吹气 成本汇总</div><div class="ls-row hi"><span class="ls-label">合计 HK$</span><span class="ls-val">${formatNum(blowTotal)}</span></div>`;
+  container.appendChild(totalDiv);
+  if (canEdit) {
+    const btn = document.createElement('button');
+    btn.textContent = '+ 增加吹气货号'; btn.className = 'mini'; btn.style.marginTop = '8px';
+    btn.onclick = () => {
+      rows.push({ profit_x: 1.05, weight_g: 0, material_price_lb: 0, blow_labor: 0, flash: 0 });
+      renderBlowItems(container, rows, onChange, canEdit); onChange();
+    };
+    container.appendChild(btn);
+  }
+}
+
+function renderPainting(host, payload, canEdit, onChange, fxRmbHkd) {
+  payload.painting_items = payload.painting_items || [];
+  payload.second_proc_loss_pct = payload.second_proc_loss_pct ?? 1;
+  // 旧数据 second_proc 已废弃，不再迁移；首次进入空表
+
+  host.innerHTML = `
+    <h3>三、二次加工（印喷报价）</h3>
+    <div id="wb-pp"></div>
+  `;
+
+  const wrappedOnChange = (() => { const fns = []; const w = () => { fns.forEach(f => f()); onChange(); }; w._fns = fns; return w; })();
+  renderPaintingTable(host.querySelector('#wb-pp'), payload.painting_items, wrappedOnChange, canEdit);
+  wrappedOnChange._fns.push(renderLossSummary(host, '三、二次加工 成本汇总',
+    () => sum(payload.painting_items || [], paintingRowAmount),
+    () => 0, fxRmbHkd, 'HKD'));  // 不计损耗；喷油报价为港币
+}
+
+const PAINTING_PROCS = [
+  { key: 'clamp',  label: '夹模' },
+  { key: 'pad',    label: '移印' },
+  { key: 'spray',  label: '散枪' },
+  { key: 'edge',   label: '边模' },
+  { key: 'oil',    label: '抹油' },
+];
+
+function paintingRowAmount(r) {
+  return PAINTING_PROCS.reduce((s, p) => s + num(r[p.key + '_qty']) * num(r[p.key + '_unit']), 0);
+}
+
+function renderPaintingTable(container, rows, onChange, canEdit) {
+  container.innerHTML = '';
+  const table = document.createElement('table'); table.className = 'wb-table';
+  // 表头
+  const procHeader = PAINTING_PROCS.map(p => `<th colspan="2" style="text-align:center">${p.label}</th>`).join('');
+  const procSubhead = PAINTING_PROCS.map(_ => `<th style="width:55px">数量</th><th style="width:75px">单价 HKD</th>`).join('');
+  table.innerHTML = `<thead>
+    <tr>
+      <th rowspan="2" style="width:40px">#</th>
+      <th rowspan="2" style="width:120px">图片</th>
+      <th rowspan="2" style="width:130px">货号</th>
+      <th rowspan="2" style="width:180px">位置</th>
+      ${procHeader}
+      <th rowspan="2" style="width:90px">报价 HKD</th>
+      <th rowspan="2" style="width:200px">备注</th>
+      ${canEdit ? '<th rowspan="2" style="width:120px"></th>' : ''}
+    </tr>
+    <tr>${procSubhead}</tr>
+  </thead><tbody></tbody>`;
+  const tbody = table.querySelector('tbody');
+
+  rows.forEach((row, idx) => {
+    row.images = row.images || [];
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td class="ro">${idx + 1}</td>`;
+    // 图片
+    const tdImg = document.createElement('td'); tdImg.className = 'mold-img-cell';
+    renderImageCell(tdImg, row, canEdit, onChange);
+    tr.appendChild(tdImg);
+    // 货号
+    tr.appendChild(makePCell('item_code', 'text', row, canEdit, onChange));
+    // 位置
+    tr.appendChild(makePCell('position', 'text', row, canEdit, onChange));
+    // 五工序
+    const calcCells = [];
+    PAINTING_PROCS.forEach(p => {
+      tr.appendChild(makePCell(p.key + '_qty', 'number', row, canEdit, () => { onChange(); refreshAmt(); }));
+      tr.appendChild(makePCell(p.key + '_unit', 'number', row, canEdit, () => { onChange(); refreshAmt(); }));
+    });
+    // 报价（计算列）
+    const tdAmt = document.createElement('td'); tdAmt.className = 'ro';
+    const refreshAmt = () => { tdAmt.textContent = formatNum(paintingRowAmount(row)); };
+    refreshAmt();
+    tr.appendChild(tdAmt);
+    // 备注
+    tr.appendChild(makePCell('note', 'text', row, canEdit, onChange));
+    // 行操作
+    if (canEdit) {
+      const td = document.createElement('td'); td.className = 'row-actions';
+      const mkBtn = (label, title, fn, cls) => { const b = document.createElement('button'); b.textContent = label; b.title = title; b.className = 'mini ' + (cls||''); b.style.padding='2px 6px'; b.style.marginRight='2px'; b.onclick = fn; return b; };
+      if (idx > 0) td.appendChild(mkBtn('↑', '上移', () => { [rows[idx-1], rows[idx]] = [rows[idx], rows[idx-1]]; renderPaintingTable(container, rows, onChange, canEdit); onChange(); }));
+      if (idx < rows.length - 1) td.appendChild(mkBtn('↓', '下移', () => { [rows[idx+1], rows[idx]] = [rows[idx], rows[idx+1]]; renderPaintingTable(container, rows, onChange, canEdit); onChange(); }));
+      td.appendChild(mkBtn('⎘', '复制此行', () => { rows.splice(idx+1, 0, JSON.parse(JSON.stringify(rows[idx]))); renderPaintingTable(container, rows, onChange, canEdit); onChange(); }));
+      td.appendChild(mkBtn('×', '删除', () => { rows.splice(idx, 1); renderPaintingTable(container, rows, onChange, canEdit); onChange(); }, 'danger'));
+      tr.appendChild(td);
+    }
+    tbody.appendChild(tr);
+  });
+
+  // 合计行
+  const totals = PAINTING_PROCS.map(p => sum(rows, r => num(r[p.key + '_qty'])));
+  const totalAmt = sum(rows, paintingRowAmount);
+  const tr = document.createElement('tr'); tr.className = 'hi';
+  let html = `<td colspan="4" style="text-align:right">合计</td>`;
+  PAINTING_PROCS.forEach((p, i) => { html += `<td>${formatNum(totals[i])}</td><td></td>`; });
+  html += `<td>${formatNum(totalAmt)}</td><td></td>${canEdit ? '<td></td>' : ''}`;
+  tr.innerHTML = html;
+  tbody.appendChild(tr);
+
+  container.appendChild(table);
+  if (canEdit) {
+    const btn = document.createElement('button'); btn.textContent = '+ 增加行'; btn.className = 'mini'; btn.style.marginTop = '8px';
+    btn.onclick = () => { rows.push({ images: [] }); renderPaintingTable(container, rows, onChange, canEdit); onChange(); };
+    container.appendChild(btn);
+  }
+}
+
+function makePCell(key, type, row, canEdit, onChange) {
+  const td = document.createElement('td');
+  if (!canEdit) {
+    td.className = 'ro'; td.textContent = formatNum(row[key] ?? '');
+  } else {
+    const inp = document.createElement('input');
+    inp.type = type === 'number' ? 'number' : 'text';
+    if (type === 'number') inp.step = 'any';
+    inp.value = row[key] ?? '';
+    inp.oninput = () => { row[key] = type === 'number' ? (inp.value === '' ? null : Number(inp.value)) : inp.value; onChange(); };
+    td.appendChild(inp);
+  }
+  return td;
+}
+
+function renderAssembly(host, payload, canEdit, onChange, fxRmbHkd) {
+  payload.assembly_labor = payload.assembly_labor || [];
+  payload.packaging_labor = payload.packaging_labor || [];
+  payload.assembly_step_groups = payload.assembly_step_groups || [];
+  payload.assembly_base_rate = payload.assembly_base_rate ?? 310;
+  payload.assembly_std_time = payload.assembly_std_time ?? 11;
+
+  const ro = canEdit ? '' : 'disabled';
+  host.innerHTML = `
+    <h3>七、组装人工 — 排拉工序（按产品分组）</h3>
+    <div style="display:flex;gap:14px;flex-wrap:wrap;align-items:center;margin-bottom:10px;padding:10px;background:#fef9c3;border-radius:6px">
+      <label>基数 (HKD/人) <input id="asm-rate" type="number" step="any" value="${payload.assembly_base_rate}" style="width:80px" ${ro}/></label>
+      <label>标准工时 (H) <input id="asm-time" type="number" step="any" value="${payload.assembly_std_time}" style="width:60px" ${ro}/></label>
+      <small class="muted">人工/PCS = 基数 × 人数 ÷ 该组生产量</small>
+      ${canEdit ? '<button class="mini" id="asm-add-group" style="margin-left:auto">+ 新增产品组</button>' : ''}
+      ${canEdit ? '<button class="mini" id="asm-import" type="button">📄 导入排拉工序表</button><input id="asm-file" type="file" accept=".xls,.xlsx" style="display:none"/>' : ''}
+    </div>
+    <div id="asm-import-preview"></div>
+    <div id="wb-asm-groups"></div>
+    <div id="wb-asm-grand"></div>
+
+    <h3 style="margin-top:24px">八、包装/混装人工 — 排拉工序（按产品分组）</h3>
+    <div style="display:flex;gap:14px;flex-wrap:wrap;align-items:center;margin-bottom:10px;padding:10px;background:#fef9c3;border-radius:6px">
+      <small class="muted">人工/PCS = 基数 × 人数 ÷ 该组生产量（共享上方 基数 / 标准工时）</small>
+      ${canEdit ? '<button class="mini" id="pkg-add-group" style="margin-left:auto">+ 新增产品组</button>' : ''}
+      ${canEdit ? '<button class="mini" id="pkg-import" type="button">📄 导入排拉工序表</button><input id="pkg-file" type="file" accept=".xls,.xlsx" style="display:none"/>' : ''}
+    </div>
+    <div id="pkg-import-preview"></div>
+    <div id="wb-pkg-groups"></div>
+    <div id="wb-pkg-grand"></div>
+  `;
+  payload.packaging_step_groups = payload.packaging_step_groups || [];
+
+  const renderGroups = () => {
+    const groupsHost = host.querySelector('#wb-asm-groups');
+    const baseRate = num(payload.assembly_base_rate);
+    const stdT = num(payload.assembly_std_time);
+    let grand = 0;
+    groupsHost.innerHTML = '';
+    payload.assembly_step_groups.forEach((g, gi) => {
+      g.steps = g.steps || [];
+      g.qty = g.qty || 1;
+      const card = document.createElement('div');
+      card.className = 'labor-group';
+      card.style.cssText = 'border:1px solid #e7e5e4;border-radius:8px;padding:12px;margin-top:10px;background:#fafaf9';
+      const stepsHtml = g.steps.map((s, i) => `
+        <tr>
+          <td class="ro" style="width:40px">${i+1}</td>
+          <td><input class="asg-step-name" data-gi="${gi}" data-i="${i}" type="text" value="${(s.name||'').replace(/"/g,'&quot;')}" ${ro}/></td>
+          <td><input class="asg-step-count" data-gi="${gi}" data-i="${i}" type="number" step="1" value="${num(s.count)}" style="width:70px" ${ro}/></td>
+          <td class="ro" style="width:80px">${formatNum(stdT)}</td>
+          <td class="ro" style="width:80px">${formatNum(baseRate)}</td>
+          <td class="ro" style="width:120px;font-weight:600;color:#0369a1">${formatNum(baseRate * num(s.count) / Math.max(num(g.qty), 1))}</td>
+          <td><input class="asg-step-note" data-gi="${gi}" data-i="${i}" type="text" value="${(s.note||'').replace(/"/g,'&quot;')}" ${ro}/></td>
+          ${canEdit ? `<td style="width:50px"><button class="mini danger asg-step-del" data-gi="${gi}" data-i="${i}">×</button></td>` : ''}
+        </tr>
+      `).join('');
+      const groupTotal = g.steps.reduce((s, x) => s + baseRate * num(x.count) / Math.max(num(g.qty), 1), 0);
+      const totalPeople = g.steps.reduce((s, x) => s + num(x.count), 0);
+      grand += groupTotal;
+      card.innerHTML = `
+        <div style="display:flex;gap:10px;align-items:center;margin-bottom:8px;flex-wrap:wrap">
+          <strong style="color:#16a34a">📦 产品：</strong>
+          <input class="asg-name" data-gi="${gi}" value="${(g.product||'').replace(/"/g,'&quot;')}" placeholder="如：6寸小蜥蜴" style="width:200px" ${ro}/>
+          <label>生产量 <input class="asg-qty" data-gi="${gi}" type="number" step="any" value="${g.qty}" style="width:90px" ${ro}/></label>
+          <span class="muted">总人数：${totalPeople} · 合计 人工/PCS：<b style="color:#0369a1">${formatNum(groupTotal)} HKD</b></span>
+          ${canEdit ? `<button class="mini asg-add-step" data-gi="${gi}">+ 增加工序</button>` : ''}
+          ${canEdit ? `<button class="mini danger asg-del" data-gi="${gi}" style="margin-left:auto">删除整组</button>` : ''}
+        </div>
+        <table class="wb-table"><thead><tr>
+          <th style="width:40px">#</th>
+          <th>工序名称</th>
+          <th style="width:80px">人数</th>
+          <th style="width:80px">标准工时</th>
+          <th style="width:80px">基数 HKD</th>
+          <th style="width:120px">人工/PCS</th>
+          <th>备注</th>
+          ${canEdit ? '<th style="width:50px"></th>' : ''}
+        </tr></thead><tbody>${stepsHtml || `<tr><td colspan="${canEdit?8:7}" class="ro" style="text-align:center;padding:20px;color:#9ca3af">+ 增加工序</td></tr>`}</tbody></table>
+      `;
+      groupsHost.appendChild(card);
+    });
+    host.querySelector('#wb-asm-grand').innerHTML = `
+      <div class="labor-total" style="margin-top:10px"><span>所有产品 合计 人工/PCS</span><span style="font-weight:700;color:#16a34a">${formatNum(grand)} HKD</span></div>
+    `;
+
+    if (!canEdit) return;
+    // 绑定
+    host.querySelectorAll('.asg-name').forEach(i => i.oninput = (e) => { payload.assembly_step_groups[+i.dataset.gi].product = e.target.value; onChange(); });
+    host.querySelectorAll('.asg-qty').forEach(i => i.oninput = (e) => { payload.assembly_step_groups[+i.dataset.gi].qty = Number(e.target.value) || 1; onChange(); renderGroups(); });
+    host.querySelectorAll('.asg-step-name').forEach(i => i.oninput = (e) => { payload.assembly_step_groups[+i.dataset.gi].steps[+i.dataset.i].name = e.target.value; onChange(); });
+    host.querySelectorAll('.asg-step-count').forEach(i => i.oninput = (e) => { payload.assembly_step_groups[+i.dataset.gi].steps[+i.dataset.i].count = e.target.value === '' ? null : Number(e.target.value); onChange(); renderGroups(); });
+    host.querySelectorAll('.asg-step-note').forEach(i => i.oninput = (e) => { payload.assembly_step_groups[+i.dataset.gi].steps[+i.dataset.i].note = e.target.value; onChange(); });
+    host.querySelectorAll('.asg-step-del').forEach(b => b.onclick = () => { payload.assembly_step_groups[+b.dataset.gi].steps.splice(+b.dataset.i, 1); onChange(); renderGroups(); });
+    host.querySelectorAll('.asg-add-step').forEach(b => b.onclick = () => { payload.assembly_step_groups[+b.dataset.gi].steps.push({ name: '', count: 1, note: '' }); onChange(); renderGroups(); });
+    host.querySelectorAll('.asg-del').forEach(b => b.onclick = () => {
+      const gi = +b.dataset.gi;
+      if (!confirm(`删除产品组"${payload.assembly_step_groups[gi].product || '未命名'}"？`)) return;
+      payload.assembly_step_groups.splice(gi, 1); onChange(); renderGroups();
+    });
+  };
+  renderGroups();
+
+  if (canEdit) {
+    host.querySelector('#asm-rate').oninput = (e) => { payload.assembly_base_rate = Number(e.target.value) || 0; onChange(); renderGroups(); };
+    host.querySelector('#asm-time').oninput = (e) => { payload.assembly_std_time = Number(e.target.value) || 0; onChange(); renderGroups(); };
+    const addG = host.querySelector('#asm-add-group');
+    if (addG) addG.onclick = () => { payload.assembly_step_groups.push({ product: '', qty: 1, steps: [] }); onChange(); renderGroups(); };
+    // 导入排拉工序表
+    const impBtn = host.querySelector('#asm-import');
+    const impFile = host.querySelector('#asm-file');
+    const impPreview = host.querySelector('#asm-import-preview');
+    if (impBtn) impBtn.onclick = () => impFile.click();
+    if (impFile) impFile.onchange = async (e) => {
+      const f = e.target.files[0]; if (!f) return;
+      impPreview.innerHTML = '<i class="muted" style="padding:8px;display:block">正在解析…</i>';
+      try {
+        const fd = new FormData(); fd.append('file', f);
+        const r = await fetch('/api/uploads/assembly-sheet', { method: 'POST', credentials: 'include', body: fd });
+        const j = await r.json();
+        if (!r.ok) throw new Error(j.error || '解析失败');
+        const m = j.meta || {};
+        impPreview.innerHTML = `
+          <div class="card" style="background:#f0fdf4;border:1px solid #86efac;margin-top:10px">
+            <p>解析到 <b>${j.count}</b> 个工序<br>
+            ${m.customer ? `客名: ${m.customer} · ` : ''}${m.quote_no ? `货号: ${m.quote_no} · ` : ''}${m.target_qty ? `目标数: ${m.target_qty}` : ''}</p>
+            <div style="margin-top:10px;display:flex;gap:8px;align-items:center">
+              <label>归到产品组：
+                <input id="asm-imp-name" type="text" value="${m.customer ? '货号 ' + (m.quote_no || '') : '排拉工序'}" style="width:200px"/>
+              </label>
+              <button id="asm-imp-add">作为新组添加</button>
+              <button id="asm-imp-cancel" class="mini danger">取消</button>
+            </div>
+          </div>`;
+        impPreview.querySelector('#asm-imp-add').onclick = () => {
+          const grpName = impPreview.querySelector('#asm-imp-name').value.trim() || '排拉工序';
+          payload.assembly_step_groups.push({
+            product: grpName,
+            qty: Number(m.target_qty) || 1,
+            steps: j.steps.map(s => ({ name: s.name, count: s.count, note: '' })),
+          });
+          impPreview.innerHTML = ''; impFile.value = '';
+          onChange(); renderGroups();
+        };
+        impPreview.querySelector('#asm-imp-cancel').onclick = () => { impPreview.innerHTML = ''; impFile.value = ''; };
+      } catch (err) {
+        impPreview.innerHTML = `<div class="card" style="background:#fef2f2;border:1px solid #fecaca;margin-top:10px">解析失败：${err.message}</div>`;
+      }
+    };
+  }
+
+  // 包装/混装人工 — 排拉工序（按产品分组）
+  const renderPkgGroups = () => {
+    const groupsHost = host.querySelector('#wb-pkg-groups');
+    const baseRate = num(payload.assembly_base_rate);
+    const stdT = num(payload.assembly_std_time);
+    let grand = 0;
+    groupsHost.innerHTML = '';
+    payload.packaging_step_groups.forEach((g, gi) => {
+      g.steps = g.steps || [];
+      g.qty = g.qty || 1;
+      const card = document.createElement('div');
+      card.className = 'labor-group';
+      card.style.cssText = 'border:1px solid #e7e5e4;border-radius:8px;padding:12px;margin-top:10px;background:#fafaf9';
+      const stepsHtml = g.steps.map((s, i) => `
+        <tr>
+          <td class="ro" style="width:40px">${i+1}</td>
+          <td><input class="pkg-step-name" data-gi="${gi}" data-i="${i}" type="text" value="${(s.name||'').replace(/"/g,'&quot;')}" ${ro}/></td>
+          <td><input class="pkg-step-count" data-gi="${gi}" data-i="${i}" type="number" step="1" value="${num(s.count)}" style="width:70px" ${ro}/></td>
+          <td class="ro" style="width:80px">${formatNum(stdT)}</td>
+          <td class="ro" style="width:80px">${formatNum(baseRate)}</td>
+          <td class="ro" style="width:120px;font-weight:600;color:#0369a1">${formatNum(baseRate * num(s.count) / Math.max(num(g.qty), 1))}</td>
+          <td><input class="pkg-step-note" data-gi="${gi}" data-i="${i}" type="text" value="${(s.note||'').replace(/"/g,'&quot;')}" ${ro}/></td>
+          ${canEdit ? `<td style="width:50px"><button class="mini danger pkg-step-del" data-gi="${gi}" data-i="${i}">×</button></td>` : ''}
+        </tr>
+      `).join('');
+      const groupTotal = g.steps.reduce((s, x) => s + baseRate * num(x.count) / Math.max(num(g.qty), 1), 0);
+      const totalPeople = g.steps.reduce((s, x) => s + num(x.count), 0);
+      grand += groupTotal;
+      card.innerHTML = `
+        <div style="display:flex;gap:10px;align-items:center;margin-bottom:8px;flex-wrap:wrap">
+          <strong style="color:#16a34a">📦 产品：</strong>
+          <input class="pkg-name" data-gi="${gi}" value="${(g.product||'').replace(/"/g,'&quot;')}" placeholder="如：6寸小蜥蜴" style="width:200px" ${ro}/>
+          <label>生产量 <input class="pkg-qty" data-gi="${gi}" type="number" step="any" value="${g.qty}" style="width:90px" ${ro}/></label>
+          <span class="muted">总人数：${totalPeople} · 合计 人工/PCS：<b style="color:#0369a1">${formatNum(groupTotal)} HKD</b></span>
+          ${canEdit ? `<button class="mini pkg-add-step" data-gi="${gi}">+ 增加工序</button>` : ''}
+          ${canEdit ? `<button class="mini danger pkg-del" data-gi="${gi}" style="margin-left:auto">删除整组</button>` : ''}
+        </div>
+        <table class="wb-table"><thead><tr>
+          <th style="width:40px">#</th>
+          <th>工序名称</th>
+          <th style="width:80px">人数</th>
+          <th style="width:80px">标准工时</th>
+          <th style="width:80px">基数 HKD</th>
+          <th style="width:120px">人工/PCS</th>
+          <th>备注</th>
+          ${canEdit ? '<th style="width:50px"></th>' : ''}
+        </tr></thead><tbody>${stepsHtml || `<tr><td colspan="${canEdit?8:7}" class="ro" style="text-align:center;padding:20px;color:#9ca3af">+ 增加工序</td></tr>`}</tbody></table>
+      `;
+      groupsHost.appendChild(card);
+    });
+    host.querySelector('#wb-pkg-grand').innerHTML = `
+      <div class="labor-total" style="margin-top:10px"><span>所有产品 合计 人工/PCS</span><span style="font-weight:700;color:#16a34a">${formatNum(grand)} HKD</span></div>
+    `;
+    if (!canEdit) return;
+    host.querySelectorAll('.pkg-name').forEach(i => i.oninput = (e) => { payload.packaging_step_groups[+i.dataset.gi].product = e.target.value; onChange(); });
+    host.querySelectorAll('.pkg-qty').forEach(i => i.oninput = (e) => { payload.packaging_step_groups[+i.dataset.gi].qty = Number(e.target.value) || 1; onChange(); renderPkgGroups(); });
+    host.querySelectorAll('.pkg-step-name').forEach(i => i.oninput = (e) => { payload.packaging_step_groups[+i.dataset.gi].steps[+i.dataset.i].name = e.target.value; onChange(); });
+    host.querySelectorAll('.pkg-step-count').forEach(i => i.oninput = (e) => { payload.packaging_step_groups[+i.dataset.gi].steps[+i.dataset.i].count = e.target.value === '' ? null : Number(e.target.value); onChange(); renderPkgGroups(); });
+    host.querySelectorAll('.pkg-step-note').forEach(i => i.oninput = (e) => { payload.packaging_step_groups[+i.dataset.gi].steps[+i.dataset.i].note = e.target.value; onChange(); });
+    host.querySelectorAll('.pkg-step-del').forEach(b => b.onclick = () => { payload.packaging_step_groups[+b.dataset.gi].steps.splice(+b.dataset.i, 1); onChange(); renderPkgGroups(); });
+    host.querySelectorAll('.pkg-add-step').forEach(b => b.onclick = () => { payload.packaging_step_groups[+b.dataset.gi].steps.push({ name: '', count: 1, note: '' }); onChange(); renderPkgGroups(); });
+    host.querySelectorAll('.pkg-del').forEach(b => b.onclick = () => {
+      const gi = +b.dataset.gi;
+      if (!confirm(`删除产品组"${payload.packaging_step_groups[gi].product || '未命名'}"？`)) return;
+      payload.packaging_step_groups.splice(gi, 1); onChange(); renderPkgGroups();
+    });
+  };
+  renderPkgGroups();
+
+  if (canEdit) {
+    const addPG = host.querySelector('#pkg-add-group');
+    if (addPG) addPG.onclick = () => { payload.packaging_step_groups.push({ product: '', qty: 1, steps: [] }); onChange(); renderPkgGroups(); };
+    // 当 base_rate/std_time 改时 包装组也重画
+    const oldRate = host.querySelector('#asm-rate'), oldTime = host.querySelector('#asm-time');
+    if (oldRate) { const prev = oldRate.oninput; oldRate.oninput = (e) => { if (prev) prev(e); renderPkgGroups(); }; }
+    if (oldTime) { const prev = oldTime.oninput; oldTime.oninput = (e) => { if (prev) prev(e); renderPkgGroups(); }; }
+    // 导入排拉工序表 → 加到 包装组
+    const impBtn = host.querySelector('#pkg-import');
+    const impFile = host.querySelector('#pkg-file');
+    const impPreview = host.querySelector('#pkg-import-preview');
+    if (impBtn) impBtn.onclick = () => impFile.click();
+    if (impFile) impFile.onchange = async (e) => {
+      const f = e.target.files[0]; if (!f) return;
+      impPreview.innerHTML = '<i class="muted" style="padding:8px;display:block">正在解析…</i>';
+      try {
+        const fd = new FormData(); fd.append('file', f);
+        const r = await fetch('/api/uploads/assembly-sheet', { method: 'POST', credentials: 'include', body: fd });
+        const j = await r.json();
+        if (!r.ok) throw new Error(j.error || '解析失败');
+        const m = j.meta || {};
+        impPreview.innerHTML = `
+          <div class="card" style="background:#f0fdf4;border:1px solid #86efac;margin-top:10px">
+            <p>解析到 <b>${j.count}</b> 个工序<br>
+            ${m.customer ? `客名: ${m.customer} · ` : ''}${m.quote_no ? `货号: ${m.quote_no} · ` : ''}${m.target_qty ? `目标数: ${m.target_qty}` : ''}</p>
+            <div style="margin-top:10px;display:flex;gap:8px;align-items:center">
+              <label>归到产品组：<input id="pkg-imp-name" type="text" value="${m.quote_no ? '货号 ' + m.quote_no : '排拉工序'}" style="width:200px"/></label>
+              <button id="pkg-imp-add">作为新组添加</button>
+              <button id="pkg-imp-cancel" class="mini danger">取消</button>
+            </div>
+          </div>`;
+        impPreview.querySelector('#pkg-imp-add').onclick = () => {
+          const grpName = impPreview.querySelector('#pkg-imp-name').value.trim() || '排拉工序';
+          payload.packaging_step_groups.push({
+            product: grpName, qty: Number(m.target_qty) || 1,
+            steps: j.steps.map(s => ({ name: s.name, count: s.count, note: '' })),
+          });
+          impPreview.innerHTML = ''; impFile.value = '';
+          onChange(); renderPkgGroups();
+        };
+        impPreview.querySelector('#pkg-imp-cancel').onclick = () => { impPreview.innerHTML = ''; impFile.value = ''; };
+      } catch (err) {
+        impPreview.innerHTML = `<div class="card" style="background:#fef2f2;border:1px solid #fecaca;margin-top:10px">解析失败：${err.message}</div>`;
+      }
+    };
+  }
+}
+
+// 按产品分组的人工表（每产品独立子表 + 子小计 + 增加工序）
+function renderGroupedLabor(container, rows, onChange, canEdit) {
+  container.innerHTML = '';
+  // 按 product 顺序聚类（首次出现顺序）
+  const order = [];
+  const groupMap = new Map();
+  rows.forEach(r => {
+    const key = String(r.product || '未分组');
+    if (!groupMap.has(key)) { order.push(key); groupMap.set(key, []); }
+    groupMap.get(key).push(r);
+  });
+
+  order.forEach(product => {
+    const groupRows = groupMap.get(product);
+    const card = document.createElement('div');
+    card.className = 'labor-group';
+    card.innerHTML = `
+      <div class="labor-group-head">
+        <input class="lg-name" value="${product === '未分组' ? '' : product}" placeholder="产品名称" ${canEdit ? '' : 'disabled'} />
+        ${canEdit ? `<button class="mini danger lg-del">删除整组</button>` : ''}
+      </div>
+      <table class="wb-table"><thead><tr>
+        <th style="width:40px">#</th>
+        <th>工序名称</th>
+        <th style="width:90px">标准工时</th>
+        <th style="width:120px">工序单价(元/PCS)</th>
+        <th style="width:80px">用量</th>
+        <th style="width:90px">成品金额</th>
+        <th>备注</th>
+        ${canEdit ? '<th style="width:120px"></th>' : ''}
+      </tr></thead><tbody></tbody></table>
+      ${canEdit ? '<button class="mini lg-add">+ 增加工序</button>' : ''}
+    `;
+    const tbody = card.querySelector('tbody');
+
+    groupRows.forEach((row, idx) => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `<td class="ro">${idx + 1}</td>`;
+      const tdAmt = document.createElement('td'); tdAmt.className = 'ro';
+      const refresh = () => { tdAmt.textContent = formatNum(num(row.unit_price) * num(row.qty)); };
+      ['step'].forEach(k => tr.appendChild(makePCell(k, 'text', row, canEdit, onChange)));
+      tr.appendChild(makePCell('std_time', 'number', row, canEdit, onChange));
+      const tdUp = makePCell('unit_price', 'number', row, canEdit, () => { onChange(); refresh(); subtotalRefresh(); }); tr.appendChild(tdUp);
+      const tdQ = makePCell('qty', 'number', row, canEdit, () => { onChange(); refresh(); subtotalRefresh(); }); tr.appendChild(tdQ);
+      refresh();
+      tr.appendChild(tdAmt);
+      tr.appendChild(makePCell('note', 'text', row, canEdit, onChange));
+      if (canEdit) {
+        const td = document.createElement('td'); td.className = 'row-actions';
+        const mk = (lbl, t, fn, cls) => { const b = document.createElement('button'); b.textContent = lbl; b.title = t; b.className = 'mini ' + (cls||''); b.style.padding='2px 6px'; b.style.marginRight='2px'; b.onclick = fn; return b; };
+        const realIdx = rows.indexOf(row);
+        const sameProductIdxs = rows.map((r,i) => r.product === row.product ? i : -1).filter(i => i >= 0);
+        const pos = sameProductIdxs.indexOf(realIdx);
+        if (pos > 0) td.appendChild(mk('↑', '上移', () => { const a = sameProductIdxs[pos-1]; [rows[a], rows[realIdx]] = [rows[realIdx], rows[a]]; renderGroupedLabor(container, rows, onChange, canEdit); onChange(); }));
+        if (pos < sameProductIdxs.length-1) td.appendChild(mk('↓', '下移', () => { const a = sameProductIdxs[pos+1]; [rows[a], rows[realIdx]] = [rows[realIdx], rows[a]]; renderGroupedLabor(container, rows, onChange, canEdit); onChange(); }));
+        td.appendChild(mk('×', '删除', () => { rows.splice(realIdx, 1); renderGroupedLabor(container, rows, onChange, canEdit); onChange(); }, 'danger'));
+        tr.appendChild(td);
+      }
+      tbody.appendChild(tr);
+    });
+
+    // 子小计
+    const trSub = document.createElement('tr'); trSub.className = 'hi';
+    let subAmt = 0;
+    const subtotalRefresh = () => {
+      subAmt = sum(groupRows, r => num(r.unit_price) * num(r.qty));
+      const td = trSub.querySelector('.lg-subval');
+      if (td) td.textContent = formatNum(subAmt);
+    };
+    trSub.innerHTML = `<td colspan="5" style="text-align:right">${product === '未分组' ? '未分组' : product} 小计</td>
+      <td class="lg-subval">${formatNum(sum(groupRows, r => num(r.unit_price) * num(r.qty)))}</td>
+      <td></td>${canEdit ? '<td></td>' : ''}`;
+    tbody.appendChild(trSub);
+
+    // 重命名 / 删整组 / 增加工序
+    if (canEdit) {
+      const nameInp = card.querySelector('.lg-name');
+      nameInp.oninput = () => {
+        const newName = nameInp.value || '未分组';
+        groupRows.forEach(r => { r.product = newName === '未分组' ? '' : newName; });
+        onChange();
+      };
+      card.querySelector('.lg-del').onclick = () => {
+        if (!confirm(`删除整个"${product}"产品组的所有工序？`)) return;
+        for (let i = rows.length - 1; i >= 0; i--) if (groupRows.includes(rows[i])) rows.splice(i, 1);
+        renderGroupedLabor(container, rows, onChange, canEdit); onChange();
+      };
+      card.querySelector('.lg-add').onclick = () => {
+        rows.push({ product: product === '未分组' ? '' : product, step: '', qty: 1 });
+        renderGroupedLabor(container, rows, onChange, canEdit); onChange();
+      };
+    }
+
+    container.appendChild(card);
+  });
+
+  // 总合计
+  const totalAmt = sum(rows, r => num(r.unit_price) * num(r.qty));
+  const tot = document.createElement('div'); tot.className = 'labor-total';
+  tot.innerHTML = `<span>总合计</span><span>${formatNum(totalAmt)}</span>`;
+  container.appendChild(tot);
+
+  // 新增产品组
+  if (canEdit) {
+    const addProd = document.createElement('button');
+    addProd.textContent = '+ 新增产品组'; addProd.className = 'mini';
+    addProd.style.marginTop = '8px';
+    addProd.onclick = () => {
+      const name = prompt('新产品名称：'); if (!name) return;
+      rows.push({ product: name, step: '', qty: 1 });
+      renderGroupedLabor(container, rows, onChange, canEdit); onChange();
+    };
+    container.appendChild(addProd);
+  }
+}
+
+// 运费类型 ↔ 容量字段 配置
+const FREIGHT_TYPES = [
+  { key: 'hk40',  label: 'HK 40柜',  capKey: 'cap_40',  feeLabel: 'HK 40" 运费+吊柜费' },
+  { key: 'hk20',  label: 'HK 20柜',  capKey: 'cap_20',  feeLabel: 'HK 20" 运费+吊柜费' },
+  { key: 'yt40',  label: 'YT 40柜',  capKey: 'cap_40',  feeLabel: 'YT 40" 运费+吊柜费' },
+  { key: 'yt20',  label: 'YT 20柜',  capKey: 'cap_20',  feeLabel: 'YT 20" 运费+吊柜费' },
+  { key: 'hk10t', label: 'HK 10吨', capKey: 'cap_10t', feeLabel: 'HK 10吨运费' },
+  { key: 'yt10t', label: 'YT 10吨', capKey: 'cap_10t', feeLabel: 'YT 10吨运费' },
+  { key: 'hk5t',  label: 'HK 5吨',  capKey: 'cap_5t',  feeLabel: 'HK 5吨运费' },
+  { key: 'yt5t',  label: 'YT 5吨',  capKey: 'cap_5t',  feeLabel: 'YT 5吨运费' },
+];
+const CAPACITY_FIELDS = [
+  { key: 'cap_10t', label: '10吨车容量' },
+  { key: 'cap_5t',  label: '5吨车容量' },
+  { key: 'cap_40',  label: '40柜容量' },
+  { key: 'cap_20',  label: '20柜容量' },
+];
+
+function computeFreightMap(f, eCarton) {
+  const cuft = num(eCarton.cuft) || ((num(eCarton.cl) * num(eCarton.cw) * num(eCarton.ch)) / 1728);
+  const pcs = num(eCarton.qty) || 1;
+  const safeCuft = cuft > 0 ? cuft : 1;
+  const boxes = (cap) => Math.max(Math.round(cap / safeCuft), 1);
+  const map = { _cuft: cuft, _pcs: pcs };
+  for (const t of FREIGHT_TYPES) {
+    const b = boxes(num(f[t.capKey]));
+    map[t.key + '_box'] = b;
+    map[t.key] = num(f[t.key]) / b / Math.max(pcs, 1);
+  }
+  return map;
+}
+
+function renderFreightCalc(host, f, eCarton, canEdit, onChange) {
+  const ro = canEdit ? '' : 'readonly';
+  const inputCell = (id, key, unit) =>
+    `<td><input id="${id}" type="number" step="any" value="${num(f[key]) || ''}" ${ro} style="width:90px"/>${unit ? ` <small class="muted">${unit}</small>` : ''}</td>`;
+
+  function paint() {
+    const m = computeFreightMap(f, eCarton);
+    const set = (id, v) => { const e = host.querySelector('#' + id); if (e) e.textContent = v; };
+    set('fc-cuft', m._cuft.toFixed(2));
+    set('fc-pcs', m._pcs);
+    for (const t of FREIGHT_TYPES) {
+      set('fc-' + t.key + '-box', m[t.key + '_box']);
+      set('fc-' + t.key + '-pp', m[t.key].toFixed(2));
+    }
+  }
+
+  const capRows = CAPACITY_FIELDS.map(c =>
+    `<tr><td>${c.label}</td>${inputCell('fc-' + c.key, c.key, 'CUFT')}<td></td></tr>`).join('');
+  const feeRows = FREIGHT_TYPES.map(t =>
+    `<tr><td>${t.feeLabel}</td>${inputCell('fc-' + t.key, t.key, 'HK$')}<td></td></tr>`).join('');
+
+  const resultTable = (title, types) => `
+    <table class="wb-table" style="margin-top:10px;font-size:13px;text-align:center">
+      <thead><tr>${types.map(t => `<th>${t.label}</th>`).join('')}<th></th></tr></thead>
+      <tbody>
+        <tr>${types.map(t => `<td id="fc-${t.key}-box">0</td>`).join('')}<td class="muted">总箱数</td></tr>
+        <tr style="background:#ecfdf5;font-weight:600;color:#065f46">
+          ${types.map(t => `<td id="fc-${t.key}-pp">0</td>`).join('')}<td class="muted">运+吊柜 (HK$/PCS)</td>
+        </tr>
+      </tbody>
+    </table>`;
+
+  host.innerHTML = `
+    <div style="border:1px solid #e7e5e4;border-radius:8px;padding:10px;background:#fafaf9;max-width:900px">
+      <table class="wb-table" style="font-size:13px">
+        <tbody>
+          <tr><td>1箱的 CUFT</td><td id="fc-cuft" style="font-weight:600">0</td><td class="muted">CUFT (来自工程纸箱计算)</td></tr>
+          <tr><td>1箱装的个数</td><td id="fc-pcs" style="font-weight:600">0</td><td class="muted">PCS (来自工程纸箱计算)</td></tr>
+          ${capRows}
+          ${feeRows}
+        </tbody>
+      </table>
+      ${resultTable('集装柜', FREIGHT_TYPES.slice(0, 4))}
+      ${resultTable('卡车', FREIGHT_TYPES.slice(4))}
+    </div>`;
+  paint();
+  if (!canEdit) return;
+
+  const allFields = [
+    ...CAPACITY_FIELDS.map(c => c.key),
+    ...FREIGHT_TYPES.map(t => t.key),
+  ];
+  for (const key of allFields) {
+    const el = host.querySelector('#fc-' + key); if (!el) continue;
+    el.oninput = () => { f[key] = el.value === '' ? 0 : Number(el.value); onChange(); paint(); };
+  }
+}
+
+function matchFreightByName(name) {
+  const n = (name || '').toString();
+  const isIndo = /印尼|indo|indonesia/i.test(n);
+  const isYT = /盐田|YT|yt/.test(n);
+  const isHK = /香港|HK|hk/.test(n);
+  const prefix = isIndo ? 'indo' : (isYT ? 'yt' : (isHK ? 'hk' : null));
+  if (!prefix) return null;
+  if (/40\s*柜|40['"\s]*[尺呎]?|40hq/i.test(n)) return prefix + '40';
+  if (/20\s*柜|20['"\s]*[尺呎]?|20hq/i.test(n)) return prefix + '20';
+  if (/10\s*吨/.test(n)) return prefix + '10t';
+  if (/5\s*吨/.test(n)) return prefix + '5t';
+  return null;
+}
+
+function renderShipping(host, payload, header, canEdit, onChange, freightMap, priceHkdPerPcs, surtaxHkdPerPcs, moldShareHkdPerPcs) {
+  freightMap = freightMap || {};
+  // 自动确保第一个场景是"出厂价"（freight/lifting = 0）
+  if (!payload.shipping.scenarios.length || !payload.shipping.scenarios[0].is_factory) {
+    payload.shipping.scenarios.unshift({ name: '出厂价', base_rmb: 0, mold_share_rmb: 0, is_factory: true });
+  }
+  // 顶部小汇总：来自 九、合计 的值（每次刷新都同步）
+  payload.shipping.top = payload.shipping.top || {};
+  if (priceHkdPerPcs != null) payload.shipping.top.total_hkd = +num(priceHkdPerPcs).toFixed(4);
+  if (surtaxHkdPerPcs != null) payload.shipping.top.surtax = +num(surtaxHkdPerPcs).toFixed(4);
+  if (moldShareHkdPerPcs != null) payload.shipping.top.mold_share = +num(moldShareHkdPerPcs).toFixed(4);
+  const topData = payload.shipping.top;
+  const s = payload.shipping;
+  const fxHU = num(header.fx_hkd_usd) || 7.8;
+  const fxRH = num(header.fx_rmb_hkd) || 0.85;
+  const fmt = (n) => Number.isFinite(n) ? n.toFixed(2) : '-';
+
+  const compute = () => {
+    const totalHkd = num(topData.total_hkd);
+    const surtax = num(topData.surtax);
+    const moldShareTop = num(topData.mold_share);
+    const combined = totalHkd + surtax + moldShareTop;
+    topData.combined = +combined.toFixed(4);
+
+    s.scenarios.forEach(x => {
+      if (x.is_factory) {
+        x._freight_matched = null;
+        x.base_rmb = +totalHkd.toFixed(4); // 出厂价底价 = TOTAL HK$
+        x._freight_rate = 0;
+        return;
+      }
+      const key = matchFreightByName(x.name);
+      if (key && freightMap[key] != null) {
+        x._freight_rate = freightMap[key];
+        x._freight_matched = key;
+      } else {
+        x._freight_rate = num(x.base_rmb); // 手填的 base_rmb 当 freight rate
+        x._freight_matched = null;
+      }
+      x.base_rmb = +combined.toFixed(4); // 其他场景底价 = TOTAL + 附加税 + 模费分摊
+    });
+
+    const rows = s.scenarios.map(x => {
+      const base = num(x.base_rmb);
+      const freightRate = num(x._freight_rate);
+      const freight = x.is_factory ? 0 : freightRate * num(s.freight_pct) / 100;
+      const lifting = x.is_factory ? 0 : freightRate * num(s.lifting_pct) / 100;
+      const afterShip = base + freight + lifting;
+      const afterMarkup = afterShip * num(s.markup_x);
+      const totalHKD = afterMarkup / num(s.divisor);
+      const totalRMB = totalHKD * fxRH;
+      const totalUSD = totalHKD / fxHU;
+      const finalUSD = totalUSD;  // 模费分摊已并入顶部"合计"，不再重复
+      return { freight, lifting, afterShip, afterMarkup, totalHKD, totalRMB, totalUSD, finalUSD };
+    });
+    const target = num(s.target_usd);
+    // 报客货价 = 第一个非"出厂价"场景（默认 盐田40柜）；若全是出厂价则取最小
+    const customerIdx = s.scenarios.findIndex(x => !x.is_factory);
+    const customerUSD = (customerIdx >= 0 && rows[customerIdx]) ? rows[customerIdx].finalUSD : (rows.length ? Math.min(...rows.map(r => r.finalUSD)) : 0);
+    const diffPct = target > 0 ? (customerUSD - target) / target * 100 : 0;
+    return { rows, target, customerUSD, diffPct };
+  };
+
+  // 重算并仅刷新计算单元格 / 同步出货底价（不重建 DOM，输入不丢焦）
+  function refresh() {
+    const { rows, target, customerUSD, diffPct } = compute();
+    // 顶部小汇总刷新
+    const setTop = (id, v) => { const e = host.querySelector('#' + id); if (e) e.textContent = v; };
+    setTop('sh-top-total', fmt(num(topData.total_hkd)));
+    setTop('sh-top-surtax', fmt(num(topData.surtax)));
+    setTop('sh-top-combined', fmt(num(topData.combined)));
+    rows.forEach((r, i) => {
+      const setC = (k, v) => { const td = host.querySelector(`td[data-i="${i}"][data-k="${k}"]`); if (td) td.textContent = v; };
+      setC('freight', fmt(r.freight));
+      setC('lifting', fmt(r.lifting));
+      setC('afterShip', fmt(r.afterShip));
+      setC('afterMarkup', fmt(r.afterMarkup));
+      setC('totalHKD', fmt(r.totalHKD));
+      setC('totalRMB', fmt(r.totalRMB));
+      setC('totalUSD', fmt(r.totalUSD));
+      setC('finalUSD', fmt(r.finalUSD));
+      // 出货底价 input：matched 则同步 + 禁用 + 上色
+      const baseInp = host.querySelector(`.sc-base[data-i="${i}"]`);
+      if (baseInp) {
+        const x = s.scenarios[i];
+        if (x._freight_matched) {
+          if (document.activeElement !== baseInp) baseInp.value = x.base_rmb;
+          baseInp.disabled = true;
+          baseInp.style.background = '#ecfdf5';
+          baseInp.title = '已按场景名自动套用运费（' + x._freight_matched + '）';
+        } else {
+          baseInp.disabled = !canEdit;
+          baseInp.style.background = '';
+          baseInp.title = '';
+        }
+      }
+    });
+    const set = (sel, v, bg) => { const el = host.querySelector(sel); if (el) { el.value = v; if (bg) el.style.background = bg; } };
+    set('.sh-customer', fmt(customerUSD));
+    set('.sh-diff', target > 0 ? diffPct.toFixed(2) + '%' : '-', diffPct >= 0 ? '#fef3c7' : '#dcfce7');
+  }
+
+  // 重建整个块（场景增删 / 初次渲染时调用）
+  function build() {
+    const sc = s.scenarios;
+    const { rows, target, customerUSD, diffPct } = compute();
+    const cellTd = (i, k, r) => `<td class="ro" data-i="${i}" data-k="${k}">${fmt(r[k])}</td>`;
+    host.innerHTML = `
+      <p class="muted" style="font-size:12px;margin:0 0 10px 0">
+        出货底价 = 报客 HKD <b id="sh-top-total">${fmt(num(topData.total_hkd))}</b>
+        + 附加税 <b id="sh-top-surtax">${fmt(num(topData.surtax))}</b>
+        + 模具分摊 <b id="sh-top-mold">${fmt(num(topData.mold_share))}</b>
+        = <b style="color:#7c2d12" id="sh-top-combined">${fmt(num(topData.combined))}</b> HK$
+        <small>（数据来自上方 九、合计；其中 出厂价列 仅用报客 HKD 不加后两项）</small>
+      </p>
+      <table class="wb-table ship-table">
+        <thead><tr>
+          <th style="width:200px">项</th>
+          ${sc.map((x, i) => `<th>${canEdit ? `<div style="display:flex;gap:4px;align-items:center"><input class="sc-name" data-i="${i}" value="${x.name || ''}" style="flex:1" ${x.is_factory?'disabled':''}>${x.is_factory ? '' : `<button class="mini danger sc-del" data-i="${i}" title="删除该场景" style="padding:2px 7px">×</button>`}</div>` : (x.name || '场景' + (i+1))}</th>`).join('')}
+          ${canEdit ? '<th style="width:30px"></th>' : ''}
+        </tr></thead>
+        <tbody>
+          <tr><td>出货底价 HK$</td>${sc.map((x, i) => `<td><input class="sc-base" data-i="${i}" type="number" step="any" value="${x.base_rmb ?? 0}" ${canEdit && !x._freight_matched ? '' : 'disabled'} style="${x._freight_matched ? 'background:#ecfdf5' : ''}"></td>`).join('')}${canEdit ? '<td></td>' : ''}</tr>
+          <tr><td>运费 (${canEdit ? `<input id="sh-freight" type="number" step="any" value="${s.freight_pct}" style="width:60px">` : s.freight_pct}%)</td>${rows.map((r, i) => cellTd(i, 'freight', r)).join('')}${canEdit ? '<td></td>' : ''}</tr>
+          <tr><td>吊柜费 (${canEdit ? `<input id="sh-lifting" type="number" step="any" value="${s.lifting_pct}" style="width:60px">` : s.lifting_pct}%)</td>${rows.map((r, i) => cellTd(i, 'lifting', r)).join('')}${canEdit ? '<td></td>' : ''}</tr>
+          <tr class="hi"><td>含运 HK$</td>${rows.map((r, i) => cellTd(i, 'afterShip', r)).join('')}${canEdit ? '<td></td>' : ''}</tr>
+          <tr><td>码点 × (${canEdit ? `<input id="sh-markup" type="number" step="any" value="${s.markup_x}" style="width:60px">` : s.markup_x})</td>${rows.map((r, i) => cellTd(i, 'afterMarkup', r)).join('')}${canEdit ? '<td></td>' : ''}</tr>
+          <tr><td>找数 ÷ (${canEdit ? `<input id="sh-divisor" type="number" step="any" value="${s.divisor}" style="width:60px">` : s.divisor})</td>${rows.map((r, i) => cellTd(i, 'totalHKD', r)).join('')}${canEdit ? '<td></td>' : ''}</tr>
+          <tr class="hi"><td>TOTAL (HK$)</td>${rows.map((r, i) => cellTd(i, 'totalHKD', r)).join('')}${canEdit ? '<td></td>' : ''}</tr>
+          <tr><td>(USD) = HK$/${fxHU}</td>${rows.map((r, i) => cellTd(i, 'totalUSD', r)).join('')}${canEdit ? '<td></td>' : ''}</tr>
+          <tr class="hi"><td>TOTAL (USD)</td>${rows.map((r, i) => cellTd(i, 'finalUSD', r)).join('')}${canEdit ? '<td></td>' : ''}</tr>
+        </tbody>
+      </table>
+      <div class="ship-foot">
+        <label>报客货价 (USD) <input class="sh-customer" value="${fmt(customerUSD)}" disabled style="width:100px;background:#f0f9ff;font-weight:600"></label>
+        <label>目标价 (USD) ${canEdit ? `<input id="sh-target" type="number" step="any" value="${s.target_usd}" style="width:100px">` : `<span>${s.target_usd}</span>`}</label>
+        <label>相差 % <input class="sh-diff" value="${target > 0 ? diffPct.toFixed(2) + '%' : '-'}" disabled style="width:90px;background:${diffPct >= 0 ? '#fef3c7' : '#dcfce7'};font-weight:600"></label>
+        ${canEdit ? `<button class="mini" id="sh-add">+ 增加场景</button>` : ''}
+      </div>
+    `;
+    if (!canEdit) return;
+    // 绑定：纯数据更新 + 局部刷新（不重建 DOM）
+    const bindNum = (sel, key) => host.querySelectorAll(sel).forEach(inp => inp.oninput = () => {
+      const i = +inp.dataset.i;
+      s.scenarios[i][key] = inp.value === '' ? null : Number(inp.value);
+      onChange(); refresh();
+    });
+    host.querySelectorAll('.sc-name').forEach(inp => inp.oninput = () => {
+      const i = +inp.dataset.i;
+      s.scenarios[i].name = inp.value;
+      onChange(); refresh(); // 名字变了重新匹配运费
+    });
+    bindNum('.sc-base', 'base_rmb');
+    bindNum('.sc-mold', 'mold_share_rmb');
+    const globalMap = { freight: 'freight_pct', lifting: 'lifting_pct', markup: 'markup_x', divisor: 'divisor', target: 'target_usd' };
+    Object.entries(globalMap).forEach(([id, key]) => {
+      const el = host.querySelector('#sh-' + id);
+      if (el) el.oninput = () => { s[key] = num(el.value); onChange(); refresh(); };
+    });
+    // 结构性变更（增删场景）才重建
+    host.querySelectorAll('.sc-del').forEach(btn => btn.onclick = () => {
+      const i = +btn.dataset.i;
+      if (!confirm(`删除场景"${s.scenarios[i].name || '场景' + (i+1)}"？`)) return;
+      s.scenarios.splice(i, 1);
+      onChange(); build();
+    });
+    const addBtn = host.querySelector('#sh-add');
+    if (addBtn) addBtn.onclick = () => {
+      s.scenarios.push({ name: '场景' + (s.scenarios.length + 1), base_rmb: 0, mold_share_rmb: 0 });
+      onChange(); build();
+    };
+  }
+  build();
+}
+
+function renderSales(host, payload, quote, canEditHeader, canEditPricing, allSections, onChange, onHeaderChange) {
+  payload.header = payload.header || { currency: 'HKD', fx_hkd_usd: 7.8, fx_rmb_hkd: 0.85 };
+  payload.pricing = payload.pricing || { mgmt_fee_pct: 0, profit_pct: 10, tax_pct: 13, shipping_per_pcs: 0, mold_amortization_qty: quote.qty || 10000 };
+  payload.shipping = payload.shipping || {
+    freight_pct: 48, lifting_pct: 52, markup_x: 1.20, divisor: 0.98,
+    target_usd: 0,
+    scenarios: [
+      { name: '盐田40柜', base_rmb: 0, mold_share_rmb: 0 },
+      { name: '盐田5吨车', base_rmb: 0, mold_share_rmb: 0 },
+    ],
+  };
+
+  const h = payload.header;
+  const p = payload.pricing;
+
+  // 汇总各部门已审 section payload
+  const totals = computeTotals(allSections, p);
+
+  host.innerHTML = `
+    <h3>报价单表头</h3>
+    <div class="wb-grid2">
+      <label>货号 <input id="h-no" value="${quote.quote_no}" disabled /></label>
+      <label>产品名称 <input id="h-pn" value="${quote.product_name || ''}" ${canEditHeader ? '' : 'disabled'} /></label>
+      <label>版本 <input id="h-ver" value="${quote.version || ''}" placeholder="如 V1/改色版" ${canEditHeader ? '' : 'disabled'} /></label>
+      <label>客户 <input id="h-cu" value="${quote.customer || ''}" ${canEditHeader ? '' : 'disabled'} /></label>
+      <label>出货数量 <input id="h-qty" type="number" value="${quote.qty || ''}" ${canEditHeader ? '' : 'disabled'} /></label>
+      <label>币种
+        <select id="h-cy" ${canEditPricing ? '' : 'disabled'}>
+          <option value="HKD" ${h.currency==='HKD'?'selected':''}>HKD</option>
+          <option value="USD" ${h.currency==='USD'?'selected':''}>USD</option>
+        </select>
+      </label>
+      <label>RMB→HKD 汇率 <input id="h-fxrh" type="number" step="any" value="${h.fx_rmb_hkd}" ${canEditPricing ? '' : 'disabled'} /></label>
+      <label>HKD→USD 汇率 <input id="h-fxhu" type="number" step="any" value="${h.fx_hkd_usd}" ${canEditPricing ? '' : 'disabled'} /></label>
+    </div>
+
+    <div class="hidden">
+      <input id="p-ship" type="number" value="${p.shipping_per_pcs}" />
+      <input id="p-mgmt" type="number" value="${p.mgmt_fee_pct}" />
+      <input id="p-prof" type="number" value="${p.profit_pct}" />
+      <input id="p-tax" type="number" value="${p.tax_pct}" />
+      <input id="p-amt" type="number" value="${p.mold_amortization_qty}" />
+    </div>
+
+    <h3>九、运费计算 (HK$)</h3>
+    <div id="wb-freight"></div>
+    <p class="muted" style="font-size:13px;margin-top:8px">📌 出货价算价 已移到 <b>📊 汇总</b> tab，可在那里查看与编辑。</p>
+  `;
+
+  // 从工程取 1 箱 CUFT / 1 箱装个数
+  const engSec = (allSections || []).find(s => s.dept === 'engineering');
+  const engPayload = engSec && engSec.payload_json ? JSON.parse(engSec.payload_json) : {};
+  const eCarton = engPayload.carton_calc || {};
+  payload.freight_calc = payload.freight_calc || {
+    cap_10t: 1166, cap_5t: 750, cap_40: 1980, cap_20: 883,
+    hk40: 8000, hk20: 7100, yt40: 7200, yt20: 6000,
+    hk10t: 14900, yt10t: 11500, hk5t: 12500, yt5t: 11000,
+  };
+  renderFreightCalc(host.querySelector('#wb-freight'), payload.freight_calc, eCarton, true, onChange);
+
+  if (canEditHeader) {
+    ['h-pn', 'h-ver', 'h-cu', 'h-qty'].forEach(id => $(id).oninput = () => onHeaderChange({
+      product_name: $('h-pn').value, version: $('h-ver').value, customer: $('h-cu').value, qty: Number($('h-qty').value) || null,
+    }));
+  }
+  if (canEditPricing) {
+    $('h-cy').onchange = () => { h.currency = $('h-cy').value; onChange(); };
+    $('h-fxrh').oninput = () => { h.fx_rmb_hkd = num($('h-fxrh').value); onChange(); };
+    $('h-fxhu').oninput = () => { h.fx_hkd_usd = num($('h-fxhu').value); onChange(); };
+    [['p-ship', 'shipping_per_pcs'], ['p-mgmt', 'mgmt_fee_pct'], ['p-prof', 'profit_pct'], ['p-tax', 'tax_pct'], ['p-amt', 'mold_amortization_qty']]
+      .forEach(([id, k]) => $(id).oninput = () => { p[k] = num($(id).value); onChange(); });
+  }
+}
+
+// ==================== 跨部门汇总 ====================
+function computeTotals(sections, p) {
+  const get = (dept) => {
+    const s = sections.find(x => x.dept === dept);
+    if (!s || !s.payload_json) return null;
+    try { return JSON.parse(s.payload_json); } catch { return null; }
+  };
+  const eng = get('engineering') || {};
+  const mold = get('molding') || {};
+  const pnt = get('painting') || {};
+  const asm = get('assembly') || {};
+  const elec = get('electronic') || {};
+  const elecSrc = (elec.electronics && elec.electronics.length) ? elec.electronics : (eng.electronics || []);
+
+  // 电子/五金/辅助/包装/二次加工(喷油) 均为 HKD，换算回 RMB（×汇率）以与其余 RMB 项相加
+  const _salesFx = num((get('sales') || {}).header?.fx_rmb_hkd) || 0.85;
+  const injection = applyLoss(sum(mold.injection || [], r => num(r.shot_price) / Math.max(num(r.sets), 1)), mold.injection_loss_pct ?? 1);
+  // 注：模板里"成品金额"列其实是 啤价/套数 之类，这里先按 shot_price/sets 估算，导出时严格按模板填回。
+  const second_proc = applyLoss(sum(pnt.second_proc || [], r => num(r.price) * num(r.qty)), pnt.second_proc_loss_pct ?? 1) * _salesFx;
+  const electronics = (freeTableSubtotal(elecSrc)  // 电子部优先，与导出一致
+                    + freeTableSubtotal(eng.hardware || [])) * _salesFx;  // 五金不计损耗
+  const aux = applyLoss(freeTableSubtotal(eng.aux_materials || []), eng.aux_loss_pct ?? 1) * _salesFx;
+  const packaging_mat = applyLoss(sum(eng.packaging_materials || [], r => num(r.qty) * num(r.unit_price)), eng.packaging_loss_pct ?? 1) * _salesFx;
+  const asm_labor = sum(asm.assembly_labor || [], r => num(r.unit_price) * num(r.qty)) * _salesFx;  // 装配人工港币 → RMB
+  const pkg_labor = sum(asm.packaging_labor || [], r => num(r.unit_price) * num(r.qty)) * _salesFx;
+  const shipping = num(p.shipping_per_pcs);
+
+  const cost = injection + second_proc + electronics + aux + packaging_mat + asm_labor + pkg_labor + shipping;
+  const moldSum = sum(eng.molds || [], r => num(r.price_rmb));
+  const mold_share = moldSum / Math.max(num(p.mold_amortization_qty), 1);
+  const with_mgmt = cost * (1 + num(p.mgmt_fee_pct) / 100);
+  const with_profit = with_mgmt * (1 + num(p.profit_pct) / 100);
+  const price_rmb = with_profit * (1 + num(p.tax_pct) / 100) + mold_share;
+  // 汇率从业务表头读
+  const sales = get('sales') || {};
+  const fx_rmb_hkd = num(sales.header?.fx_rmb_hkd) || 0.85;
+  const fx_hkd_usd = num(sales.header?.fx_hkd_usd) || 7.8;
+  const price_hkd = price_rmb / fx_rmb_hkd;
+  const price_usd = price_hkd / fx_hkd_usd;
+
+  return { injection, second_proc, electronics, aux, packaging_mat, asm_labor, pkg_labor, shipping, cost, mold_share, with_mgmt, with_profit, price_rmb, price_hkd, price_usd };
+}
+
+// ==================== 入口：渲染整个详情页 ====================
+async function renderQuotePage() {
+  const id = new URLSearchParams(location.search).get('id');
+  $('qid').textContent = id;
+  const me = await api('/auth/me');
+  if ($('who-chip')) {
+    const roleZh = { admin: '管理员', supervisor: '主管', staff: '员工' }[me.role] || me.role;
+    const nm = me.display_name || me.name || me.username || '';
+    $('who-chip').textContent = `${me.dept_name} · ${roleZh}${nm ? ' · ' + nm : ''}`;
+  }
+  if ($('btn-switch')) $('btn-switch').onclick = async (e) => {
+    e.preventDefault();
+    try { await api('/auth/logout', { method: 'POST' }); } catch {}
+    location.href = './index.html';
+  };
+  const data = await api('/quotes/' + id);
+  const { quote, sections } = data;
+  window.__data = { quote, sections, me };
+  // 从业务 section 读税率，给所有 loss-summary 用
+  const salesSecForTax = sections.find(s => s.dept === 'sales');
+  if (salesSecForTax && salesSecForTax.payload_json) {
+    try { window.__salesTaxPct = num(JSON.parse(salesSecForTax.payload_json).pricing?.tax_pct ?? 13); }
+    catch { window.__salesTaxPct = 13; }
+  } else window.__salesTaxPct = 13;
+
+  // 状态徽标
+  $('status-bar').innerHTML = sections.map(s =>
+    `<span class="badge ${STATUS_CLS[s.status]}">${s.dept_name}: ${STATUS_TXT[s.status]}</span>`
+  ).join(' ');
+
+  // 工作台容器
+  const mySec = sections.find(s => s.dept === me.dept);
+  if (!mySec) { $('sections').innerHTML = '<i>未找到本部门 section</i>'; return; }
+  const payload = mySec.payload_json ? JSON.parse(mySec.payload_json) : {};
+  const canEdit = mySec.status !== 'approved' && me.dept !== 'sales' ? true : false;
+  // 业务部门 section 永远可编辑（除非已审）
+  const canEditMine = mySec.status !== 'approved';
+
+  const host = document.getElementById('sections'); host.innerHTML = '';
+
+  // 基于权限决定能看哪些部门 tab
+  const visibleDepts = sections.filter(s => hasPerm(me, DEPT_MENU[s.dept], 'view') || s.dept === me.dept);
+  const canSeeSummary = hasPerm(me, '汇总分析', 'view');
+  const showTabs = visibleDepts.length > 1 || canSeeSummary;
+  const canSeeAll = visibleDepts.length === sections.length;  // 保留旧变量给后续判断用
+  if (showTabs) {
+    const tabBar = document.createElement('div'); tabBar.className = 'dept-tabs';
+    const tabKey = 'activeTab:' + quote.id;
+    const savedTab = sessionStorage.getItem(tabKey) || me.dept;
+    visibleDepts.forEach(s => {
+      const tab = document.createElement('div'); tab.className = 'dept-tab';
+      if (s.dept === savedTab) tab.classList.add('active');
+      tab.dataset.dept = s.dept;
+      tab.innerHTML = `${s.dept_name} <small class="badge ${STATUS_CLS[s.status]}">${STATUS_TXT[s.status]}</small>`;
+      tab.onclick = () => {
+        sessionStorage.setItem(tabKey, s.dept);
+        host.querySelectorAll('.dept-tab').forEach(t => t.classList.remove('active'));
+        tab.classList.add('active');
+        host.querySelectorAll('.section-pane').forEach(p => p.style.display = p.dataset.dept === s.dept ? '' : 'none');
+      };
+      tabBar.appendChild(tab);
+    });
+    if (canSeeSummary) {
+      // 汇总 tab
+      const sumTab = document.createElement('div'); sumTab.className = 'dept-tab';
+      if (savedTab === '__summary__') sumTab.classList.add('active');
+      sumTab.dataset.dept = '__summary__';
+      sumTab.innerHTML = '📊 汇总';
+      sumTab.onclick = () => {
+        sessionStorage.setItem(tabKey, '__summary__');
+        host.querySelectorAll('.dept-tab').forEach(t => t.classList.remove('active'));
+        sumTab.classList.add('active');
+        host.querySelectorAll('.section-pane').forEach(p => p.style.display = p.dataset.dept === '__summary__' ? '' : 'none');
+      };
+      tabBar.appendChild(sumTab);
+    }
+    host.appendChild(tabBar);
+
+    if (canSeeSummary) {
+      const sumPane = document.createElement('div'); sumPane.className = 'card section-pane';
+      sumPane.dataset.dept = '__summary__';
+      sumPane.style.display = 'none';
+      renderSummaryPane(sumPane, sections, quote, me);
+      host.appendChild(sumPane);
+    }
+  }
+
+  const wb = document.createElement('div'); wb.className = 'card section-pane'; wb.dataset.dept = mySec.dept; host.appendChild(wb);
+  wb.innerHTML = `<h2>我的工作台 — ${mySec.dept_name} <small class="badge ${STATUS_CLS[mySec.status]}">${STATUS_TXT[mySec.status]}</small></h2>
+    <div id="wb-body"></div>
+    <div class="wb-bar">
+      ${canEditMine ? `<button id="btn-save">保存草稿</button>
+                       <button id="btn-submit">提交审核</button>` : ''}
+      ${(me.role === 'supervisor' || me.role === 'admin') && mySec.status === 'filled'
+        ? `<button id="btn-approve">审核通过</button>
+           <button id="btn-reject" class="danger">驳回</button>` : ''}
+      ${mySec.status === 'approved'
+        ? `<button id="btn-reopen" class="mini">🔓 解除审核 / 重新编辑</button>` : ''}
+      ${mySec.review_comment ? `<span class="muted">${mySec.review_comment}</span>` : ''}
+    </div>`;
+
+  const onChange = () => {}; // 实时刷新留给各 render 内部
+  const body = wb.querySelector('#wb-body');
+
+  // 取工程已审模具，供啤机参考行使用
+  // 工程模具摘要：后端不论审核状态都会返回，供啤机/喷油/装配作参考
+  const refMolds = data.engineering_molds || [];
+
+  if (me.dept === 'sales') {
+    renderSales(body, payload, quote, canEditMine, canEditMine, sections, onChange, async (patch) => {
+      // 表头改动直接更新 quotes 表
+      await api('/quotes/' + id + '/header', { method: 'PUT', body: JSON.stringify(patch) }).catch(e => alert(e.message));
+    });
+  } else {
+    const salesSec = sections.find(x => x.dept === 'sales');
+    const salesHdr = salesSec && salesSec.payload_json ? (JSON.parse(salesSec.payload_json).header || {}) : {};
+    const fx = num(salesHdr.fx_rmb_hkd) || 0.85;
+    const fxHU = num(salesHdr.fx_hkd_usd) || 7.8;
+    const fxRmbUsd = fx * fxHU || 6.63;
+    if (me.dept === 'engineering') renderEngineering(body, payload, canEditMine, onChange, fx, fxRmbUsd);
+    else if (me.dept === 'electronic') renderElectronic(body, payload, canEditMine, onChange, fx);
+    else if (me.dept === 'molding') renderMolding(body, payload, canEditMine, onChange, refMolds, fx, me.role);
+    else if (me.dept === 'painting') renderPainting(body, payload, canEditMine, onChange, fx);
+    else if (me.dept === 'slush') renderSlush(body, payload, canEditMine, onChange, fx);
+    else if (me.dept === 'sewing') renderSewing(body, payload, canEditMine, onChange, fx);
+    else if (me.dept === 'assembly') renderAssembly(body, payload, canEditMine, onChange, fx);
+  }
+
+  // 其他部门 section 渲染（用户对哪些部门有 view 权限就渲染哪些）
+  if (visibleDepts.length > 1) {
+    const others = visibleDepts.filter(s => s.dept !== me.dept);
+    const salesSecForFx = sections.find(x => x.dept === 'sales');
+    const salesHdrOther = salesSecForFx && salesSecForFx.payload_json ? (JSON.parse(salesSecForFx.payload_json).header || {}) : {};
+    const fxRate = num(salesHdrOther.fx_rmb_hkd) || 0.85;
+    const fxRateUsd = fxRate * (num(salesHdrOther.fx_hkd_usd) || 7.8) || 6.63;
+
+    others.forEach(s => {
+      const sectionPayload = s.payload_json ? JSON.parse(s.payload_json) : {};
+      // 默认只读，避免业务/工程不小心点保存覆盖其他部门数据
+      // 点"✏️ 进入编辑"切换为可写
+      let inEdit = false;
+      const c = document.createElement('div'); c.className = 'card section-pane';
+      c.dataset.dept = s.dept;
+      c.style.display = 'none';
+      const renderHeader = () => `<h2>${s.dept_name} <small class="badge ${STATUS_CLS[s.status]}">${STATUS_TXT[s.status]}</small>
+        ${s.reviewed_at ? `<small class="muted" style="font-weight:normal;font-size:13px">审于 ${s.reviewed_at}</small>` : ''}
+        ${inEdit ? `<small style="color:#dc2626;font-weight:600;margin-left:8px">⚠️ 编辑模式</small>` : ''}</h2>`;
+      const renderBar = () => `<div class="wb-bar">
+        ${s.status !== 'approved' && !inEdit ? `<button data-act="enter-edit" class="mini">✏️ 进入编辑</button>` : ''}
+        ${inEdit ? `<button data-act="save">保存草稿</button>
+                    <button data-act="submit">提交审核</button>
+                    <button data-act="exit-edit" class="mini">退出编辑（不保存）</button>` : ''}
+        ${s.status === 'filled' && !inEdit ? `<button data-act="approve">审核通过</button>
+                                              <button data-act="reject" class="danger">驳回</button>` : ''}
+        ${s.status === 'approved' && !inEdit ? `<button data-act="reopen" class="mini">🔓 解除审核</button>` : ''}
+        ${s.review_comment ? `<span class="muted">${s.review_comment}</span>` : ''}
+      </div>`;
+      c.innerHTML = renderHeader() + '<div class="ro-body"></div>' + renderBar();
+      const body = c.querySelector('.ro-body');
+      const renderBody = () => {
+        body.innerHTML = '';
+        const onChangeOther = () => {};
+        if (s.dept === 'engineering') renderEngineering(body, sectionPayload, inEdit, onChangeOther, fxRate, fxRateUsd);
+        else if (s.dept === 'electronic') renderElectronic(body, sectionPayload, inEdit, onChangeOther, fxRate);
+        else if (s.dept === 'sales') renderSales(body, sectionPayload, quote, inEdit, inEdit, sections, onChangeOther, async (patch) => {
+          await api('/quotes/' + id + '/header', { method: 'PUT', body: JSON.stringify(patch) }).catch(e => alert(e.message));
+        });
+        else if (s.dept === 'molding') renderMolding(body, sectionPayload, inEdit, onChangeOther, data.engineering_molds || [], fxRate, me.role);
+        else if (s.dept === 'painting') renderPainting(body, sectionPayload, inEdit, onChangeOther, fxRate);
+        else if (s.dept === 'slush') renderSlush(body, sectionPayload, inEdit, onChangeOther, fxRate);
+        else if (s.dept === 'sewing') renderSewing(body, sectionPayload, inEdit, onChangeOther, fxRate);
+        else if (s.dept === 'assembly') renderAssembly(body, sectionPayload, inEdit, onChangeOther, fxRate);
+      };
+      renderBody();
+
+      // 绑定本卡操作（每次重渲染都重新绑定）
+      const bindActs = () => {
+        c.querySelectorAll('button[data-act]').forEach(btn => {
+          btn.onclick = async () => {
+            const act = btn.dataset.act;
+            if (act === 'enter-edit') {
+              inEdit = true;
+              c.querySelector('h2').outerHTML = renderHeader();
+              c.querySelector('.wb-bar').outerHTML = renderBar();
+              renderBody();
+              bindActs();
+              return;
+            }
+            if (act === 'exit-edit') {
+              inEdit = false;
+              // 重新解析原始 payload，丢弃未保存改动
+              Object.keys(sectionPayload).forEach(k => delete sectionPayload[k]);
+              Object.assign(sectionPayload, s.payload_json ? JSON.parse(s.payload_json) : {});
+              c.querySelector('h2').outerHTML = renderHeader();
+              c.querySelector('.wb-bar').outerHTML = renderBar();
+              renderBody();
+              bindActs();
+              return;
+            }
+            try {
+              if (act === 'save' || act === 'submit') {
+                if (!confirm(`确认保存到 ${s.dept_name} section？该部门已有数据会被覆盖。`)) return;
+                await api('/sections/' + s.id, { method: 'PUT', body: JSON.stringify({ payload: sectionPayload, submit: act === 'submit' }) });
+              } else if (act === 'approve') {
+                await api('/reviews/' + s.id, { method: 'POST', body: JSON.stringify({ action: 'approve' }) });
+              } else if (act === 'reject') {
+                const comment = prompt('驳回理由：'); if (comment == null) return;
+                await api('/reviews/' + s.id, { method: 'POST', body: JSON.stringify({ action: 'reject', comment }) });
+              } else if (act === 'reopen') {
+                const reason = prompt('解除理由（写入修改记录）：'); if (reason == null) return;
+                await api('/reviews/' + s.id + '/reopen', { method: 'POST', body: JSON.stringify({ reason }) });
+              }
+              renderQuotePage();
+            } catch (e) { alert(e.message); }
+          };
+        });
+      };
+      bindActs();
+
+      host.appendChild(c);
+    });
+  }
+
+  // 恢复上次激活的 tab 对应的 pane
+  if (showTabs) {
+    const savedTab = sessionStorage.getItem('activeTab:' + quote.id) || me.dept;
+    host.querySelectorAll('.section-pane').forEach(p => {
+      p.style.display = p.dataset.dept === savedTab ? '' : 'none';
+    });
+  }
+
+  // 导出按钮
+  const exp = document.createElement('div'); exp.className = 'card';
+  const approved = sections.filter(s => s.status === 'approved').length;
+  const totalDepts = sections.length;
+  exp.innerHTML = `<button id="btn-export" ${approved < totalDepts ? 'disabled' : ''}>导出内部明细表 (${approved}/${totalDepts})</button>
+    <pre id="export-result" style="margin-top:10px;max-height:300px;overflow:auto"></pre>`;
+  host.appendChild(exp);
+
+  // 行为绑定
+  const saveSection = async (submit) => {
+    try {
+      await api('/sections/' + mySec.id, { method: 'PUT', body: JSON.stringify({ payload, submit }) });
+      renderQuotePage();
+    } catch (e) { alert(e.message); }
+  };
+  $('btn-save') && ($('btn-save').onclick = () => saveSection(false));
+  $('btn-submit') && ($('btn-submit').onclick = () => saveSection(true));
+  $('btn-approve') && ($('btn-approve').onclick = async () => {
+    try { await api('/reviews/' + mySec.id, { method: 'POST', body: JSON.stringify({ action: 'approve' }) }); renderQuotePage(); }
+    catch (e) { alert(e.message); }
+  });
+  $('btn-reject') && ($('btn-reject').onclick = async () => {
+    const comment = prompt('驳回理由：'); if (comment == null) return;
+    try { await api('/reviews/' + mySec.id, { method: 'POST', body: JSON.stringify({ action: 'reject', comment }) }); renderQuotePage(); }
+    catch (e) { alert(e.message); }
+  });
+  $('btn-export').onclick = async () => {
+    try {
+      const r = await fetch('/api/quotes/' + id + '/export', { credentials: 'include' });
+      if (!r.ok) {
+        const j = await r.json().catch(() => ({})); throw new Error(j.error || r.statusText);
+      }
+      const blob = await r.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${data.quote.quote_no || id}_内部报价明细.xlsx`;
+      document.body.appendChild(a); a.click(); a.remove();
+      URL.revokeObjectURL(url);
+    } catch (e) { alert(e.message); }
+  };
+  if ($('btn-reopen')) $('btn-reopen').onclick = async () => {
+    const reason = prompt('解除审核理由（会写入修改记录）：');
+    if (reason == null) return;
+    try {
+      await api('/reviews/' + mySec.id + '/reopen', { method: 'POST', body: JSON.stringify({ reason }) });
+      renderQuotePage();
+    } catch (e) { alert(e.message); }
+  };
+
+  // ============ 修改记录时间线 ============
+  await renderAuditLog(host, id);
+}
+
+const ACTION_LABEL = {
+  create: '创建报价单', login: '登录', fill: '保存草稿', submit: '提交审核',
+  approve: '✅ 审核通过', reject: '❌ 驳回', reopen: '🔓 解除审核',
+  export: '📤 导出', edit_header: '✏️ 修改表头', change_pin: '修改 PIN',
+  reset_staff_pin: '重置员工 PIN',
+  view: '👁️ 浏览', clone: '📋 复制',
+};
+
+async function renderAuditLog(host, quoteId) {
+  let rows;
+  try { rows = await api('/quotes/' + quoteId + '/audit-log'); }
+  catch (e) { return; }
+  const c = document.createElement('div'); c.className = 'card';
+  c.innerHTML = `<h3>修改记录
+      <small class="muted" id="audit-count">共 ${rows.length} 条</small>
+      <input id="audit-search" class="audit-search" placeholder="🔍 搜索 部门 / 人 / 动作 / 备注…" />
+    </h3>
+    <div class="audit-list"></div>`;
+  const list = c.querySelector('.audit-list');
+  const search = c.querySelector('#audit-search');
+  const countEl = c.querySelector('#audit-count');
+
+  function rowText(r) {
+    return [r.at, r.dept_name, r.dept, r.actor, r.action, ACTION_LABEL[r.action], r.detail]
+      .filter(Boolean).join(' ').toLowerCase();
+  }
+  const PAGE_SIZE = 15;
+  let page = 1;
+  function render() {
+    const q = (search.value || '').trim().toLowerCase();
+    const filtered = q ? rows.filter(r => rowText(r).includes(q)) : rows;
+    const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+    if (page > totalPages) page = totalPages;
+    const start = (page - 1) * PAGE_SIZE;
+    const slice = filtered.slice(start, start + PAGE_SIZE);
+    countEl.textContent = q ? `匹配 ${filtered.length} / ${rows.length}` : `共 ${rows.length} 条`;
+    if (!filtered.length) {
+      list.innerHTML = '<i class="muted">无匹配记录</i>';
+    } else {
+      list.innerHTML = slice.map(r => `
+        <div class="audit-row">
+          <span class="audit-at">${fmtAuditAt(r.at)}</span>
+          <span class="audit-dept">${r.dept_name || r.dept || '系统'}</span>
+          <span class="audit-actor">${r.actor || '匿名'}</span>
+          <span class="audit-action">${ACTION_LABEL[r.action] || r.action}</span>
+          <span class="audit-detail muted">${r.detail ? escapeHtml(r.detail) : ''}</span>
+        </div>`).join('');
+      // 分页器
+      const pager = document.createElement('div'); pager.className = 'audit-pager';
+      pager.innerHTML = `
+        <button class="mini" ${page <= 1 ? 'disabled' : ''} data-pg="prev">‹ 上一页</button>
+        <span>${page} / ${totalPages}</span>
+        <button class="mini" ${page >= totalPages ? 'disabled' : ''} data-pg="next">下一页 ›</button>`;
+      pager.querySelector('[data-pg="prev"]').onclick = () => { if (page > 1) { page--; render(); } };
+      pager.querySelector('[data-pg="next"]').onclick = () => { if (page < totalPages) { page++; render(); } };
+      list.appendChild(pager);
+    }
+  }
+  search.oninput = () => { page = 1; render(); };
+  render();
+  host.appendChild(c);
+}
+
+function fmtAuditAt(s) {
+  if (!s) return '';
+  const d = new Date(s.includes('T') ? s : s.replace(' ', 'T') + 'Z');
+  if (isNaN(d.getTime())) return s;
+  const p = (n) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())} ${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`;
+}
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, c => ({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' }[c]));
+}
+
+renderQuotePage();

--- a/apps/业务部/内部报价系统/package.json
+++ b/apps/业务部/内部报价系统/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "internal-quote",
+  "version": "0.1.0",
+  "private": true,
+  "description": "公司内部报价明细系统 - 多部门分工填写 + 主管审核 + 受控导出",
+  "main": "backend/server.js",
+  "scripts": {
+    "start": "node backend/server.js",
+    "dev": "node --watch backend/server.js"
+  },
+  "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "cookie-session": "^2.1.0",
+    "exceljs": "^4.4.0",
+    "express": "^4.19.2",
+    "fast-xml-parser": "^5.8.0",
+    "jszip": "^3.10.1",
+    "multer": "^2.1.1",
+    "xlsx": "^0.18.5"
+  }
+}

--- a/docker-compose.cloud.yml
+++ b/docker-compose.cloud.yml
@@ -472,7 +472,7 @@ services:
       context: ./apps/业务部/内部报价系统
       dockerfile: Dockerfile
     environment:
-      - PORT=3210
+      - PORT=3211
       - NODE_ENV=production
       - SESSION_SECRET=${INTERNAL_QUOTE_SESSION_SECRET:-}
       - ADMIN_INITIAL_PASSWORD=${INTERNAL_QUOTE_ADMIN_PASSWORD:-}
@@ -480,7 +480,7 @@ services:
       - ./apps/业务部/内部报价系统/backend/data:/app/backend/data
       - ./apps/业务部/内部报价系统/backend/uploads:/app/backend/uploads
     healthcheck:
-      test: ["CMD", "node", "-e", "require('http').get('http://127.0.0.1:3210/health',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"]
+      test: ["CMD", "node", "-e", "require('http').get('http://127.0.0.1:3211/health',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/docker-compose.cloud.yml
+++ b/docker-compose.cloud.yml
@@ -467,6 +467,34 @@ services:
     networks:
       - platform-net
 
+  internal-quote:
+    build:
+      context: ./apps/业务部/内部报价系统
+      dockerfile: Dockerfile
+    environment:
+      - PORT=3210
+      - NODE_ENV=production
+      - SESSION_SECRET=${INTERNAL_QUOTE_SESSION_SECRET:-}
+      - ADMIN_INITIAL_PASSWORD=${INTERNAL_QUOTE_ADMIN_PASSWORD:-}
+    volumes:
+      - ./apps/业务部/内部报价系统/backend/data:/app/backend/data
+      - ./apps/业务部/内部报价系统/backend/uploads:/app/backend/uploads
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('http').get('http://127.0.0.1:3210/health',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    mem_limit: 512m
+    memswap_limit: 512m
+    restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    networks:
+      - platform-net
+
   tomy-paiqi:
     build:
       context: ./apps/业务部/TOMY排期核对系统

--- a/frontend/index.cloud.html
+++ b/frontend/index.cloud.html
@@ -366,6 +366,12 @@
             </div>
             <div class="plugin-item">
               <div class="plugin-info">
+                <div class="plugin-dot gray" id="internalQuoteDot"></div>
+                <span class="plugin-name">内部报价系统</span>
+              </div>
+            </div>
+            <div class="plugin-item">
+              <div class="plugin-info">
                 <div class="plugin-dot gray" id="tomyDot"></div>
                 <span class="plugin-name">TOMY排期核对系统</span>
               </div>
@@ -640,6 +646,26 @@
 
     <div class="detail-plugin-card">
       <div class="detail-plugin-left">
+        <div class="detail-plugin-icon" style="background:linear-gradient(135deg,#0ea5e9,#2563eb);">&#128221;</div>
+        <div>
+          <div class="detail-plugin-name">内部报价系统</div>
+          <div class="detail-plugin-desc">多部门分工填写(业务/工程/电子/啤机/喷油/搪胶/车缝/装配) + 主管审核 + 受控导出内部报价明细 xlsx</div>
+          <div class="feature-grid">
+            <div class="feature-tag">&#128101; 多部门协作</div>
+            <div class="feature-tag">&#9989; 主管审核</div>
+            <div class="feature-tag">&#128202; 减税明细/成本汇总</div>
+            <div class="feature-tag">&#128229; Excel 导出</div>
+          </div>
+        </div>
+      </div>
+      <div class="detail-plugin-right">
+        <div class="detail-plugin-status"><div class="plugin-dot gray" id="internalQuoteDetailDot"></div> 检查中...</div>
+        <a href="/internal-quote/" target="_blank" class="btn btn-primary">打开系统</a>
+      </div>
+    </div>
+
+    <div class="detail-plugin-card">
+      <div class="detail-plugin-left">
         <div class="detail-plugin-icon" style="background:linear-gradient(135deg,#f59e0b,#ef4444);">&#128197;</div>
         <div>
           <div class="detail-plugin-name">TOMY排期核对系统</div>
@@ -895,6 +921,7 @@ async function checkHealth() {
       { name: 'zuruOrder', url: '/zuru-order-system/health', dot: 'zuruOrderDot', detailDot: 'zuruOrderDetailDot' },
       { name: 'liwenjuan', url: '/liwenjuan/health', dot: 'liwenjuanDot', detailDot: 'liwenjuanDetailDot' },
       { name: 'baojia', url: '/baojia/health', dot: 'baojiaDot', detailDot: 'baojiaDetailDot' },
+      { name: 'internalQuote', url: '/internal-quote/health', dot: 'internalQuoteDot', detailDot: 'internalQuoteDetailDot' },
       { name: 'tomy', url: '/tomy-paiqi/health', dot: 'tomyDot', detailDot: 'tomyDetailDot' },
       { name: 'zuruMaster', url: '/zuru-master/health', dot: 'zuruMasterDot', detailDot: 'zuruMasterDetailDot' },
       { name: 'hySchedule', url: '/hy-schedule/health', dot: 'hyScheduleDot', detailDot: 'hyScheduleDetailDot' },

--- a/nginx/nginx.cloud.conf
+++ b/nginx/nginx.cloud.conf
@@ -637,6 +637,60 @@ http {
             add_header Cache-Control "no-cache, must-revalidate" always;
         }
 
+        # ─── Standalone: 内部报价系统 (internal-quote) ───
+        location = /internal-quote {
+            return 301 /internal-quote/;
+        }
+        location = /internal-quote/health {
+            auth_basic off;
+            set $ups "internal-quote:3210";
+            proxy_pass http://$ups/health;
+            proxy_set_header Host $host;
+        }
+        location /internal-quote/api/ {
+            limit_req zone=api_limit burst=20 nodelay;
+            set $ups "internal-quote:3210";
+            rewrite ^/internal-quote/(.*)$ /$1 break;
+            proxy_pass http://$ups;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_no_cache 1;
+            proxy_cache_bypass 1;
+            client_max_body_size 50m;
+            # Excel 导入/导出耗时较长
+            proxy_read_timeout 600s;
+            proxy_send_timeout 600s;
+        }
+        location /internal-quote/ {
+            limit_req zone=api_limit burst=20 nodelay;
+            set $ups "internal-quote:3210";
+            rewrite ^/internal-quote/(.*)$ /$1 break;
+            proxy_pass http://$ups;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+        }
+        # 静态资源(含 /uploads 图片)绕开 rate limiter
+        location ~* ^/internal-quote/.+\.(js|css|png|jpg|jpeg|gif|svg|ico|woff|woff2|ttf|eot|map)$ {
+            set $ups "internal-quote:3210";
+            rewrite ^/internal-quote/(.*)$ /$1 break;
+            proxy_pass http://$ups;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            add_header Cache-Control "no-cache, must-revalidate" always;
+        }
+
         # ─── Standalone: TOMY排期核对系统 (tomy-paiqi) ───
         location = /tomy-paiqi {
             return 301 /tomy-paiqi/;

--- a/nginx/nginx.cloud.conf
+++ b/nginx/nginx.cloud.conf
@@ -643,13 +643,13 @@ http {
         }
         location = /internal-quote/health {
             auth_basic off;
-            set $ups "internal-quote:3210";
+            set $ups "internal-quote:3211";
             proxy_pass http://$ups/health;
             proxy_set_header Host $host;
         }
         location /internal-quote/api/ {
             limit_req zone=api_limit burst=20 nodelay;
-            set $ups "internal-quote:3210";
+            set $ups "internal-quote:3211";
             rewrite ^/internal-quote/(.*)$ /$1 break;
             proxy_pass http://$ups;
             proxy_set_header Host $host;
@@ -667,7 +667,7 @@ http {
         }
         location /internal-quote/ {
             limit_req zone=api_limit burst=20 nodelay;
-            set $ups "internal-quote:3210";
+            set $ups "internal-quote:3211";
             rewrite ^/internal-quote/(.*)$ /$1 break;
             proxy_pass http://$ups;
             proxy_set_header Host $host;
@@ -679,7 +679,7 @@ http {
         }
         # 静态资源(含 /uploads 图片)绕开 rate limiter
         location ~* ^/internal-quote/.+\.(js|css|png|jpg|jpeg|gif|svg|ico|woff|woff2|ttf|eot|map)$ {
-            set $ups "internal-quote:3210";
+            set $ups "internal-quote:3211";
             rewrite ^/internal-quote/(.*)$ /$1 break;
             proxy_pass http://$ups;
             proxy_set_header Host $host;


### PR DESCRIPTION
重新上线 internal-quote（#181 曾上线后容器启动崩溃 → 已 revert #182，孤儿清理 #183）。本分支在原功能基础上加了启动加固。

## 本次相对 #181 的修复
- **Dockerfile `node:22-alpine` → `node:24-alpine`**：本地用 Node 24 完整验证 `node backend/server.js` 启动正常（db/seed/listen 全 OK）；上次崩溃是 node:22-alpine 环境特有（node:sqlite/WAL 行为差异），对齐到已验证环境消除该变量。
- **db/index.js 启动加固**：DB 打开 + WAL + schema 包 try/catch，失败打 `[FATAL][db-init]` 清晰日志再退出，杜绝静默 crash-loop。
- 含 `f31c57b` 的应用层安全/正确性修复（客户范围校验、XSS、全局 error handler、上传 magic-bytes 等）。

## 安全网（已在 main）
- `--remove-orphans` 已进 update-server.sh（#183）：万一再崩，下次部署自动清孤儿，不会重演拖垮内存。
- blast radius 已证明仅限 `/internal-quote/`，不影响其他服务。

## 注意
- 端口 3211（与 qa-weekly-report 不冲突，已在 CLAUDE.md 注册表）。
- GHA 健康检查列表暂未含 `/internal-quote/health`（token 无 workflow scope，无法改 .github）→ **部署后人工冒烟验证**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
