### PR TITLE
Fix QC OCR deployment dispatch

### DIFF
--- a/apps/生产部/品质管理系统/ai-ocr.js
+++ b/apps/生产部/品质管理系统/ai-ocr.js
@@ -1,76 +1,114 @@
-/* ══════════════════════════════════════════════════════════════
-   兴信 QMS · AI 识别接入（阿里百炼 qwen-vl）  ai-ocr.js
-   ────────────────────────────────────────────────────────────
-   在 app.js 之后加载。劫持 startOcr()：
-     · 后端 AI 就绪(/api/ai/status.ready) → 用 AI 视觉模型只提取系统需要的字段
-     · 未就绪或调用失败 → 自动回退到原 Tesseract 流程
-   不改 app.js。图片从 #ocrPreview 的 dataURL 取，必要时压缩后发后端。
-══════════════════════════════════════════════════════════════ */
+/* 兴信 QMS - AI OCR 接入
+   加载在 app.js 之后。稳定接管“开始识别”按钮：
+   - 后端 AI 就绪时使用 /api/ai/ocr-extract
+   - AI 未配置时才回退到原本 Tesseract
+   - 线上脚本加载顺序变化时也会重复尝试挂载
+*/
 (function () {
   'use strict';
 
   var aiReady = false;
-  // API 基址：兼容根部署与 /qc/ 子路径部署（与 qc-backend.js 一致）
+  var aiStatus = null;
+  var statusPromise = null;
+  var patchTimer = null;
+
   var API_BASE = (function () {
     var p = location.pathname.replace(/[^/]*$/, '');
     return p.replace(/\/$/, '');
   })();
-  // 启动时查询 AI 是否可用
-  fetch(API_BASE + '/api/ai/status').then(function (r) { return r.json(); })
-    .then(function (s) { aiReady = !!(s && s.ready); updateHint(s); })
-    .catch(function () { aiReady = false; });
 
-  function updateHint(s) {
+  function setV(id, v) {
+    var el = document.getElementById(id);
+    if (el && v != null) el.value = v;
+  }
+
+  function setT(id, v) {
+    var el = document.getElementById(id);
+    if (el) el.textContent = v;
+  }
+
+  function toast(msg, type) {
+    if (typeof window.showToast === 'function') window.showToast(msg, type || 'info');
+  }
+
+  function checkAiStatus(force) {
+    if (statusPromise && !force) return statusPromise;
+    statusPromise = fetch(API_BASE + '/api/ai/status', { cache: 'no-store' })
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        return r.json();
+      })
+      .then(function (s) {
+        aiStatus = s || {};
+        aiReady = !!(s && s.ready);
+        updateHint();
+        return aiReady;
+      })
+      .catch(function (err) {
+        aiStatus = { ready: false, error: err && err.message };
+        aiReady = false;
+        updateHint();
+        return false;
+      });
+    return statusPromise;
+  }
+
+  function updateHint() {
     var el = document.getElementById('ocrStatus');
-    if (el && (!el.textContent || /未上传图片/.test(el.textContent))) {
-      el.textContent = aiReady ? ('AI识别已就绪(' + (s.ocrModel || '百炼') + ')，上传图片后点开始识别')
-                               : '未上传图片（AI未配置，将用本地OCR）';
+    if (!el) return;
+    var text = el.textContent || '';
+    if (!text || text === '未上传图片' || text.indexOf('AI OCR') === 0 || text.indexOf('本地 OCR') === 0) {
+      el.textContent = aiReady
+        ? 'AI OCR 已就绪(' + ((aiStatus && aiStatus.ocrModel) || '百炼') + ')'
+        : 'AI OCR 未就绪，将回退本地 OCR';
     }
   }
 
-  /* 把 dataURL 压到长边 ≤2000px，控制上传体积、保留清晰度 */
   function shrinkDataUrl(dataUrl, maxEdge) {
     return new Promise(function (resolve) {
       try {
         var img = new Image();
         img.onload = function () {
-          var w = img.width, h = img.height;
+          var w = img.width;
+          var h = img.height;
           var long = Math.max(w, h);
-          if (long <= maxEdge) { resolve(dataUrl); return; }
+          if (long <= maxEdge) {
+            resolve(dataUrl);
+            return;
+          }
           var scale = maxEdge / long;
           var cv = document.createElement('canvas');
-          cv.width = Math.round(w * scale); cv.height = Math.round(h * scale);
+          cv.width = Math.round(w * scale);
+          cv.height = Math.round(h * scale);
           cv.getContext('2d').drawImage(img, 0, 0, cv.width, cv.height);
           resolve(cv.toDataURL('image/jpeg', 0.9));
         };
         img.onerror = function () { resolve(dataUrl); };
         img.src = dataUrl;
-      } catch (e) { resolve(dataUrl); }
+      } catch (e) {
+        resolve(dataUrl);
+      }
     });
   }
 
-  function setV(id, v) { var el = document.getElementById(id); if (el && v != null) el.value = v; }
-  function setT(id, v) { var el = document.getElementById(id); if (el) el.textContent = v; }
-
-  /* 把 AI 返回的结构化字段填进 OCR 预览字段 + 原文框 */
   function applyFields(fields) {
+    fields = fields || {};
     var items = Array.isArray(fields.items) ? fields.items : [];
     var first = items[0] || {};
 
-    if (fields.date)        setV('ocrDate', fields.date);
-    if (fields.supplier)    setV('ocrSupplier', fields.supplier);
-    if (fields.deliveryNo)  setV('ocrDeliveryNo', fields.deliveryNo);
-    if (fields.type)        setV('ocrType', fields.type || '来料');
-    if (first.productNo)    setV('ocrProductNo', first.productNo);
-    if (first.productName)  setV('ocrProductName', first.productName);
-    if (first.qty)          setV('ocrQty', String(first.qty).replace(/[^\d.]/g, ''));
+    if (fields.date) setV('ocrDate', fields.date);
+    if (fields.supplier) setV('ocrSupplier', fields.supplier);
+    if (fields.deliveryNo) setV('ocrDeliveryNo', fields.deliveryNo);
+    if (fields.type) setV('ocrType', fields.type || '来料');
+    if (first.productNo) setV('ocrProductNo', first.productNo);
+    if (first.productName) setV('ocrProductName', first.productName);
+    if (first.qty) setV('ocrQty', String(first.qty).replace(/[^\d.]/g, ''));
 
-    // 把完整识别结果（含订单号、所有行）写进原文框，避免信息丢失
     var lines = [];
-    if (fields.supplier)   lines.push('供应商：' + fields.supplier);
-    if (fields.date)       lines.push('日期：' + fields.date);
+    if (fields.supplier) lines.push('供应商：' + fields.supplier);
+    if (fields.date) lines.push('日期：' + fields.date);
     if (fields.deliveryNo) lines.push('送货单号：' + fields.deliveryNo);
-    if (fields.orderNo)    lines.push('订单号：' + fields.orderNo);
+    if (fields.orderNo) lines.push('订单号：' + fields.orderNo);
     if (items.length) {
       lines.push('货品明细：');
       items.forEach(function (it, i) {
@@ -79,20 +117,22 @@
     }
     setV('ocrRawText', lines.join('\n'));
 
-    // 暂存结构化结果，供"应用"按钮判断走单条还是多行批量
     window.__qcAiResult = {
       common: {
-        date: fields.date || '', supplier: fields.supplier || '',
-        deliveryNo: fields.deliveryNo || '', orderNo: fields.orderNo || '',
+        date: fields.date || '',
+        supplier: fields.supplier || '',
+        deliveryNo: fields.deliveryNo || '',
+        orderNo: fields.orderNo || '',
         type: fields.type || '来料',
       },
       items: items,
     };
+
     var applyBtn = document.getElementById('btnApplyOcrToForm');
     if (applyBtn) {
       applyBtn.textContent = items.length > 1
-        ? ('✓ 应用 ' + items.length + ' 条（逐条录入）')
-        : '✓ 应用到单条录入';
+        ? ('应用 ' + items.length + ' 条（逐条录入）')
+        : '应用到单条录入';
     }
     return items.length;
   }
@@ -101,59 +141,60 @@
     var imgEl = document.getElementById('ocrPreview');
     var dataUrl = imgEl && imgEl.src && imgEl.src.indexOf('data:image') === 0 ? imgEl.src : '';
     if (!dataUrl) {
-      if (typeof window.showToast === 'function') window.showToast('请先上传图片', 'error');
-      return;
+      toast('请先上传图片', 'error');
+      return Promise.resolve();
     }
+
     var btn = document.getElementById('btnStartOcr');
     if (btn) btn.disabled = true;
-    setT('ocrStatus', 'AI 识别中，请稍候…');
-    window.__qcAiResult = null;   // 清掉上一次结果
+    setT('ocrStatus', 'AI 识别中，请稍候...');
+    window.__qcAiResult = null;
 
-    shrinkDataUrl(dataUrl, 2000).then(function (small) {
-      return fetch(API_BASE + '/api/ai/ocr-extract', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ image: small }),
-      });
-    }).then(function (r) { return r.json().then(function (j) { return { ok: r.ok, j: j }; }); })
+    return shrinkDataUrl(dataUrl, 2000)
+      .then(function (small) {
+        return fetch(API_BASE + '/api/ai/ocr-extract', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ image: small }),
+        });
+      })
+      .then(function (r) {
+        return r.json().catch(function () { return {}; }).then(function (j) {
+          return { ok: r.ok, status: r.status, j: j };
+        });
+      })
       .then(function (res) {
         if (!res.ok || !res.j || !res.j.ok) {
-          throw new Error((res.j && res.j.error) || 'AI 识别失败');
+          throw new Error((res.j && res.j.error) || ('HTTP ' + res.status));
         }
         var n = applyFields(res.j.fields || {});
         setT('ocrStatus', 'AI 识别完成' + (n > 1 ? ('（共 ' + n + ' 行货品，已填第 1 行）') : ''));
-        if (typeof window.showToast === 'function') {
-          window.showToast(n > 1 ? ('✓ 识别完成，共 ' + n + ' 行，已填第1行，其余见原文框') : '✓ AI 识别完成，请核对字段', 'success');
-        }
+        toast(n > 1 ? ('识别完成，共 ' + n + ' 行，已填第 1 行') : 'AI 识别完成，请核对字段', 'success');
       })
       .catch(function (err) {
-        console.warn('[AI-OCR] 失败，回退本地 OCR：', err && err.message);
-        setT('ocrStatus', 'AI 识别失败，改用本地 OCR…');
-        if (typeof window.__origStartOcr === 'function') {
-          window.__origStartOcr();   // 回退 Tesseract
-        } else if (typeof window.showToast === 'function') {
-          window.showToast('AI 识别失败：' + (err && err.message || ''), 'error');
-        }
+        var msg = err && err.message ? err.message : '未知错误';
+        console.warn('[AI-OCR]', msg, err);
+        setT('ocrStatus', 'AI 识别失败：' + msg);
+        toast('AI 识别失败：' + msg, 'error');
       })
-      .finally(function () { if (btn) btn.disabled = false; });
+      .finally(function () {
+        if (btn) btn.disabled = false;
+      });
   }
 
-  /* 劫持：AI 就绪走 AI，否则走原 Tesseract */
-  /* ── 多行货品「逐条录入」队列 ──
-     把每行货品依次填进单条录入表单，由用户逐条判定合格/不合格 + 不良明细后保存，
-     保存成功后自动加载下一条，直到全部录完。整单共用 日期/供应商/送货单号/类型。 */
   function loadQueueItem(q) {
     if (!q || q.idx >= q.items.length) return;
-    var it = q.items[q.idx], c = q.common || {};
-    if (typeof window.openAddModal === 'function') window.openAddModal(); // 开/重置单条表单(会切到单条、清表单、填今天)
-    setV('f_date', c.date || '');               // 用送货单日期覆盖"今天"
+    var it = q.items[q.idx];
+    var c = q.common || {};
+    if (typeof window.openAddModal === 'function') window.openAddModal();
+    setV('f_date', c.date || '');
     setV('f_supplier', c.supplier || '');
     setV('f_deliveryNo', c.deliveryNo || '');
     if (c.type) setV('f_type', c.type);
     setV('f_productNo', it.productNo || '');
     setV('f_productName', it.productName || '');
     setV('f_qty', String(it.qty == null ? '' : it.qty).replace(/[^\d.]/g, ''));
-    if (typeof window.onQtyChange === 'function') window.onQtyChange();          // 触发 AQL 抽样自动计算
+    if (typeof window.onQtyChange === 'function') window.onQtyChange();
     if (typeof window.onProductNoChange === 'function') window.onProductNoChange();
     setT('modalTitle', '新增验货记录（第 ' + (q.idx + 1) + '/' + q.items.length + ' 条）');
   }
@@ -161,18 +202,38 @@
   function startQueue(common, items) {
     window.__qcQueue = { common: common, items: items, idx: 0 };
     loadQueueItem(window.__qcQueue);
-    if (typeof window.showToast === 'function') {
-      window.showToast('共 ' + items.length + ' 条货品，逐条录入：判定合格/不合格后保存，自动跳下一条', 'info');
-    }
+    toast('共 ' + items.length + ' 条货品，逐条录入', 'info');
   }
 
-  /* 劫持：AI 就绪走 AI，否则走原 Tesseract；应用/保存/关闭挂队列逻辑 */
+  function runOriginalOcr() {
+    if (typeof window.__origStartOcr === 'function') return window.__origStartOcr();
+    toast('本地 OCR 入口未就绪，请刷新页面后重试', 'error');
+  }
+
+  function aiDispatch() {
+    return checkAiStatus(false).then(function (ready) {
+      if (ready) return aiStartOcr();
+      setT('ocrStatus', 'AI OCR 未就绪，正在改用本地 OCR...');
+      return runOriginalOcr();
+    });
+  }
+
   function patch() {
-    if (typeof window.startOcr === 'function' && window.startOcr !== aiDispatch) {
+    if (typeof window.startOcr === 'function' && window.startOcr !== aiDispatch && window.startOcr !== window.__origStartOcr) {
       window.__origStartOcr = window.startOcr;
-      window.startOcr = aiDispatch;
     }
-    // 应用按钮：多行(AI识别)→逐条录入队列；单行/Tesseract→原单条录入
+    window.startOcr = aiDispatch;
+
+    var btn = document.getElementById('btnStartOcr');
+    if (btn && !btn.__qcAiClickPatched) {
+      btn.addEventListener('click', function (e) {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        aiDispatch();
+      }, true);
+      btn.__qcAiClickPatched = true;
+    }
+
     if (typeof window.applyOcrToForm === 'function' && !window.applyOcrToForm.__qcWrapped) {
       var origApply = window.applyOcrToForm;
       window.applyOcrToForm = function () {
@@ -182,26 +243,28 @@
       };
       window.applyOcrToForm.__qcWrapped = true;
     }
-    // 保存成功(弹窗被关)后，若队列还有剩余→自动加载下一条
+
     if (typeof window.saveRecord === 'function' && !window.saveRecord.__qcQueueWrapped) {
       var origSave = window.saveRecord;
       window.saveRecord = function () {
         var q = window.__qcQueue;
         var overlay = document.getElementById('modalOverlay');
         var ret = origSave.apply(this, arguments);
-        if (q && overlay && !overlay.classList.contains('show')) {  // 关掉了=保存成功；校验失败弹窗仍在
+        if (q && overlay && !overlay.classList.contains('show')) {
           q.idx++;
-          if (q.idx < q.items.length) { window.__qcQueue = q; loadQueueItem(q); }
-          else {
+          if (q.idx < q.items.length) {
+            window.__qcQueue = q;
+            loadQueueItem(q);
+          } else {
             window.__qcQueue = null;
-            if (typeof window.showToast === 'function') window.showToast('✓ ' + q.items.length + ' 条货品已全部录入完成', 'success');
+            toast(q.items.length + ' 条货品已全部录入完成', 'success');
           }
         }
         return ret;
       };
       window.saveRecord.__qcQueueWrapped = true;
     }
-    // 取消/关闭弹窗→清空队列，避免之后误触发
+
     if (typeof window.closeModalDirect === 'function' && !window.closeModalDirect.__qcQueueWrapped) {
       var origClose = window.closeModalDirect;
       window.closeModalDirect = function () {
@@ -212,11 +275,16 @@
       window.closeModalDirect.__qcQueueWrapped = true;
     }
   }
-  function aiDispatch() {
-    if (aiReady) return aiStartOcr();
-    if (typeof window.__origStartOcr === 'function') return window.__origStartOcr();
+
+  function schedulePatch() {
+    patch();
+    if (patchTimer) clearTimeout(patchTimer);
+    patchTimer = setTimeout(patch, 300);
+    setTimeout(patch, 1000);
+    setTimeout(patch, 2500);
   }
 
-  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', patch);
-  else patch();
+  checkAiStatus(false);
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', schedulePatch);
+  else schedulePatch();
 })();

--- a/apps/生产部/品质管理系统/ai-ocr.js
+++ b/apps/生产部/品质管理系统/ai-ocr.js
@@ -211,7 +211,7 @@
   }
 
   function aiDispatch() {
-    return checkAiStatus(false).then(function (ready) {
+    return checkAiStatus(true).then(function (ready) {
       if (ready) return aiStartOcr();
       setT('ocrStatus', 'AI OCR 未就绪，正在改用本地 OCR...');
       return runOriginalOcr();

--- a/apps/生产部/品质管理系统/index.html
+++ b/apps/生产部/品质管理系统/index.html
@@ -749,7 +749,7 @@
 <script src="report_export.js"></script>
 <script src="qc-backend.js"></script><!-- 后端同步层：必须在 app.js 之前 -->
 <script src="app.js?v=20260702-heatmap"></script>
-<script src="ai-ocr.js"></script><!-- AI(百炼)识别，劫持 startOcr -->
+<script src="ai-ocr.js?v=20260706-ocr-dispatch"></script><!-- AI(百炼)识别，劫持 startOcr -->
 <script src="mobile.js"></script><!-- 移动端侧栏抽屉交互 -->
 </div><!-- /appWrapper -->
 

--- a/apps/生产部/品质管理系统/server/ai-config.json
+++ b/apps/生产部/品质管理系统/server/ai-config.json
@@ -4,5 +4,5 @@
   "apiKey": "",
   "ocrModel": "qwen-vl-max",
   "textModel": "qwen-plus",
-  "_note": "生产环境密钥经容器环境变量 DASHSCOPE_API_KEY 注入（docker-compose 里映射 QC_BAILIAN_API_KEY），请勿把真实密钥写进本文件提交。本地单机用时可临时填 apiKey 调试。"
+  "_note": "生产环境密钥请用 DASHSCOPE_API_KEY 或 QC_BAILIAN_API_KEY 注入。不要把真实密钥提交到仓库；本地单机调试时才临时填写 apiKey。"
 }

--- a/apps/生产部/品质管理系统/server/server.js
+++ b/apps/生产部/品质管理系统/server/server.js
@@ -30,9 +30,10 @@ function loadAiConfig() {
     textModel: 'qwen-plus',
   };
   try { Object.assign(cfg, JSON.parse(fs.readFileSync(AI_CONFIG_PATH, 'utf8'))); }
-  catch (e) { /* 无配置文件时保持禁用 */ }
+  catch (e) { console.warn('[AI] config not loaded:', e.message); }
   // 环境变量可覆盖密钥
-  if (process.env.DASHSCOPE_API_KEY) cfg.apiKey = process.env.DASHSCOPE_API_KEY;
+  const envApiKey = process.env.DASHSCOPE_API_KEY || process.env.QC_BAILIAN_API_KEY;
+  if (envApiKey) cfg.apiKey = envApiKey;
   // 仅当密钥已填写真实值（非占位）才算可用
   const placeholder = !cfg.apiKey || /粘贴|你的|YOUR|xxxx|sk-xxx/i.test(cfg.apiKey) || cfg.apiKey.includes('****');
   cfg.ready = cfg.enabled !== false && !placeholder;


### PR DESCRIPTION
修复 QC 系统部署后 OCR 直接识别失败的问题：

- 前端 AI OCR 点击时实时检查 /api/ai/status，线上加载顺序变化也能稳定接管按钮
- 修复 ai-config.json 模板 JSON 可解析性
- 后端支持 DASHSCOPE_API_KEY 和 QC_BAILIAN_API_KEY 注入密钥
- 给 ai-ocr.js 加版本号，避免部署后继续使用旧缓存

验证：
- node --check apps/生产部/品质管理系统/ai-ocr.js
- node --check apps/生产部/品质管理系统/server/server.js
- ai-config.json JSON parse OK
- git diff --check