### PR TITLE
fix(huadeng): SQLite 启用 WAL，修复并发下偶发 500(对账撤回等)

### DIFF
--- a/apps/PMC跟仓管/华登包材管理/app.py
+++ b/apps/PMC跟仓管/华登包材管理/app.py
@@ -55,6 +55,13 @@ def init_db():
     con = sqlite3.connect(DATABASE)
     cur = con.cursor()
 
+    # 并发加固：gunicorn 多 worker/thread 下 SQLite 默认 DELETE journal 读写抢锁，
+    # 偶发 "database is locked" → 500（如对账撤回）。WAL 模式持久化写入库文件，
+    # 一次设置对之后所有连接生效：读不再阻塞写，仅写-写互斥，配 busy_timeout 等待重试。
+    cur.execute("PRAGMA journal_mode=WAL")
+    cur.execute("PRAGMA synchronous=NORMAL")
+    cur.execute("PRAGMA busy_timeout=10000")
+
     # flow_records 主流水表
     cur.execute("""
     CREATE TABLE IF NOT EXISTS flow_records (


### PR DESCRIPTION
## 问题
华登包材管理偶发：点「撤回对账」失败，浏览器下载 `withdraw.htm` 提示「服务器出现问题」；重试常能成。

## 诊断(系统化排查)
- 代码正确：本地 Flask test client 端到端复现 withdraw → 302 正常，状态置 withdrawn。
- schema 一致：v1→v2 迁移会 drop+recreate flow_records/reconciliations 成完整 v2(含 reconciliation_id/locked)。
- 运行身份可写：容器以 appuser 跑，DATA_PATH 为 777 bind-mount、DB 文件归 appuser。
- 架构：gunicorn `--workers 2 --threads 2`(最多 4 并发) + SQLite 默认 DELETE journal(写需独占、读阻塞写) + 26 处连接均无 WAL/busy_timeout。
- 症状特征(偶发 + 重试能成 + 写操作)= SQLite `database is locked` 并发争锁的典型签名。

## 修复
`init_db()` 启用 WAL(持久化进库文件，对之后所有连接生效，读不再阻塞写)+ synchronous=NORMAL + busy_timeout=10s。最小改动(+7 行)，仅动 huadeng。

## 验证
本地全新库导入后 journal_mode=wal、withdraw 仍 302、8 线程并发写 240 行 0 锁错误。

注：未取得线上 traceback(无 SSH)，为基于症状+架构的高置信度根治；若仍偶发再抓日志。WAL 会在 data 目录生成 -wal/-shm 文件(目录可写，正常)。

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>