### PR TITLE
fix(hy-schedule): 清洗产品名称去除包装规格后缀

### DIFF
--- a/apps/业务部/ZURU河源排期入单/app.py
+++ b/apps/业务部/ZURU河源排期入单/app.py
@@ -543,7 +543,7 @@ def hy_submit_selection():
 def hy_export_only():
     """仅生成分类Excel，不写入排期。ambiguous货号放入所有匹配sheet。"""
     from hy_schedule import _extract_header, _prepare_line_data, \
-        _item_upper, _generate_new_excel
+        _item_upper, _generate_new_excel, _clean_cn_name
 
     data = request.json or {}
     session_id = data.get('session_id')
@@ -593,7 +593,7 @@ def hy_export_only():
         ln_data = _prepare_line_data(order, order['lines'][li], hdr['ship_dt'], hdr['full_note'],
                                      wb_name=nl['file'])
         item_base = re.match(r'(\d+[A-Za-z]*\d*)', _item_upper(nl['item']))
-        cn_name = cn_names.get(item_base.group(1).upper(), '') if item_base else ''
+        cn_name = _clean_cn_name(cn_names.get(item_base.group(1).upper(), '') if item_base else '')
         _has_outer = bool(ln_data['outer_qty'])
         _has_price = bool(ln_data['price'])
         new_rows.append({
@@ -619,7 +619,7 @@ def hy_export_only():
         ln_data = _prepare_line_data(order, order['lines'][li], hdr['ship_dt'], hdr['full_note'],
                                      wb_name=m['file'])
         item_base = re.match(r'(\d+[A-Za-z]*\d*)', _item_upper(m['item']))
-        cn_name = cn_names.get(item_base.group(1).upper(), '') if item_base else ''
+        cn_name = _clean_cn_name(cn_names.get(item_base.group(1).upper(), '') if item_base else '')
         _has_outer = bool(ln_data['outer_qty'])
         _has_price = bool(ln_data['price'])
         new_rows.append({
@@ -644,7 +644,7 @@ def hy_export_only():
         ln_data = _prepare_line_data(order, order['lines'][li], hdr['ship_dt'], hdr['full_note'],
                                      wb_name='')
         item_base = re.match(r'(\d+[A-Za-z]*\d*)', _item_upper(uk['item']))
-        cn_name = cn_names.get(item_base.group(1).upper(), '') if item_base else ''
+        cn_name = _clean_cn_name(cn_names.get(item_base.group(1).upper(), '') if item_base else '')
         _has_outer = bool(ln_data['outer_qty'])
         _has_price = bool(ln_data['price'])
         new_rows.append({

--- a/apps/业务部/ZURU河源排期入单/hy_schedule.py
+++ b/apps/业务部/ZURU河源排期入单/hy_schedule.py
@@ -50,6 +50,13 @@ def _item_upper(v):
     return re.sub(r'[\s\n]+', '', str(v or '')).strip().upper()
 
 
+def _clean_cn_name(raw):
+    """清洗产品名称：去除包装规格后缀（如 12PCS/CTN、(4PCS/PDQ/CTN)）"""
+    s = str(raw or '').split('\n')[0].strip()
+    s = re.sub(r'[（(]?\d+PCS.*$', '', s, flags=re.IGNORECASE).strip()
+    return s
+
+
 # 辅助sheet关键词黑名单（命中任一子串 → 不是排期sheet）
 # 注意：'MA' 不能作为普通子串（会误伤 MAIN/MATCH 等），用正则单独处理
 AUX_KEYWORDS = (
@@ -274,7 +281,8 @@ def build_global_index(schedule_dir):
                     r = header_row + 1 + offset
                     po_val = _normalize_po(row[COL['po'] - 1].value if len(row) >= COL['po'] else None)
                     item_val = _item_upper(row[COL['item'] - 1].value if len(row) >= COL['item'] else None)
-                    cn_val = str((row[COL['cn_name'] - 1].value if len(row) >= COL['cn_name'] else None) or '').strip()
+                    cn_raw = (row[COL['cn_name'] - 1].value if len(row) >= COL['cn_name'] else None)
+                    cn_val = _clean_cn_name(cn_raw)
 
                     if not item_val:
                         empty_count += 1
@@ -592,7 +600,7 @@ def write_orders(schedule_dir, orders, ambiguous_selections=None, export_dir=Non
                                      wb_name=nl['file'])
 
         item_base = re.match(r'(\d+[A-Za-z]*\d*)', _item_upper(nl['item']))
-        cn_name = cn_names.get(item_base.group(1).upper(), '') if item_base else ''
+        cn_name = (cn_names.get(item_base.group(1).upper(), '') if item_base else '').split('\n')[0].strip()
 
         # 只有当 outer 和 price 有效值时才生成公式占位符，否则留空避免 #DIV/0! / #VALUE!
         _has_outer = bool(ln_data['outer_qty'])
@@ -622,7 +630,7 @@ def write_orders(schedule_dir, orders, ambiguous_selections=None, export_dir=Non
         ln_data = _prepare_line_data(order, order['lines'][li], hdr['ship_dt'], hdr['full_note'],
                                      wb_name=m['file'])
         item_base = re.match(r'(\d+[A-Za-z]*\d*)', _item_upper(m['item']))
-        cn_name = cn_names.get(item_base.group(1).upper(), '') if item_base else ''
+        cn_name = (cn_names.get(item_base.group(1).upper(), '') if item_base else '').split('\n')[0].strip()
         _has_outer = bool(ln_data['outer_qty'])
         _has_price = bool(ln_data['price'])
         new_rows.append({
@@ -651,7 +659,7 @@ def write_orders(schedule_dir, orders, ambiguous_selections=None, export_dir=Non
                                      wb_name='')
 
         item_base = re.match(r'(\d+[A-Za-z]*\d*)', _item_upper(uk['item']))
-        cn_name = cn_names.get(item_base.group(1).upper(), '') if item_base else ''
+        cn_name = (cn_names.get(item_base.group(1).upper(), '') if item_base else '').split('\n')[0].strip()
 
         _has_outer = bool(ln_data['outer_qty'])
         _has_price = bool(ln_data['price'])

--- a/apps/业务部/ZURU河源排期入单/hy_schedule.py
+++ b/apps/业务部/ZURU河源排期入单/hy_schedule.py
@@ -600,7 +600,7 @@ def write_orders(schedule_dir, orders, ambiguous_selections=None, export_dir=Non
                                      wb_name=nl['file'])
 
         item_base = re.match(r'(\d+[A-Za-z]*\d*)', _item_upper(nl['item']))
-        cn_name = (cn_names.get(item_base.group(1).upper(), '') if item_base else '').split('\n')[0].strip()
+        cn_name = _clean_cn_name(cn_names.get(item_base.group(1).upper(), '') if item_base else '')
 
         # 只有当 outer 和 price 有效值时才生成公式占位符，否则留空避免 #DIV/0! / #VALUE!
         _has_outer = bool(ln_data['outer_qty'])
@@ -630,7 +630,7 @@ def write_orders(schedule_dir, orders, ambiguous_selections=None, export_dir=Non
         ln_data = _prepare_line_data(order, order['lines'][li], hdr['ship_dt'], hdr['full_note'],
                                      wb_name=m['file'])
         item_base = re.match(r'(\d+[A-Za-z]*\d*)', _item_upper(m['item']))
-        cn_name = (cn_names.get(item_base.group(1).upper(), '') if item_base else '').split('\n')[0].strip()
+        cn_name = _clean_cn_name(cn_names.get(item_base.group(1).upper(), '') if item_base else '')
         _has_outer = bool(ln_data['outer_qty'])
         _has_price = bool(ln_data['price'])
         new_rows.append({
@@ -659,7 +659,7 @@ def write_orders(schedule_dir, orders, ambiguous_selections=None, export_dir=Non
                                      wb_name='')
 
         item_base = re.match(r'(\d+[A-Za-z]*\d*)', _item_upper(uk['item']))
-        cn_name = (cn_names.get(item_base.group(1).upper(), '') if item_base else '').split('\n')[0].strip()
+        cn_name = _clean_cn_name(cn_names.get(item_base.group(1).upper(), '') if item_base else '')
 
         _has_outer = bool(ln_data['outer_qty'])
         _has_price = bool(ln_data['price'])


### PR DESCRIPTION
## Summary
- 添加 `_clean_cn_name()` 函数，用正则去除产品名称中的包装规格后缀（如 `12PCS/CTN`、`(4PCS/PDQ/CTN)`）
- 修复导出Excel中产品名称包含包装信息的问题
- 同步修改 `hy_schedule.py`（索引构建）和 `app.py`（导出3处）

## Test plan
- [x] 13个测试用例验证正则清洗正确性
- [ ] 服务器拉取后用实际排期文件测试导出

🤖 Generated with [Claude Code](https://claude.com/claude-code)