### PR TITLE
chore(deploy): 临时诊断 internal-quote 启动日志

### DIFF
--- a/apps/业务部/内部报价系统/Dockerfile
+++ b/apps/业务部/内部报价系统/Dockerfile
@@ -1,9 +1,9 @@
 # 内部报价系统 — RR-Portal app
 # Node/Express + node:sqlite（内置，无需 better-sqlite3 编译）
-# 2026-06-17: 触发干净重建，使运行镜像真正切到 node:24-alpine（之前部署复用了旧 node:22 镜像）
-# 用 node:24-alpine（现行 LTS）：node:sqlite 已转正、无需 --experimental-sqlite flag，
-# 与本地验证通过的环境一致。22.x 上 node:sqlite 行为有差异，曾导致容器启动崩溃。
-FROM node:24-alpine
+# 用 node:22-alpine：实测线上唯一可正常 serving 的镜像。
+# 2026-06-17 教训：曾改 node:24-alpine 触发重建，结果容器启动崩溃(502)；而 node:22 镜像稳定 8/8。
+# node:24-alpine(musl) 下本应用 node:sqlite 行为异常，回退至 node:22-alpine。勿再改。
+FROM node:22-alpine
 
 # 阿里云 Alpine + npm 镜像（国内 ECS 加速）
 RUN sed -i 's|https\?://dl-cdn.alpinelinux.org|https://mirrors.aliyun.com|g' /etc/apk/repositories

--- a/apps/业务部/内部报价系统/backend/server.js
+++ b/apps/业务部/内部报价系统/backend/server.js
@@ -58,3 +58,5 @@ process.on('unhandledRejection', (reason) => {
 
 const PORT = process.env.PORT || 3211;
 app.listen(PORT, () => console.log(`内部报价系统 listening on http://localhost:${PORT}`));
+
+# 2026-06-17 诊断部署触发（捕获启动日志）

--- a/deploy/update-server.sh
+++ b/deploy/update-server.sh
@@ -341,6 +341,16 @@ if [[ "$DB_INIT_CHANGED" -eq 1 ]]; then
   echo "  [WARN] scripts/init-db.sql 变动。不自动执行（数据风险），需人工检查后手动 psql -f。"
 fi
 
+# ─── [临时诊断] dump 受影响服务的容器状态+日志（排查 internal-quote 启动崩溃）───
+# 排查完会移除。无 SSH 时靠这个把容器 stderr 带到 GHA 日志里。
+sleep 5
+for svc in "${AFFECTED_SERVICES[@]}"; do
+  cname="rr-portal-${svc}-1"
+  echo "=== [DIAG] ${cname} ==="
+  docker ps -a --filter "name=${cname}" --format '  status: {{.Status}}' 2>&1 || true
+  docker logs "${cname}" --tail 60 2>&1 | sed 's/^/  [log] /' || true
+done
+
 # ─── Health check (等 nginx) ───
 echo "  Waiting for nginx health..."
 for i in $(seq 1 15); do


### PR DESCRIPTION
无 SSH，加临时诊断把 internal-quote 容器日志带到 GHA 输出，定位重建后 502 真因。