### PR TITLE
fix(huadeng): 对账单号归一化，忽略 * 前缀

### DIFF
--- a/apps/PMC跟仓管/华登包材管理/app.py
+++ b/apps/PMC跟仓管/华登包材管理/app.py
@@ -1402,9 +1402,16 @@ def compare_pair(party_a, party_b, date_from, date_to):
     return result
 
 
+def _norm_order_no(raw):
+    """单号归一化：去掉首尾空白和星号(*)，使 1402710 与 *1402710 视为同一单号。
+    某些录入方会给单号加 * 前缀，核对时应忽略，避免假性不匹配。"""
+    return (raw or '').strip().strip('*').strip()
+
+
 def _sum_items_by_order(con, *, recorded_by, from_party, to_party, date_from, date_to):
     """按 order_no 汇总各包材数量。返回 (by_order, no_orderno_count)。
-    by_order = {order_no: {item_key: float}}，只含非空 order_no；
+    by_order = {归一化 order_no: {item_key: float}}，只含非空 order_no；
+    单号先经 _norm_order_no 归一化（去 * 和空白），归一化后相同的单号合并相加；
     no_orderno_count = 该方向下 order_no 为空的记录条数（不参与单号级核对）。"""
     qty_cols_sql = ', '.join([f'COALESCE(SUM({k}_qty), 0) AS {k}_sum' for k, _ in ITEMS])
     rows = con.execute(f"""
@@ -1414,10 +1421,12 @@ def _sum_items_by_order(con, *, recorded_by, from_party, to_party, date_from, da
     """, (recorded_by, from_party, to_party, date_from, date_to)).fetchall()
     by_order = {}
     for r in rows:
-        on = (r['order_no'] or '').strip()
+        on = _norm_order_no(r['order_no'])
         if not on:
             continue
-        by_order[on] = {k: float(r[f'{k}_sum']) for k, _ in ITEMS}
+        acc = by_order.setdefault(on, {k: 0.0 for k, _ in ITEMS})
+        for k, _ in ITEMS:
+            acc[k] += float(r[f'{k}_sum'])
     no_cnt = con.execute("""
         SELECT COUNT(*) FROM flow_records
         WHERE recorded_by=? AND from_party=? AND to_party=? AND date BETWEEN ? AND ?

--- a/apps/PMC跟仓管/华登包材管理/tests/test_reconcile_algo.py
+++ b/apps/PMC跟仓管/华登包材管理/tests/test_reconcile_algo.py
@@ -56,6 +56,17 @@ def test_compare_pair_date_range(client):
     assert result['hd_to_sy']['sender_recorded']['jx'] == 100
 
 
+def test_compare_pair_star_prefix_order_no(client):
+    """一方单号带 * 前缀（*1402710），另一方不带（1402710）→ 应视为同一单号，不进 missing 列表。"""
+    _insert('hd', 'hd', 'sy', '2026-05-01', order_no='1402710', jx_qty=100)
+    _insert('sy', 'hd', 'sy', '2026-05-01', order_no='*1402710', jx_qty=100)
+    result = app_module.compare_pair('hd', 'sy', '2026-05-01', '2026-05-01')
+    oc = result['hd_to_sy']['order_check']
+    assert oc['missing_in_receiver'] == []
+    assert oc['missing_in_sender'] == []
+    assert oc['item_mismatches'] == []
+
+
 def test_compare_pair_negative_diff(client):
     """收方录得比发方多 → diff 为负（锁住 Task 14 UI 契约）。"""
     _insert('hd', 'hd', 'sy', '2026-05-01', jx_qty=98)


### PR DESCRIPTION
## 问题
包材核对系统按单号匹配时，一方录的单号带 `*` 前缀（如 `*1402710`），另一方不带（`1402710`），被当成两个不同单号，双方都进了"对方没有的单号"列表，产生假性不匹配。

## 修复
- 新增 `_norm_order_no()`：单号归一化，去掉首尾空白和 `*` 号
- `_sum_items_by_order()` 改为按归一化后的单号聚合（归一化后相同的单号合并相加，而非互相覆盖）

顶部汇总表（按包材总量比对）不受影响。

## 测试
新增 `test_compare_pair_star_prefix_order_no`，本地 reconcile 测试全过（30 passed）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)