### PR TITLE
fix(deploy): internal-quote 纳入服务映射 + node:24 干净重建

### DIFF
--- a/apps/业务部/内部报价系统/Dockerfile
+++ b/apps/业务部/内部报价系统/Dockerfile
@@ -1,5 +1,6 @@
 # 内部报价系统 — RR-Portal app
 # Node/Express + node:sqlite（内置，无需 better-sqlite3 编译）
+# 2026-06-17: 触发干净重建，使运行镜像真正切到 node:24-alpine（之前部署复用了旧 node:22 镜像）
 # 用 node:24-alpine（现行 LTS）：node:sqlite 已转正、无需 --experimental-sqlite flag，
 # 与本地验证通过的环境一致。22.x 上 node:sqlite 行为有差异，曾导致容器启动崩溃。
 FROM node:24-alpine

--- a/deploy/update-server.sh
+++ b/deploy/update-server.sh
@@ -112,6 +112,7 @@ declare -A PATH_TO_SERVICE=(
   ["apps/业务部/ZURU接单表入单系统/"]="zuru-order-system"
   ["apps/业务部/ZURU总排期入单/"]="zuru-master-schedule"
   ["apps/业务部/ZURU河源排期入单/"]="hy-schedule-system"
+  ["apps/业务部/内部报价系统/"]="internal-quote"
   ["apps/工程部/A-doc生成系統/"]="zouhuo"
   ["apps/工程部/工程啤办单/"]="rr-production"
   ["apps/工程部/模具手办采购订单系统/"]="figure-mold-cost-system"


### PR DESCRIPTION
线上 internal-quote 当前跑的仍是 #181 的旧 node:22 镜像（上次 compose up 复用未重建）。本 PR：①把 internal-quote 加进 update-server.sh 服务映射，今后改它会被正确增量 rebuild；②触发本次将其用 node:24-alpine 重建运行镜像。预期部署日志出现 Building rr-portal-internal-quote。

🤖 Generated with [Claude Code](https://claude.com/claude-code)