### PR TITLE
feat(internal-quote): 账号改角色 + 车缝导入放宽

### DIFF
--- a/apps/业务部/内部报价系统/backend/routes/admin.js
+++ b/apps/业务部/内部报价系统/backend/routes/admin.js
@@ -63,6 +63,20 @@ router.post('/users', (req, res) => {
   }
 });
 
+// PUT /api/admin/users/:id/role  { role } — 改角色并按新角色模板重置权限
+router.put('/users/:id/role', (req, res) => {
+  const id = Number(req.params.id);
+  const { role } = req.body || {};
+  if (!['staff', 'supervisor', 'admin'].includes(role)) return res.status(400).json({ error: 'role 非法' });
+  const u = db.prepare('SELECT dept, username FROM users WHERE id = ?').get(id);
+  if (!u) return res.status(404).json({ error: '用户不存在' });
+  db.prepare('UPDATE users SET role = ? WHERE id = ?').run(role, id);
+  applyTemplate(id, u.dept, role);  // 按新角色模板重置权限
+  db.prepare(`INSERT INTO audit_log (dept, actor, action, detail) VALUES (?, ?, 'change_role', ?)`)
+    .run(u.dept, req.user.username, `${u.username} -> ${role}`);
+  res.json({ ok: true });
+});
+
 // POST /api/admin/users/:id/reset-password  { password }
 router.post('/users/:id/reset-password', (req, res) => {
   const id = Number(req.params.id);

--- a/apps/业务部/内部报价系统/backend/services/parseSewingSheet.js
+++ b/apps/业务部/内部报价系统/backend/services/parseSewingSheet.js
@@ -6,7 +6,8 @@
 // 多个产品在同一工作表里堆叠。
 const ExcelJS = require('exceljs');
 
-const HEADER_KEYS = ['物料名称', '裁片部位', '用量', '单价', '价钱'];
+// 表头必含项（放宽「单价」：有的表用「物料价」而非「单价」，故不强求）
+const HEADER_KEYS = ['物料名称', '裁片部位', '用量', '价钱'];
 
 function toStr(v) {
   if (v == null) return '';
@@ -42,7 +43,7 @@ function buildHeaderIndex(headerCells) {
     else if (s.includes('裁片部位')) setOnce('part', i);
     else if (s.includes('供应商')) setOnce('supplier', i);
     else if (s.includes('用量')) setOnce('qty', i);
-    else if (s === '单价' || s.includes('单价')) setOnce('unit_price', i);
+    else if (s.includes('单价') || s.includes('物料价')) setOnce('unit_price', i);
     else if (s.includes('成本')) setOnce('cost', i);
     else if (s.includes('码点')) setOnce('markup', i);
     else if (s.includes('价钱')) setOnce('price', i);
@@ -87,7 +88,9 @@ async function parseWorkbook(buffer) {
 
     // 全行只有 1 个 cell + 不是 header → 视为下一分组的标题
     if (joined.length <= 2 && !isHeaderRow(r) && !headerIdx) {
-      pendingTitle = joined.join(' ');
+      const t = joined.join(' ').trim();
+      // 跳过「明细表 / DATE:xxx / 日期 / 纯年月日」等表头噪音，别当成产品名
+      if (t && !/^明细表|^DATE|日期|^\s*20\d\d[.\-/]/i.test(t)) pendingTitle = t;
       continue;
     }
 
@@ -103,6 +106,13 @@ async function parseWorkbook(buffer) {
     if (matName.includes('合计') || (part === '' && matName === '' && price != null && qty == null)) {
       // 重置 header 等待下一个产品
       headerIdx = null;
+      continue;
+    }
+
+    // 产品标题行：物料名称列有文字、但无用量/单价/价钱（如 "18寸 超级机器人…"，表头下方分节标题）
+    if (matName && qty == null && price == null && unitPrice == null && part === '') {
+      if (cur && cur.items.length === 0) cur.name = matName;  // 当前空组直接命名
+      else { cur = { name: matName, items: [], labor_amount: 0, sub_parts: [] }; groups.push(cur); }
       continue;
     }
 
@@ -136,9 +146,11 @@ async function parseWorkbook(buffer) {
     });
   }
 
-  if (!groups.length) return { error: '没有解析到任何产品分组（请确认表头含 物料名称/裁片部位/用量/单价/价钱）' };
+  // 去掉没有任何物料行的空组（如仅由 DATE/表头噪音生成的组）
+  const nonEmpty = groups.filter(g => (g.items || []).length > 0);
+  if (!nonEmpty.length) return { error: '没有解析到任何产品分组（请确认表头含 物料名称/裁片部位/用量/价钱）' };
 
-  return { groups, count: groups.length, sheet_used: ws.name };
+  return { groups: nonEmpty, count: nonEmpty.length, sheet_used: ws.name };
 }
 
 module.exports = { parseWorkbook };

--- a/apps/业务部/内部报价系统/frontend/admin.js
+++ b/apps/业务部/内部报价系统/frontend/admin.js
@@ -65,7 +65,11 @@ function renderUsers() {
       <td><b>${esc(u.username)}</b></td>
       <td>${esc(u.display_name)}</td>
       <td>${esc(u.dept_name || u.dept)}</td>
-      <td>${ROLE_ZH[u.role] || u.role}</td>
+      <td><select class="role-sel" data-id="${u.id}" data-username="${esc(u.username)}" data-cur="${u.role}" style="padding:3px 6px">
+        <option value="staff" ${u.role==='staff'?'selected':''}>员工</option>
+        <option value="supervisor" ${u.role==='supervisor'?'selected':''}>主管</option>
+        <option value="admin" ${u.role==='admin'?'selected':''}>管理员</option>
+      </select></td>
       <td>${isLocked ? '<span class="badge b-empty">已锁定</span>' : '<span class="badge b-approved">正常</span>'}</td>
       <td class="ro" style="font-size:12px">${last}</td>
       <td>
@@ -86,6 +90,19 @@ function renderUsers() {
   document.querySelectorAll('.btn-lock').forEach(b => b.onclick = () => lockUser(b.dataset.id, b.dataset.username));
   document.querySelectorAll('.btn-unlock').forEach(b => b.onclick = () => unlockUser(b.dataset.id));
   document.querySelectorAll('.btn-del').forEach(b => b.onclick = () => delUser(b.dataset.id, b.dataset.username));
+  document.querySelectorAll('.role-sel').forEach(s => s.onchange = () => changeRole(s.dataset.id, s.dataset.username, s.value, s.dataset.cur));
+}
+
+async function changeRole(id, username, role, cur) {
+  if (role === cur) return;
+  if (!confirm(`把「${username}」的角色改为「${ROLE_ZH[role] || role}」？\n会按新角色模板重置该用户权限（之前手动改的权限会被覆盖）。`)) {
+    loadUsers();  // 取消则还原下拉
+    return;
+  }
+  try {
+    await api('/admin/users/' + id + '/role', { method: 'PUT', body: JSON.stringify({ role }) });
+    await loadUsers();
+  } catch (e) { alert(e.message); loadUsers(); }
 }
 
 // ============== 权限矩阵抽屉 ==============


### PR DESCRIPTION
## 改动
- **账号管理**：角色列改成下拉可改（员工/主管/管理员）；新增 `PUT /api/admin/users/:id/role`（仅管理员），改角色并按新角色模板重置权限，写审计日志。
- **车缝导入**（parseSewingSheet）：
  - 表头不再强求「单价」——兼容用「物料价（RMB）」的表；
  - 支持产品标题在**表头下方**的分节写法；
  - 跳过「DATE:xxx / 明细表」等噪音行，不当成产品名；
  - 过滤无物料行的空组（修复导入后多出一个空产品组）。

> 注：VQ「报客表」导出功能仍在开发，本 PR 不含。

🤖 Generated with [Claude Code](https://claude.com/claude-code)