### PR TITLE
feat(tomy排期): 识别 RR03 印尼RRM 工厂（RR02=印尼RRI）

### DIFF
--- a/apps/业务部/TOMY排期核对系统/client/src/App.tsx
+++ b/apps/业务部/TOMY排期核对系统/client/src/App.tsx
@@ -77,6 +77,7 @@ interface ProcessResponse {
   scheduleId: ScheduleResult | null
   reconciliationDg?: ReconciliationSummary
   reconciliationId?: ReconciliationSummary
+  reconciliationRrm?: ReconciliationSummary
   outputReady?: boolean
   sessionId?: string
 }
@@ -248,10 +249,11 @@ function PoClassificationCard({
 
   const dgPOs = result.files.filter((f) => f.data?.items[0]?.factoryCode === 'RR01')
   const idPOs = result.files.filter((f) => f.data?.items[0]?.factoryCode === 'RR02')
+  const rrmPOs = result.files.filter((f) => f.data?.items[0]?.factoryCode === 'RR03')
   const unknownPOs = result.files.filter((f) => {
     if (f.status === 'error') return true
     const fc = f.data?.items[0]?.factoryCode
-    return fc !== 'RR01' && fc !== 'RR02'
+    return fc !== 'RR01' && fc !== 'RR02' && fc !== 'RR03'
   })
 
   return (
@@ -292,10 +294,25 @@ function PoClassificationCard({
         {idPOs.length > 0 && (
           <div>
             <div style={{ fontSize: 13, color: colors.purple, fontWeight: 500, marginBottom: 6 }}>
-              印尼 RR02 · {idPOs.length} 个
+              印尼RRI RR02 · {idPOs.length} 个
             </div>
             <div>
               {idPOs.map((f, i) => (
+                <span key={i} className="file-tag id" title={f.filename}>
+                  {f.filename}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {rrmPOs.length > 0 && (
+          <div>
+            <div style={{ fontSize: 13, color: colors.pink, fontWeight: 500, marginBottom: 6 }}>
+              印尼RRM RR03 · {rrmPOs.length} 个
+            </div>
+            <div>
+              {rrmPOs.map((f, i) => (
                 <span key={i} className="file-tag id" title={f.filename}>
                   {f.filename}
                 </span>
@@ -468,7 +485,7 @@ function App() {
           >
             <Button icon={<FileTextOutlined />}>选择印尼排期表 Excel</Button>
           </Upload>
-          <p className="meta">单文件 · .xlsx 或 .xls · 对应工厂代码 RR02</p>
+          <p className="meta">单文件 · .xlsx 或 .xls · 含两个 sheet：KIK总排期(RR02/RRI)、RRM总排期(RR03/RRM)</p>
         </Card>
       </Section>
 
@@ -509,8 +526,15 @@ function App() {
 
             {result.reconciliationId && (
               <ReconciliationCard
-                title="印尼 (RR02) 核对结果"
+                title="印尼RRI (RR02) 核对结果"
                 reconciliation={result.reconciliationId}
+              />
+            )}
+
+            {result.reconciliationRrm && (
+              <ReconciliationCard
+                title="印尼RRM (RR03) 核对结果"
+                reconciliation={result.reconciliationRrm}
               />
             )}
 

--- a/apps/业务部/TOMY排期核对系统/client/src/theme.ts
+++ b/apps/业务部/TOMY排期核对系统/client/src/theme.ts
@@ -20,9 +20,12 @@ export const colors = {
   dangerSoft: '#faeaea',
   info: '#2f5d8f',
   infoSoft: '#e8effa',
-  // Accent purple for 印尼 RR02 category (distinct from teal primary)
+  // Accent purple for 印尼RRI RR02 category (distinct from teal primary)
   purple: '#6e4a9e',
   purpleSoft: '#f1ebf8',
+  // Accent pink for 印尼RRM RR03 category
+  pink: '#b03a7a',
+  pinkSoft: '#f8ebf2',
 } as const
 
 // AntD 6 ConfigProvider theme — tokens drive the entire component library.

--- a/apps/业务部/TOMY排期核对系统/server/lib/dateCodeGenerator.test.ts
+++ b/apps/业务部/TOMY排期核对系统/server/lib/dateCodeGenerator.test.ts
@@ -53,6 +53,12 @@ describe('generateDateCode', () => {
     expect(generateDateCode('01 Nov 2026', 'RR02')).toBe('I3026RR02')
   })
 
+  // RR03 (印尼RRM) is a recognized factory code
+  it('returns D1526RR03 for 15 May 2026 with RR03', () => {
+    // Apr 15, 2026 is a Wednesday → workday → use as-is; D = April, factory=RR03
+    expect(generateDateCode('15 May 2026', 'RR03')).toBe('D1526RR03')
+  })
+
   // DATE-01: Unknown factory code returns null
   it('returns null for unknown factory code', () => {
     expect(generateDateCode('15 May 2026', 'XX99')).toBeNull()

--- a/apps/业务部/TOMY排期核对系统/server/lib/dateCodeGenerator.ts
+++ b/apps/业务部/TOMY排期核对系统/server/lib/dateCodeGenerator.ts
@@ -8,22 +8,22 @@ const MONTH_LETTERS = 'ABCDEFGHIJKL'
  * Generates a production date code for a PO item.
  *
  * Algorithm:
- * 1. Validate factoryCode matches RR01 or RR02; return null otherwise
+ * 1. Validate factoryCode matches RR01, RR02 or RR03; return null otherwise
  * 2. Parse the PO走货期 string (e.g., "15 May 2026") using date-fns
  * 3. Subtract one calendar month (subMonths handles end-of-month clamping)
  * 4. Roll back to nearest prior workday if date falls on weekend/public holiday
  * 5. Format as: monthLetter + day + 2-digit-year + factoryCode
  *
  * @param poZouHuoQiStr - PO走货期 string in "d MMM yyyy" format, e.g. "15 May 2026"
- * @param factoryCode - Factory code, must be "RR01" or "RR02"
+ * @param factoryCode - Factory code, must be "RR01", "RR02" or "RR03"
  * @returns Date code string (e.g., "D1526RR02") or null if inputs are invalid
  */
 export function generateDateCode(
   poZouHuoQiStr: string,
   factoryCode: string
 ): string | null {
-  // Validate factory code — only RR01 and RR02 are recognized
-  if (!factoryCode.match(/^RR0[12]$/)) return null
+  // Validate factory code — only RR01 (东莞), RR02 (印尼RRI) and RR03 (印尼RRM) are recognized
+  if (!factoryCode.match(/^RR0[123]$/)) return null
 
   // Parse date string — return null for empty or unparseable input
   if (!poZouHuoQiStr) return null

--- a/apps/业务部/TOMY排期核对系统/server/lib/excelParser.ts
+++ b/apps/业务部/TOMY排期核对系统/server/lib/excelParser.ts
@@ -67,14 +67,32 @@ function getCellValue(row: ExcelJS.Row, colIndex: number | undefined): unknown {
  * - Formula cells (外箱, 总箱数, 数量) returning { formula, result } — unwrapped to number
  * - Date cells (PO走货期, 接单期) returning JS Date objects — kept as Date
  * - Empty rows (no tomyPO value) are skipped
+ *
+ * @param buffer - Workbook file bytes
+ * @param sheetName - Optional sheet selector. When given, the worksheet is
+ *   resolved by exact name first, then by substring match (e.g. 'KIK' →
+ *   'KIK总排期', 'RRM' → 'RRM总排期'). Throws if no sheet matches.
+ *   When omitted, falls back to the 总排期 / TOMY-PO-column auto-detection.
  */
-export async function parseScheduleExcel(buffer: Buffer): Promise<ScheduleRow[]> {
+export async function parseScheduleExcel(buffer: Buffer, sheetName?: string): Promise<ScheduleRow[]> {
   const workbook = new ExcelJS.Workbook()
   await workbook.xlsx.load(buffer)
 
+  let ws: ExcelJS.Worksheet | undefined
+
+  // Explicit sheet selection: exact name, then substring match
+  if (sheetName) {
+    ws = workbook.getWorksheet(sheetName)
+      ?? workbook.worksheets.find((s) => s.name.includes(sheetName))
+    if (!ws) {
+      const sheetNames = workbook.worksheets.map(s => s.name).join(', ')
+      throw new Error(`Sheet "${sheetName}" not found in workbook (available: ${sheetNames})`)
+    }
+  }
+
   // Try known sheet name aliases in order
   const SHEET_CANDIDATES = ['总排期', '排期', 'Schedule', 'Sheet1']
-  let ws = workbook.getWorksheet('总排期')
+  if (!ws) ws = workbook.getWorksheet('总排期')
   if (!ws) {
     for (const name of SHEET_CANDIDATES) {
       ws = workbook.getWorksheet(name)

--- a/apps/业务部/TOMY排期核对系统/server/lib/excelWriter.ts
+++ b/apps/业务部/TOMY排期核对系统/server/lib/excelWriter.ts
@@ -69,14 +69,26 @@ const YELLOW_FILL: ExcelJS.FillPattern = {
 export async function writeAnnotatedSchedule(
   scheduleBuffer: Buffer,
   result: ReconciliationResult,
-  scheduleRows: ScheduleRow[]
+  scheduleRows: ScheduleRow[],
+  sheetName?: string
 ): Promise<Buffer> {
   // Load the original workbook
   const workbook = new ExcelJS.Workbook()
   await workbook.xlsx.load(scheduleBuffer)
 
-  const ws = workbook.getWorksheet('总排期')
-  if (!ws) throw new Error('Sheet 总排期 not found in workbook')
+  // Resolve target sheet: explicit selector (exact, then substring), else 总排期
+  let ws: ExcelJS.Worksheet | undefined
+  if (sheetName) {
+    ws = workbook.getWorksheet(sheetName)
+      ?? workbook.worksheets.find((s) => s.name.includes(sheetName))
+    if (!ws) {
+      const sheetNames = workbook.worksheets.map(s => s.name).join(', ')
+      throw new Error(`Sheet "${sheetName}" not found in workbook (available: ${sheetNames})`)
+    }
+  } else {
+    ws = workbook.getWorksheet('总排期')
+    if (!ws) throw new Error('Sheet 总排期 not found in workbook')
+  }
 
   // Build column map from header row
   const headerRow = ws.getRow(1)

--- a/apps/业务部/TOMY排期核对系统/server/lib/pdfExtractor.ts
+++ b/apps/业务部/TOMY排期核对系统/server/lib/pdfExtractor.ts
@@ -128,7 +128,7 @@ function extractCustomerName(text: string): string {
  * Each item block in the text stream looks like:
  *   PARTNO\n \n00-RR\n \nDD Mon YYYY\n \nNNNN\n \nEA
  *
- * After the item block, factory code (RR01/RR02) appears on its own line.
+ * After the item block, factory code (RR01/RR02/RR03) appears on its own line.
  * Carton packing appears as "N EA / MASTER CARTON" or "N SET / MASTER CARTON".
  */
 function extractItems(text: string): POItem[] {
@@ -159,8 +159,8 @@ function extractItems(text: string): POItem[] {
     const segmentEnd = i + 1 < matches.length ? matches[i + 1].index : text.length
     const segment = text.slice(segmentStart, segmentEnd)
 
-    // Extract factory code (RR01 or RR02) from segment
-    const factoryMatch = segment.match(/\n(RR0[12])\n/)
+    // Extract factory code (RR01 东莞 / RR02 印尼RRI / RR03 印尼RRM) from segment
+    const factoryMatch = segment.match(/\n(RR0[123])\n/)
     const factoryCode = factoryMatch ? factoryMatch[1] : 'RR01'
 
     // Extract carton packing from "N EA / MASTER CARTON" or "N SET / MASTER CARTON" pattern

--- a/apps/业务部/TOMY排期核对系统/server/lib/summaryReport.test.ts
+++ b/apps/业务部/TOMY排期核对系统/server/lib/summaryReport.test.ts
@@ -107,6 +107,37 @@ describe('buildSummaryReport', () => {
     expect(report).toContain('RR02/印尼')
   })
 
+  it('RR03 (印尼RRM) mismatches and unmatched items appear under the RRM factory label', () => {
+    const rrmResult: ReconciliationResult = {
+      matched: [
+        makeMatchResult({
+          tomyPO: 'T-RRM-003',
+          货号: 'ITEM003',
+          mismatches: [
+            { field: '数量', scheduleValue: 1000, poValue: 999 },
+          ],
+        }),
+      ],
+      unmatchedPOItems: [
+        {
+          tomyPO: 'T-RRM-004',
+          货号: 'ITEM004',
+          sourceFile: 'po-rrm.pdf',
+          poItem: makePOItem({ factoryCode: 'RR03' }),
+          poData: makePOData({ tomyPO: 'T-RRM-004', sourceFile: 'po-rrm.pdf' }),
+        },
+      ],
+      ambiguousPOItems: [],
+      errors: [],
+    }
+    const report = buildSummaryReport(emptyResult(), emptyResult(), rrmResult)
+    expect(report).toContain('T-RRM-003')
+    expect(report).toContain('ITEM003')
+    expect(report).toContain('T-RRM-004')
+    expect(report).toContain('po-rrm.pdf')
+    expect(report).toContain('RR03/印尼RRM')
+  })
+
   it('when both results have zero mismatches and zero unmatched, report shows 共 0 条 for both sections', () => {
     const report = buildSummaryReport(emptyResult(), emptyResult())
     // Should appear twice (once for mismatches section, once for unmatched section)

--- a/apps/业务部/TOMY排期核对系统/server/lib/summaryReport.ts
+++ b/apps/业务部/TOMY排期核对系统/server/lib/summaryReport.ts
@@ -1,7 +1,8 @@
 import type { ReconciliationResult } from '../types/index.js'
 
 const DG_LABEL = 'RR01/东莞'
-const ID_LABEL = 'RR02/印尼'
+const ID_LABEL = 'RR02/印尼RRI'
+const RRM_LABEL = 'RR03/印尼RRM'
 
 const EMPTY_RESULT: ReconciliationResult = {
   matched: [],
@@ -14,15 +15,18 @@ const EMPTY_RESULT: ReconciliationResult = {
  * Builds a plain-text summary report from reconciliation results for both factories.
  *
  * @param dgResult - Reconciliation result for Dongguan (RR01) factory; null/undefined treated as empty
- * @param idResult - Reconciliation result for Indonesia (RR02) factory; null/undefined treated as empty
+ * @param idResult - Reconciliation result for Indonesia RRI (RR02) factory; null/undefined treated as empty
+ * @param rrmResult - Reconciliation result for Indonesia RRM (RR03) factory; null/undefined treated as empty
  * @returns Formatted plain-text report string
  */
 export function buildSummaryReport(
   dgResult: ReconciliationResult | null | undefined,
   idResult: ReconciliationResult | null | undefined,
+  rrmResult?: ReconciliationResult | null | undefined,
 ): string {
   const dg = dgResult ?? EMPTY_RESULT
   const id = idResult ?? EMPTY_RESULT
+  const rrm = rrmResult ?? EMPTY_RESULT
 
   const lines: string[] = []
 
@@ -36,7 +40,8 @@ export function buildSummaryReport(
   // Section 1: Field mismatches
   const dgMismatched = dg.matched.filter(r => r.mismatches.length > 0)
   const idMismatched = id.matched.filter(r => r.mismatches.length > 0)
-  const totalMismatched = dgMismatched.length + idMismatched.length
+  const rrmMismatched = rrm.matched.filter(r => r.mismatches.length > 0)
+  const totalMismatched = dgMismatched.length + idMismatched.length + rrmMismatched.length
 
   lines.push(`【字段不一致】共 ${totalMismatched} 条`)
   lines.push('----------------------------------------')
@@ -59,10 +64,19 @@ export function buildSummaryReport(
     }
   }
 
+  for (const row of rrmMismatched) {
+    lines.push(`PO: ${row.tomyPO}  货号: ${row.货号}  工厂: ${RRM_LABEL}`)
+    for (const m of row.mismatches) {
+      lines.push(`  字段: ${m.field}`)
+      lines.push(`    排期值: ${m.scheduleValue}`)
+      lines.push(`    PO值:   ${m.poValue}`)
+    }
+  }
+
   lines.push('')
 
   // Section 2: Unmatched PO items
-  const totalUnmatched = dg.unmatchedPOItems.length + id.unmatchedPOItems.length
+  const totalUnmatched = dg.unmatchedPOItems.length + id.unmatchedPOItems.length + rrm.unmatchedPOItems.length
 
   lines.push(`【PO未匹配】共 ${totalUnmatched} 条`)
   lines.push('----------------------------------------')
@@ -75,10 +89,14 @@ export function buildSummaryReport(
     lines.push(`PO: ${item.tomyPO}  货号: ${item.货号}  工厂: ${ID_LABEL}  来源: ${item.sourceFile}`)
   }
 
+  for (const item of rrm.unmatchedPOItems) {
+    lines.push(`PO: ${item.tomyPO}  货号: ${item.货号}  工厂: ${RRM_LABEL}  来源: ${item.sourceFile}`)
+  }
+
   lines.push('')
 
   // Section 3: Summary counts
-  const totalErrors = dg.errors.length + id.errors.length
+  const totalErrors = dg.errors.length + id.errors.length + rrm.errors.length
   lines.push('========================================')
   lines.push('汇总统计')
   lines.push('========================================')

--- a/apps/业务部/TOMY排期核对系统/server/routes/upload.ts
+++ b/apps/业务部/TOMY排期核对系统/server/routes/upload.ts
@@ -147,19 +147,23 @@ router.post(
       }
     }
 
-    // Process 印尼 schedule Excel
+    // Process 印尼 schedule Excel.
+    // The 印尼 workbook holds two sheets: KIK总排期 (RR02/RRI) and RRM总排期 (RR03/RRM).
     let scheduleIdResult: ProcessResponse['scheduleId'] = null
     let idBuffer: Buffer | null = null
     let idScheduleRows = null
+    let rrmScheduleRows = null
 
     if (scheduleIdFiles.length > 0) {
       const file = scheduleIdFiles[0]
       const displayName = scheduleIdName || fixFilename(file.originalname)
       try {
-        const rows = await parseScheduleExcel(file.buffer)
-        scheduleIdResult = { filename: displayName, status: 'done', rowCount: rows.length }
+        const kikRows = await parseScheduleExcel(file.buffer, 'KIK总排期')
+        const rrmRows = await parseScheduleExcel(file.buffer, 'RRM总排期')
+        scheduleIdResult = { filename: displayName, status: 'done', rowCount: kikRows.length + rrmRows.length }
         idBuffer = file.buffer
-        idScheduleRows = rows
+        idScheduleRows = kikRows
+        rrmScheduleRows = rrmRows
       } catch (err) {
         scheduleIdResult = {
           filename: displayName,
@@ -184,14 +188,21 @@ router.post(
 
       // CRITICAL: Filter POs by factory code BEFORE reconciling (Pitfall 3)
       // All items in a real PO share the same factory code — use items[0]
+      // RR01 = 东莞 (DG); RR02 = 印尼RRI (ID); RR03 = 印尼RRM (RRM).
+      // RRI and RRM share the same 印尼排期 workbook but live on separate sheets
+      // (KIK总排期 / RRM总排期); each reconciles against its own sheet and gets
+      // its own annotated output in its own ZIP folder.
       const dgPOs = poDataList.filter((po) => po.items[0]?.factoryCode === 'RR01')
       const idPOs = poDataList.filter((po) => po.items[0]?.factoryCode === 'RR02')
+      const rrmPOs = poDataList.filter((po) => po.items[0]?.factoryCode === 'RR03')
 
       try {
         let dgResult: ReconciliationResult | null = null
         let idResult: ReconciliationResult | null = null
+        let rrmResult: ReconciliationResult | null = null
         let dgExcel: Buffer | null = null
         let idExcel: Buffer | null = null
+        let rrmExcel: Buffer | null = null
 
         if (dgBuffer !== null && dgScheduleRows !== null) {
           dgResult = reconcile(dgPOs, dgScheduleRows)
@@ -200,17 +211,30 @@ router.post(
         }
 
         if (idBuffer !== null && idScheduleRows !== null) {
+          // RR02 (RRI) → KIK总排期 sheet
           idResult = reconcile(idPOs, idScheduleRows)
-          idExcel = await writeAnnotatedSchedule(idBuffer, idResult, idScheduleRows)
+          idExcel = await writeAnnotatedSchedule(idBuffer, idResult, idScheduleRows, 'KIK总排期')
           response.reconciliationId = buildReconciliationSummary(idResult)
+
+          // RR03 (RRM) → RRM总排期 sheet, separate annotated output
+          if (rrmScheduleRows !== null) {
+            rrmResult = reconcile(rrmPOs, rrmScheduleRows)
+            rrmExcel = await writeAnnotatedSchedule(idBuffer, rrmResult, rrmScheduleRows, 'RRM总排期')
+            response.reconciliationRrm = buildReconciliationSummary(rrmResult)
+          }
         }
 
         // Build summary report and ZIP
-        const summaryText = buildSummaryReport(dgResult ?? emptyResult, idResult ?? emptyResult)
+        const summaryText = buildSummaryReport(
+          dgResult ?? emptyResult,
+          idResult ?? emptyResult,
+          rrmResult ?? emptyResult,
+        )
 
         const zipEntries: Array<{ name: string; buffer: Buffer }> = []
         if (dgExcel) zipEntries.push({ name: 'DG/东莞排期核对结果.xlsx', buffer: dgExcel })
         if (idExcel) zipEntries.push({ name: 'ID/印尼排期核对结果.xlsx', buffer: idExcel })
+        if (rrmExcel) zipEntries.push({ name: 'RRM/印尼排期核对结果.xlsx', buffer: rrmExcel })
 
         // Add original PO PDFs to their factory folders
         for (const po of poBuffers) {
@@ -218,6 +242,8 @@ router.post(
             zipEntries.push({ name: `DG/PO/${po.filename}`, buffer: po.buffer })
           } else if (po.factoryCode === 'RR02') {
             zipEntries.push({ name: `ID/PO/${po.filename}`, buffer: po.buffer })
+          } else if (po.factoryCode === 'RR03') {
+            zipEntries.push({ name: `RRM/PO/${po.filename}`, buffer: po.buffer })
           }
         }
 
@@ -237,6 +263,7 @@ router.post(
         }
         if (dgBuffer !== null) response.reconciliationDg = { ...emptyErrorSummary }
         if (idBuffer !== null) response.reconciliationId = { ...emptyErrorSummary }
+        if (idBuffer !== null) response.reconciliationRrm = { ...emptyErrorSummary }
         response.outputReady = false
       }
     }

--- a/apps/业务部/TOMY排期核对系统/server/types/index.ts
+++ b/apps/业务部/TOMY排期核对系统/server/types/index.ts
@@ -2,7 +2,7 @@ export interface POItem {
   货号: string          // Part No.
   PO走货期: string      // Due Date (raw string "18 Mar 2026")
   数量: number          // Quantity
-  factoryCode: string   // "RR01" or "RR02"
+  factoryCode: string   // "RR01" (东莞), "RR02" (印尼RRI) or "RR03" (印尼RRM)
   外箱: number | null   // Carton packing (N EA/SET per MASTER CARTON)
   hasJDLabel: boolean   // true if item segment contains <FC>JDHL-0PL
 }
@@ -60,6 +60,7 @@ export interface ProcessResponse {
   } | null
   reconciliationDg?: ReconciliationSummary
   reconciliationId?: ReconciliationSummary
+  reconciliationRrm?: ReconciliationSummary
   outputReady?: boolean
   sessionId?: string
 }


### PR DESCRIPTION
## 背景
`apps/业务部/TOMY排期核对系统`：印尼现有两个工厂 **RR02 = 印尼RRI**、**RR03 = 印尼RRM**。两者共用同一份印尼排期工作簿，但分属两个 sheet：`KIK总排期`(RR02) 与 `RRM总排期`(RR03)。此前系统只识别 RR01/RR02，RR03 的 PO 会被丢为「未分类」。

## 改动
- **pdfExtractor / dateCodeGenerator**：工厂码识别扩展到 RR03（日期码如 `D1526RR03`）。
- **excelParser / excelWriter**：新增可选 `sheetName` 选择器，可按 sheet 解析/标注（默认行为不变）。
- **upload 路由**：RR02 核对 `KIK总排期`、RR03 核对 `RRM总排期`，各自生成独立标注结果；RR03 的 PO PDF 与核对结果归档到独立 `RRM/` 文件夹。
- **summaryReport / 类型 / 前端**：汇总报告与界面新增 RR03/印尼RRM 分组与核对结果卡片，RR02 改标为「印尼RRI」；theme 新增 pink 配色。
- **测试**：新增 RR03 日期码与汇总报告用例。

## 验证
`npx vitest run`（server/lib）— 56 逻辑测试通过（含新增 RR03 用例）。`pdfExtractor.test.ts` 因仓库未包含 `PO_*.pdf` 夹具而报 ENOENT，属既有问题，与本次改动无关。

对应独立仓库 PR：YUzhangj/TOMYpaiqi#1（同一改动）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)