### PR TITLE
fix(nginx): internal-quote 关闭平台 Basic Auth 修反复弹窗

### DIFF
--- a/nginx/nginx.cloud.conf
+++ b/nginx/nginx.cloud.conf
@@ -648,6 +648,9 @@ http {
             proxy_set_header Host $host;
         }
         location /internal-quote/api/ {
+            # internal-quote 有自己完整的登录/会话鉴权(bcrypt+锁定+按用户权限)，
+            # 关掉平台 Basic Auth 避免与 app 自身登录叠成双重弹窗（SPA fetch 反复触发 401）
+            auth_basic off;
             limit_req zone=api_limit burst=20 nodelay;
             set $ups "internal-quote:3211";
             rewrite ^/internal-quote/(.*)$ /$1 break;
@@ -666,6 +669,7 @@ http {
             proxy_send_timeout 600s;
         }
         location /internal-quote/ {
+            auth_basic off;
             limit_req zone=api_limit burst=20 nodelay;
             set $ups "internal-quote:3211";
             rewrite ^/internal-quote/(.*)$ /$1 break;
@@ -679,6 +683,7 @@ http {
         }
         # 静态资源(含 /uploads 图片)绕开 rate limiter
         location ~* ^/internal-quote/.+\.(js|css|png|jpg|jpeg|gif|svg|ico|woff|woff2|ttf|eot|map)$ {
+            auth_basic off;
             set $ups "internal-quote:3211";
             rewrite ^/internal-quote/(.*)$ /$1 break;
             proxy_pass http://$ups;


### PR DESCRIPTION
app 有自有完整登录，平台 Basic Auth 叠加导致 SPA fetch 反复弹 401 登不进。三个 location 加 auth_basic off。