### PR TITLE
fix(internal-quote): 复制报价单后端放开 admin

### DIFF
--- a/apps/业务部/内部报价系统/backend/routes/quotes.js
+++ b/apps/业务部/内部报价系统/backend/routes/quotes.js
@@ -67,7 +67,7 @@ router.post('/', (req, res) => {
 
 // POST /api/quotes/:id/clone  复制一张报价单（含 payload，状态全 empty）
 router.post('/:id/clone', (req, res) => {
-  if (req.user.dept !== 'sales') return res.status(403).json({ error: '只有业务可以复制报价单' });
+  if (req.user.dept !== 'sales' && req.user.role !== 'admin') return res.status(403).json({ error: '只有业务或超级管理员可以复制报价单' });
   const srcId = Number(req.params.id);
   const { quote_no, product_name, customer, qty, version } = req.body || {};
   if (!quote_no) return res.status(400).json({ error: '缺少 quote_no' });


### PR DESCRIPTION
列表「复制」按钮已放宽到 业务||admin(#205),但后端 POST /:id/clone 仍只允许 sales，admin 点复制会 403。本 PR 把后端口径改为与「删除」一致(业务或 admin)。

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>