### PR TITLE
fix(internal-quote): 移除 server.js 残留 # 语法错误行

### DIFF
--- a/apps/业务部/内部报价系统/backend/server.js
+++ b/apps/业务部/内部报价系统/backend/server.js
@@ -59,4 +59,3 @@ process.on('unhandledRejection', (reason) => {
 const PORT = process.env.PORT || 3211;
 app.listen(PORT, () => console.log(`内部报价系统 listening on http://localhost:${PORT}`));
 
-# 2026-06-17 诊断部署触发（捕获启动日志）


### PR DESCRIPTION
main 上 server.js 仍残留诊断误加的 # 注释(JS SyntaxError → 启动 502)。干净分支移除恢复。