### PR TITLE
fix(paiji): 修复导入解析后入库失败(#203 回归，serial_no 参数缺失)

### DIFF
--- a/apps/生产部/注塑啤机排产系统/server/routes/orders.js
+++ b/apps/生产部/注塑啤机排产系统/server/routes/orders.js
@@ -329,7 +329,7 @@ router.post('/import', upload.single('file'), async (req, res) => {
           o.shot_weight || 0, o.material_kg || 0, o.sprue_pct || 0, o.ratio_pct || 0,
           o.quantity_needed || 0, o.accumulated || 0, o.cavity || 1, o.cycle_time || 0,
           o.order_no || '', o.is_three_plate || 0, o.packing_qty || 0,
-          batch, req.file.originalname, 'pending', o.notes || '', workshop
+          batch, req.file.originalname, 'pending', o.notes || '', o.serial_no || '', workshop
         );
       }
     });


### PR DESCRIPTION
## 问题
啤机排单系统导入订单全部失败。线上复现 POST /paiji/api/orders/import 返回 `500 导入失败：Too few parameter values were provided`。

## 根因
#203 给共享语句 `stmts().insert` 加了 `serial_no` 列(占位符 22→23)。`POST /`(单条新增)已同步成 23 个参数，但 `POST /import` 的 `insertMany` 仍传 22 个 → better-sqlite3 抛参数个数错误 → 解析成功也无法入库(与文件类型无关)。

## 修复
import 的 insertMany 在 `order_notes` 与 `workshop` 之间补 `o.serial_no || ''`，与语句列序一致。

## 验证
- 修前: 用最小合法 xlsx 复现 → 500。
- 修后: 同文件 → count:1(部署后验证)。

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>