### PR TITLE
fix(internal-quote): 货号重复提示显示占用的客户名

### DIFF
--- a/apps/业务部/内部报价系统/backend/routes/quotes.js
+++ b/apps/业务部/内部报价系统/backend/routes/quotes.js
@@ -60,7 +60,11 @@ router.post('/', (req, res) => {
     const id = tx();
     res.json({ id });
   } catch (e) {
-    if (String(e.message).includes('UNIQUE')) return res.status(409).json({ error: '报价单号已存在' });
+    if (String(e.message).includes('UNIQUE')) {
+      const _exist = db.prepare('SELECT customer FROM quotes WHERE quote_no = ?').get(quote_no);
+      const _cust = _exist && _exist.customer ? `客户「${_exist.customer}」` : '一张无客户的单';
+      return res.status(409).json({ error: `货号「${quote_no}」已被占用（在${_cust}名下），请换一个货号` });
+    }
     throw e;
   }
 });
@@ -100,7 +104,11 @@ router.post('/:id/clone', (req, res) => {
     const id = tx();
     res.json({ id });
   } catch (e) {
-    if (String(e.message).includes('UNIQUE')) return res.status(409).json({ error: '报价单号已存在' });
+    if (String(e.message).includes('UNIQUE')) {
+      const _exist = db.prepare('SELECT customer FROM quotes WHERE quote_no = ?').get(quote_no);
+      const _cust = _exist && _exist.customer ? `客户「${_exist.customer}」` : '一张无客户的单';
+      return res.status(409).json({ error: `货号「${quote_no}」已被占用（在${_cust}名下），请换一个货号` });
+    }
     throw e;
   }
 });


### PR DESCRIPTION
## 问题
货号 `quote_no` 全局唯一，但报价单列表按客户过滤。当新建/复制时撞到**其他客户名下**的同号单，原提示只说「报价单号已存在」，业务看不到那张单、无从排查。

## 改动
新建(`POST /`)和复制(`POST /:id/clone`)遇到 UNIQUE 冲突时，查出该货号当前所属客户，提示改为：
> 货号「X」已被占用（在客户「Y」名下），请换一个货号

（无客户的单显示「在一张无客户的单名下」。）

🤖 Generated with [Claude Code](https://claude.com/claude-code)