### PR TITLE
fix(deploy): 补 qc 服务路径映射(修 #215 qc 未重建/图表空白)

### DIFF
--- a/apps/生产部/品质管理系统/index.html
+++ b/apps/生产部/品质管理系统/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>兴信 QMS · 品质管理系统</title>
+  <!-- 前端库本地自带于 vendor/（#215），触发 qc 重建（#216 修部署映射） -->
   <link rel="stylesheet" href="style.css" />
   <link rel="stylesheet" href="mobile.css" /><!-- 移动端适配，必须在 style.css 之后 -->
   <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/deploy/update-server.sh
+++ b/deploy/update-server.sh
@@ -120,6 +120,7 @@ declare -A PATH_TO_SERVICE=(
   ["apps/生产部/生产计划管理系统/"]="production-plan"
   ["apps/生产部/喷油部生产管理系统/"]="penyou"
   ["apps/生产部/啤机外发系统/"]="pi-outsource"
+  ["apps/生产部/品质管理系统/"]="qc"
   ["apps/PMC跟仓管/配色库存管理/"]="peise"
   ["apps/PMC跟仓管/华登包材管理/"]="huadeng"
   ["apps/PMC跟仓管/华登毛绒仓库/"]="huadeng-maorong"


### PR DESCRIPTION
## 根因
#204 新增 qc 时漏更新 update-server.sh 的 PATH_TO_SERVICE 映射 → #215 只改 qc 内部文件时部署判定 Affected services: <none> 直接 SKIP，qc 容器未重建。线上 /qc/vendor/*.min.js 404、图表空白、index.html 仍引 jsdelivr。

## 修复
- PATH_TO_SERVICE 补 `["apps/生产部/品质管理系统/"]="qc"`。
- index.html 加注释一行，让本次部署 diff 含 qc 文件触发重建(脚本会 re-exec 新版映射)。

## 验证(部署后)
/qc/vendor/echarts.min.js 等 → 200；/qc/ index.html 引 vendor/。

注：c-store(华登C仓库)同样不在映射表，疑似同类隐患，待确认。

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>