### PR TITLE
Fix internal quote imports and local pricing refs

### DIFF
--- a/apps/业务部/内部报价系统/backend/routes/quotes.js
+++ b/apps/业务部/内部报价系统/backend/routes/quotes.js
@@ -204,7 +204,13 @@ router.get('/:id', (req, res) => {
       engineering_molds = (p.molds || []).map(m => ({
         mold_no: m.mold_no || '', name: m.name || '', cavity: m.cavity || '',
         sets: m.sets ?? 1, material: m.material || '', color: m.color || '',
+        material_grade: m.material_grade || '', machine: m.machine || '',
+        machine_model: m.machine_model || (m.detail && m.detail.machine_model) || '',
+        target: m.target ?? (m.detail && m.detail.target) ?? null,
+        material_unit_price: m.material_unit_price ?? null,
+        shot_price: m.shot_price ?? null,
         weight_g: m.weight_g ?? null, cycle_sec: m.cycle_sec ?? null,
+        note: m.note || '',
       }));
     } catch {}
   }

--- a/apps/业务部/内部报价系统/backend/services/parseMoldSheet.js
+++ b/apps/业务部/内部报价系统/backend/services/parseMoldSheet.js
@@ -94,7 +94,8 @@ function formatStructure(v) {
   const s = String(v || '').trim();
   if (!s || s === '无') return '';
   const n = parseNumber(s);
-  return n != null ? `${n}个行位` : s;
+  if (n != null) return n > 0 ? `${n}个行位` : '';
+  return s;
 }
 
 function parseWorkbook(buf) {

--- a/apps/业务部/内部报价系统/backend/services/parseMoldSheet.js
+++ b/apps/业务部/内部报价系统/backend/services/parseMoldSheet.js
@@ -13,21 +13,24 @@ const XLSX = require('xlsx');
 // 关键词全部以「去空格 + 大写」比较，故英文关键词写成大写即可同时兼容中英表头
 const FIELD_KEYWORDS = {
   mold_no:        ['模号', '模具编号', '客人模具编号', '编号', 'MOLDNO'],
+  part_name:      ['配件名称', 'PARTNAME', 'PART NAME'],
   name:           ['产品名称', '零件名称', '中文名', 'CHINESENAME', '加工内容', '修改内容', '模具名称', '名称', 'PARTNAME', 'DESCRIPTION'],
   // 模具材料(内呵钢材) / 模具尺寸(模胚型号) 优先映射（避免被 "材质/材料" 短词抢占）
-  mold_material:  ['模具材料', '内呵材质', '内呵', '钢号', '钢材', 'TOOLINSERT', 'INSERT'],
+  mold_material:  ['模具材料', '钢材材质', '内呵材质', '内呵', '钢号', '钢材', 'STEELMATERIAL', 'TOOLINSERT', 'INSERT'],
   mold_size:      ['模具尺寸', '模胚尺寸', 'DIM', 'HXWXD', 'TOOLINFORMATION'],
-  material:       ['塑胶原料', '塑胶', '产品材质', '产品材料', '材质', '材料', '原料', "MAT'L", 'MATERIAL'],
+  material:       ['胶料类型', '塑胶原料', '塑胶', '产品材质', '产品材料', '材质', '材料', '原料', 'PLASTIC', "MAT'L", 'MATERIAL'],
   color:          ['颜色', 'COLOR'],
-  cavity:         ['出模数', '模数', 'CAV'],
+  cavity:         ['出模数', '型腔', '模数', 'CAV'],
   sets:           ['套数', 'UP', '数量/件', '数量'],
   product_size:   ['产品尺寸'],
-  weight:         ['净重', '克重', '零件重', 'PARTWEIGHT'],
+  machine:        ['机型(TON)', 'INJECTIONMACHINETYPE', '机型'],
+  weight:         ['净重', '克重', '零件重量', '零件重', 'PARTWEIGHT'],
   cycle:          ['周期', 'CYCLETIME', 'CYCLE'],   // 注塑生产周期(秒)
+  target:         ['模具预计日啤数', '目标数', 'CYCLES/DAY', 'CYCLESDAY'],
   structure:      ['滑块', '斜顶', '模具结构', '加工内容', 'SLIDE', '行位'],
   price_rmb:      ['含税模价', '总价', '模价', '价格', '单价', 'TOTALAMOUNT', 'AMOUNT'],
   price_usd:      ['USD', '美元'],
-  mold_type:      ['模胚类型', '模胚大约', '模胚型号', '模胚', '水口', 'GATE'],
+  mold_type:      ['进胶方式', '模胚类型', '模胚大约', '模胚型号', '模胚', '水口', 'GATE'],
   note:           ['备注', '说明', 'REMARK'],
 };
 
@@ -69,6 +72,29 @@ function parseNumber(v) {
   if (v == null || v === '') return null;
   const n = Number(String(v).replace(/[￥$,，\s元RMB]/gi, ''));
   return Number.isFinite(n) ? n : null;
+}
+
+function machineTonToModel(v) {
+  const m = String(v || '').match(/[\d.]+/);
+  const n = m ? Number(m[0]) : null;
+  if (n == null) return String(v || '').trim();
+  if (n <= 90) return '7A';
+  if (n <= 130) return '10A';
+  if (n <= 170) return '14A';
+  if (n <= 220) return '20A';
+  if (n <= 280) return '24A';
+  if (n <= 360) return '32A';
+  if (n <= 520) return '44A';
+  if (n <= 680) return '60A';
+  if (n <= 900) return '105A';
+  return `${n}T`;
+}
+
+function formatStructure(v) {
+  const s = String(v || '').trim();
+  if (!s || s === '无') return '';
+  const n = parseNumber(s);
+  return n != null ? `${n}个行位` : s;
 }
 
 function parseWorkbook(buf) {
@@ -129,6 +155,10 @@ function tryParseSheet(wb, sheetName) {
 
   // 数据行：从 dataStart 起；遇到新的 section 标题（如"二、注塑部分"）或新表头则停止
   const dataRows = [];
+  // bodyRows keeps continuation/detail rows that may not repeat mold_no/name.
+  // It is mainly used for assigning embedded pictures whose anchors sit on
+  // child rows under the same mold number.
+  const bodyRows = [];
   for (let i = dataStart; i < aoa.length; i++) {
     const r = aoa[i] || [];
     const txt = r.map(c => String(c ?? '')).join('').trim();
@@ -149,9 +179,19 @@ function tryParseSheet(wb, sheetName) {
     if (/[一二三四五六七八九十]、/.test(String(r[0] || ''))) continue;
     // 页脚/签名/条款（如 "Authorized signature"）；英文条款
     if (/AUTHORIZED|SIGNATURE|I\/WE ACCEPT|COMPANY CHOP|TERMS/i.test(txt)) continue;
-    // 有模号列时：既无模号又无名称的行（合计/签名/条款）不并入上一副模具
-    if (cols.mold_no >= 0 && !cell(r, 'mold_no') && !cell(r, 'name')) continue;
+    bodyRows.push({ r, ri: i });
+    // 有模号列时：既无模号又无名称的行不参与字段提取，但仍保留在 bodyRows，
+    // 让同一模号下面的明细行图片可以按行范围归属到上一副模具。
+    if (cols.mold_no >= 0 && !cell(r, 'mold_no') && !cell(r, 'name') && !cell(r, 'part_name')) continue;
     dataRows.push({ r, ri: i });  // ri = 0-based 原始行号，供图片按行归属
+  }
+
+  const hasPartDetailCols = cols.part_name >= 0 && cols.name >= 0 && cols.part_name !== cols.name;
+  if (hasPartDetailCols) {
+    const detailMolds = buildPartDetailMolds(dataRows, cell);
+    if (detailMolds.length) {
+      return { sheets: wb.SheetNames, sheet_used: sheetName, header_row: hIdx + 1, cols_found: cols, molds: detailMolds };
+    }
   }
 
   // 决定是否做"主模号合并"——仅当 mold_no 列存在且存在多个含值/空值交替的子行
@@ -164,16 +204,41 @@ function tryParseSheet(wb, sheetName) {
 
     if (isNew || !current) {
       if (current) groups.push(current);
-      current = { mold_no: moldNo, names: [], materials: [], colors: [], cavities: [], sets: null, weight: null, cycle: null, mold_material: '', mold_size: '', structures: [], price_rmb: null, mold_type: '', notes: [], rowStart: ri, rowEnd: ri };
+      current = {
+        mold_no: moldNo,
+        names: [],
+        part_names: [],
+        materials: [],
+        colors: [],
+        cavities: [],
+        sets: null,
+        weights: [],
+        weight: null,
+        cycle: null,
+        mold_material: '',
+        mold_size: '',
+        structures: [],
+        price_rmb: null,
+        mold_type: '',
+        notes: [],
+        rowStart: ri,
+        rowEnd: ri,
+      };
     }
     current.rowEnd = ri;  // 该组覆盖到当前行
     const name = cell(r, 'name');
     if (name) current.names.push(name);
+    const partName = cell(r, 'part_name');
+    if (partName) current.part_names.push(partName);
     const mat = cell(r, 'material'); if (mat) current.materials.push(mat);
     const colorVal = cell(r, 'color'); if (colorVal) current.colors.push(colorVal);
     const cav = cell(r, 'cavity');   if (cav) current.cavities.push(cav);
     const sets = parseNumber(cell(r, 'sets')); if (sets != null && current.sets == null) current.sets = sets;
-    const wt = parseNumber(cell(r, 'weight')); if (wt != null && current.weight == null) current.weight = wt;
+    const wt = parseNumber(cell(r, 'weight'));
+    if (wt != null) {
+      current.weights.push(wt);
+      if (current.weight == null) current.weight = wt;
+    }
     const cyc = parseNumber(cell(r, 'cycle')); if (cyc != null && current.cycle == null) current.cycle = cyc;
     const mm = cell(r, 'mold_material'); if (mm && !current.mold_material) current.mold_material = mm;
     const ms = cell(r, 'mold_size'); if (ms && !current.mold_size) current.mold_size = ms;
@@ -184,6 +249,23 @@ function tryParseSheet(wb, sheetName) {
   }
   if (current) groups.push(current);
 
+  // For sheets with merged/continued rows, a mold row often spans until the
+  // next mold number. Extend _rows so pictures anchored on child rows are not
+  // left unassigned.
+  if (hasMoldNoCol && groups.length && bodyRows.length) {
+    const bodyIndexes = bodyRows.map(x => x.ri).sort((a, b) => a - b);
+    groups.forEach((g, gi) => {
+      const nextStart = groups[gi + 1] ? groups[gi + 1].rowStart : null;
+      let end = g.rowEnd;
+      for (const ri of bodyIndexes) {
+        if (ri < g.rowStart) continue;
+        if (nextStart != null && ri >= nextStart) break;
+        end = ri;
+      }
+      g.rowEnd = Math.max(g.rowEnd, end);
+    });
+  }
+
   const molds = groups.filter(g => g.names.length > 0 || g.mold_no).map(g => {
     // 出模数 = 组内各件 CAV 相加（总穴数）。CAV 形如 "2" 或 "2*1" 时取乘积，空则 0
     const cavSum = g.cavities.reduce((a, c) => {
@@ -192,9 +274,15 @@ function tryParseSheet(wb, sheetName) {
       return a + nums.map(Number).reduce((x, y) => x * y, 1);
     }, 0);
     const cavity = cavSum > 0 ? String(cavSum) : (g.cavities[0] || '');
+    const uniquePartNames = [...new Set(g.part_names || [])];
+    const uniqueNames = [...new Set(g.names || [])];
+    const displayNames = uniquePartNames.length ? uniquePartNames : uniqueNames;
+    const weightTotal = uniquePartNames.length && g.weights.length
+      ? +g.weights.reduce((a, n) => a + n, 0).toFixed(4)
+      : g.weight;
     return {
       mold_no: g.mold_no,
-      name: g.names.join('/') || g.mold_no,
+      name: displayNames.join('/') || g.mold_no,
       mold_type: g.mold_type || (/细水口/.test(g.notes.join('')) ? '细水口'
                               : /大水口|潜水/.test(g.notes.join('')) ? '大水口'
                               : /三板/.test(g.notes.join('')) ? '三板模' : ''),
@@ -203,7 +291,7 @@ function tryParseSheet(wb, sheetName) {
       color: [...new Set(g.colors)].join('/'),
       cavity,
       sets: g.sets ?? 1,
-      weight_g: g.weight,
+      weight_g: weightTotal,
       cycle_sec: g.cycle,
       price_rmb: g.price_rmb,
       images: [],
@@ -214,6 +302,70 @@ function tryParseSheet(wb, sheetName) {
   });
 
   return { sheets: wb.SheetNames, sheet_used: sheetName, header_row: hIdx + 1, cols_found: cols, molds };
+}
+
+function buildPartDetailMolds(dataRows, cell) {
+  const molds = [];
+  const state = {};
+  const keep = (k, v) => {
+    const s = String(v ?? '').trim();
+    if (s) state[k] = s;
+    return state[k] || '';
+  };
+
+  for (const { r, ri } of dataRows) {
+    const moldNo = keep('mold_no', cell(r, 'mold_no'));
+    const groupName = keep('group_name', cell(r, 'name'));
+    const partName = cell(r, 'part_name') || groupName || moldNo;
+    if (!partName) continue;
+
+    const material = keep('material', cell(r, 'material'));
+    const color = keep('color', cell(r, 'color'));
+    const cavity = cell(r, 'cavity') || state.cavity || '';
+    if (cavity) state.cavity = cavity;
+    const setsCell = parseNumber(cell(r, 'sets'));
+    if (setsCell != null) state.sets = setsCell;
+    const cycleCell = parseNumber(cell(r, 'cycle'));
+    if (cycleCell != null) state.cycle = cycleCell;
+    const targetCell = parseNumber(cell(r, 'target'));
+    if (targetCell != null) state.target = targetCell;
+
+    const machine = keep('machine', cell(r, 'machine'));
+    const moldMaterial = keep('mold_material', cell(r, 'mold_material'));
+    const moldType = keep('mold_type', cell(r, 'mold_type'));
+    const structure = formatStructure(cell(r, 'structure'));
+    const note = cell(r, 'note');
+    const weight = parseNumber(cell(r, 'weight'));
+    const price = parseNumber(cell(r, 'price_rmb'));
+
+    molds.push({
+      mold_no: moldNo,
+      name: partName,
+      mold_type: moldType,
+      structure,
+      material,
+      color,
+      cavity,
+      sets: state.sets ?? 1,
+      weight_g: weight,
+      cycle_sec: state.cycle ?? null,
+      price_rmb: price,
+      images: [],
+      detail: {
+        parent_name: groupName,
+        mold_material: moldMaterial,
+        machine,
+        machine_model: machineTonToModel(machine),
+        target: state.target ?? null,
+      },
+      machine,
+      machine_model: machineTonToModel(machine),
+      target: state.target ?? null,
+      note,
+      _rows: [ri, ri],
+    });
+  }
+  return molds;
 }
 
 module.exports = { parseWorkbook };

--- a/apps/业务部/内部报价系统/frontend/workbench.js
+++ b/apps/业务部/内部报价系统/frontend/workbench.js
@@ -389,6 +389,9 @@ function elecRowAmount(r) {
   }
   return num(r.qty) * num(r.unit_price);
 }
+function elecDetailRowCount(parts) {
+  return (parts || []).reduce((a, p) => a + 1 + ((p.children || []).length), 0);
+}
 
 // 电子「含税核价 / 含利润价」逐行重算（与成本汇总 renderElecExtra 同一公式）
 // 含税核价 = (零件成本 + 邦定 + 贴片 + 人工 + 测试 + 包装) ×(1+利润%) + 抵税差额 + 抵税差额×10%
@@ -1766,15 +1769,15 @@ function renderEngineering(host, payload, canEdit, onChange, fxRmbHkd, fxRmbUsd)
       if (!r.ok) throw new Error(j.error || '解析失败');
       preview.innerHTML = `
         <div class="card" style="background:#f0fdf4;border:1px solid #86efac;">
-          <p>从 <b>${escapeHtml(j.sheet_used || '')}</b> 解析到 <b>${j.molds.length}</b> 副模具：</p>
+          <p>从 <b>${escapeHtml(j.sheet_used || '')}</b> 解析到 <b>${j.molds.length}</b> 行明细：</p>
           <table class="wb-table"><thead><tr>
             <th>模号</th><th>名称</th><th>类型</th><th>材质</th>
-            <th>出模数</th><th>套数</th><th>周期(秒)</th><th>模具尺寸</th><th>价格RMB</th><th>备注</th>
+            <th>出模数</th><th>套数</th><th>净重(g)</th><th>周期(秒)</th><th>机型</th><th>目标数</th><th>图片</th><th>模具尺寸</th><th>价格RMB</th><th>备注</th>
           </tr></thead><tbody>
           ${j.molds.map(m => `<tr>
             <td>${escapeHtml(m.mold_no || '')}</td><td>${escapeHtml(m.name || '')}</td><td>${escapeHtml(m.mold_type || '')}</td>
             <td>${escapeHtml(m.material || '')}</td><td>${escapeHtml(m.cavity || '')}</td>
-            <td>${escapeHtml(m.sets ?? '')}</td><td>${escapeHtml(m.cycle_sec ?? '')}</td><td>${escapeHtml((m.detail && m.detail.mold_size) || '')}</td><td>${escapeHtml(m.price_rmb ?? '')}</td><td>${escapeHtml(m.note || '')}</td>
+            <td>${escapeHtml(m.sets ?? '')}</td><td>${escapeHtml(m.weight_g ?? '')}</td><td>${escapeHtml(m.cycle_sec ?? '')}</td><td>${escapeHtml(m.machine_model || '')}</td><td>${escapeHtml(m.target ?? '')}</td><td>${escapeHtml((m.images || []).length)}</td><td>${escapeHtml((m.detail && m.detail.mold_size) || '')}</td><td>${escapeHtml(m.price_rmb ?? '')}</td><td>${escapeHtml(m.note || '')}</td>
           </tr>`).join('')}
           </tbody></table>
           <div style="margin-top:10px">
@@ -1867,6 +1870,9 @@ function renderElectronic(host, payload, canEdit, onChange, fxRmbHkd) {
   payload.electronics_loss_pct = payload.electronics_loss_pct ?? 1;
   payload.electronics_extra = payload.electronics_extra || { test_repair: 0, packing_shipping: 0, profit_pct: 10, tax_diff: 0, tax_payable: 0 };
   ['profit_pct', 'tax_diff', 'tax_payable'].forEach(k => { if (payload.electronics_extra[k] == null) payload.electronics_extra[k] = k === 'profit_pct' ? 10 : 0; });
+  if (payload.electronics_doc && payload.electronics_doc.parts) {
+    payload.electronics_doc.parts_count = elecDetailRowCount(payload.electronics_doc.parts);
+  }
 
   host.innerHTML = `
     <h3>电子部分
@@ -1914,6 +1920,7 @@ function renderElectronic(host, payload, canEdit, onChange, fxRmbHkd) {
             <th style="width:90px">单价 RMB</th>
             <th style="width:90px">合计 RMB</th>
             <th style="width:120px">备注</th>
+            ${canEdit ? '<th style="width:48px"></th>' : ''}
           </tr></thead>
           <tbody id="elec-detail-tbody"></tbody>
         </table>
@@ -1931,7 +1938,8 @@ function renderElectronic(host, payload, canEdit, onChange, fxRmbHkd) {
         <td><input type="number" step="any" value="${num(p.qty)}" data-pi="${i}" data-k="qty" ${ro} style="width:75px"/></td>
         <td><input type="number" step="any" value="${num(p.unit_price)}" data-pi="${i}" data-k="unit_price" ${ro} style="width:85px"/></td>
         <td class="ro">${formatNum(num(p.qty) * num(p.unit_price))}</td>
-        <td><input value="${(p.note || '').replace(/"/g, '&quot;')}" data-pi="${i}" data-k="note" ${ro} /></td>`;
+        <td><input value="${(p.note || '').replace(/"/g, '&quot;')}" data-pi="${i}" data-k="note" ${ro} /></td>
+        ${canEdit ? `<td class="row-actions"><button class="mini danger el-detail-del" type="button" data-pi="${i}" title="删除">×</button></td>` : ''}`;
       if (isChild) tr.style.background = '#f8fafc';
       tbody.appendChild(tr);
     };
@@ -1950,7 +1958,8 @@ function renderElectronic(host, payload, canEdit, onChange, fxRmbHkd) {
           <td><input type="number" step="any" value="${num(c.qty)}" data-pi="${i}" data-ci="${ci}" data-k="qty" ${ro} style="width:75px"/></td>
           <td><input type="number" step="any" value="${num(c.unit_price)}" data-pi="${i}" data-ci="${ci}" data-k="unit_price" ${ro} style="width:85px"/></td>
           <td class="ro">${formatNum(num(c.qty) * num(c.unit_price))}</td>
-          <td><input value="${(c.note || '').replace(/"/g, '&quot;')}" data-pi="${i}" data-ci="${ci}" data-k="note" ${ro} /></td>`;
+          <td><input value="${(c.note || '').replace(/"/g, '&quot;')}" data-pi="${i}" data-ci="${ci}" data-k="note" ${ro} /></td>
+          ${canEdit ? `<td class="row-actions"><button class="mini danger el-detail-del" type="button" data-pi="${i}" data-ci="${ci}" title="删除">×</button></td>` : ''}`;
         tbody.appendChild(tr);
       });
     });
@@ -1983,6 +1992,24 @@ function renderElectronic(host, payload, canEdit, onChange, fxRmbHkd) {
         if (inp.dataset.k === 'qty' || inp.dataset.k === 'unit_price') {
           inp.onchange = () => { if (isDerivedSummary()) renderElectronic(host, payload, canEdit, onChange, fxRmbHkd); };
         }
+      });
+      tbody.querySelectorAll('.el-detail-del').forEach(btn => {
+        btn.onclick = () => {
+          const pi = +btn.dataset.pi;
+          const ci = btn.dataset.ci;
+          const part = doc.parts[pi];
+          if (!part) return;
+          if (ci != null) {
+            part.children.splice(+ci, 1);
+          } else {
+            if ((part.children || []).length && !confirm(`删除「${part.name || '该零件'}」及其子项？`)) return;
+            doc.parts.splice(pi, 1);
+          }
+          doc.parts_count = elecDetailRowCount(doc.parts);
+          autoResummarize();
+          onChange();
+          renderElectronic(host, payload, canEdit, onChange, fxRmbHkd);
+        };
       });
       // 展开折叠状态记忆
       detailHost.querySelector('details').ontoggle = (e) => { doc._open = e.target.open; };
@@ -2052,7 +2079,7 @@ function renderElectronic(host, payload, canEdit, onChange, fxRmbHkd) {
             // 保存原始 parts/extras 供导出
             payload.electronics_doc = {
               parts: j.parts, extras: j.extras, meta: j.meta || {},
-              parts_count: j.count,
+              parts_count: elecDetailRowCount(j.parts || []),
               imported_at: new Date().toISOString().slice(0, 10),
             };
             impPreview.innerHTML = ''; impFile.value = '';
@@ -2196,16 +2223,22 @@ function renderMolding(host, payload, canEdit, onChange, refMolds, fxRmbHkd, use
     payload.injection = refMolds.map(m => ({
       mold_no: m.mold_no || '', name: m.name,
       material: m.material || '',
-      material_grade: '',
+      material_grade: m.material_grade || '',
       color: m.color || '',
       cavity: m.cavity || '',
       weight_g: m.weight_g ?? null,
       cycle_sec: m.cycle_sec ?? null,
       sets: m.sets || 1,
+      machine: m.machine || '',
+      machine_model: m.machine_model || '',
+      target: m.target ?? null,
+      material_unit_price: m.material_unit_price ?? null,
+      shot_price: m.shot_price ?? null,
+      note: m.note || '',
     }));
   }
 
-  const canEditPrices = canEdit && (userRole === 'supervisor' || userRole === 'admin');
+  const canEditPrices = canEdit;
   host.innerHTML = `
     <h3>二、注塑部分 <small>料损耗 %
       <input id="inj-loss" type="number" step="any" style="width:60px" value="${payload.injection_loss_pct ?? 3}" ${canEdit ? '' : 'disabled'} />
@@ -2221,7 +2254,7 @@ function renderMolding(host, payload, canEdit, onChange, refMolds, fxRmbHkd, use
     <div id="wb-blow"></div>
 
     <details class="ref-tables" style="margin-top:18px">
-      <summary class="ref-summary">📋 参考表（料价 / 机型价）${canEditPrices ? ' · 主管可改' : ''}</summary>
+      <summary class="ref-summary">📋 参考表（料价 / 机型价）${canEditPrices ? ' · 本单可改' : ''}</summary>
       ${canEditPrices ? '<div style="margin-top:8px"><button id="btn-pull-refs" class="mini" type="button">🔄 同步全局参考表到本单</button> <small class="muted">用最新的全局参考表覆盖本单</small></div>' : ''}
       <div style="margin-top:10px;display:grid;grid-template-columns:1fr 1fr;gap:16px">
         <div>
@@ -2243,17 +2276,9 @@ function renderMolding(host, payload, canEdit, onChange, refMolds, fxRmbHkd, use
     { key: 'price', label: 'HK$/Lb', type: 'number', width: '100px' },
     { key: 'price_per_g', label: 'HK$/g', readonly: true, calc: r => num(r.price) / 454, width: '100px' },
   ];
-  // 参考表改动：同步到全局 (debounced)
-  let refSaveTimer = null;
-  const saveRefDebounced = (key, data) => {
-    clearTimeout(refSaveTimer);
-    refSaveTimer = setTimeout(() => {
-      api('/refs/' + key, { method: 'PUT', body: JSON.stringify({ data }) }).catch(() => {});
-      window.__refs[key] = JSON.parse(JSON.stringify(data));
-    }, 500);
-  };
-  const onMatChange = () => { onChange(); saveRefDebounced('material_prices', payload.material_prices); };
-  const onMachChange = () => { onChange(); saveRefDebounced('machine_prices', payload.machine_prices); };
+  // 参考表改动仅保存到当前报价单，不反向覆盖全局参考表。
+  const onMatChange = () => { onChange(); };
+  const onMachChange = () => { onChange(); };
   renderTable(host.querySelector('#wb-material-prices'), mpCols, payload.material_prices, { readonly: !canEditPrices, onChange: onMatChange });
 
   // 机型价表
@@ -2293,12 +2318,18 @@ function renderMolding(host, payload, canEdit, onChange, refMolds, fxRmbHkd, use
           mold_no: m.mold_no || existing.mold_no || '',
           name: m.name,
           material: m.material || existing.material || '',
-          material_grade: existing.material_grade || '',
+          material_grade: m.material_grade || existing.material_grade || '',
           color: m.color || existing.color || '',
           cavity: m.cavity || existing.cavity || '',
           weight_g: m.weight_g ?? existing.weight_g ?? null,
           cycle_sec: m.cycle_sec ?? existing.cycle_sec ?? null,
           sets: existing.sets ?? (m.sets || 1),
+          machine: m.machine || existing.machine || '',
+          machine_model: m.machine_model || existing.machine_model || '',
+          target: m.target ?? existing.target ?? null,
+          material_unit_price: m.material_unit_price ?? existing.material_unit_price ?? null,
+          shot_price: m.shot_price ?? existing.shot_price ?? null,
+          note: m.note || existing.note || '',
         };
       });
       onChange(); renderMolding(host, payload, canEdit, onChange, refMolds, fxRmbHkd, userRole);
@@ -2345,8 +2376,21 @@ function renderMolding(host, payload, canEdit, onChange, refMolds, fxRmbHkd, use
     };
   }
 
-  // 颜色判断：Pantone (如 675C / 231C / 7547C) 或含 色/白/黑/灰 等
-  const isColorToken = (s) => /^\d{2,4}[A-Z]{1,2}$/.test(s) || /色|白|黑|灰|红|蓝|绿|黄|紫|棕|金|银/.test(s);
+  // 颜色判断：Pantone (如 675C / 231C / 7547C) 或含 色/白/黑/灰 等。
+  // 注意不要把 ABS 750SW、PP 7032 E3 这类料型号误判成颜色。
+  const isColorToken = (s) => {
+    const t = String(s || '').replace(/\s+/g, '').toUpperCase();
+    return /^(?:PANTONE)?\d{2,4}(?:C|U|TCX|TPX)$/.test(t) || /色|白|黑|灰|红|蓝|绿|黄|紫|棕|金|银/.test(String(s || ''));
+  };
+  const isMaterialGrade = (material, model) => {
+    const mat = String(material || '').replace(/\s+/g, '').toUpperCase();
+    const mod = String(model || '').replace(/\s+/g, '').toUpperCase();
+    if (!mat || !mod) return false;
+    return (payload.material_prices || []).some(p =>
+      String(p.name || '').replace(/\s+/g, '').toUpperCase() === mat &&
+      String(p.model || '').replace(/\s+/g, '').toUpperCase() === mod
+    );
+  };
 
   // 旧数据迁移：material_color → material / material_grade / color
   (payload.injection || []).forEach(r => {
@@ -2361,7 +2405,8 @@ function renderMolding(host, payload, canEdit, onChange, refMolds, fxRmbHkd, use
         else { r.material_grade = parts.slice(1).join(' '); r.color = ''; }
       } else if (parts.length === 2) {
         r.material = parts[0];
-        if (isColorToken(parts[1])) r.color = parts[1];
+        if (isMaterialGrade(r.material, parts[1])) r.material_grade = parts[1];
+        else if (isColorToken(parts[1])) r.color = parts[1];
         else r.material_grade = parts[1];
       } else if (parts.length === 1) {
         r.material = parts[0];
@@ -2371,6 +2416,11 @@ function renderMolding(host, payload, canEdit, onChange, refMolds, fxRmbHkd, use
     if (r.material_grade && !r.color && isColorToken(r.material_grade)) {
       r.color = r.material_grade;
       r.material_grade = '';
+    }
+    // 修正旧数据：曾经会把 ABS 750SW 这类料型号误塞到 color。
+    if (!r.material_grade && r.color && isMaterialGrade(r.material, r.color)) {
+      r.material_grade = r.color;
+      r.color = '';
     }
   });
 


### PR DESCRIPTION
Summary:
- Improve internal quote mold-sheet import so part-detail rows, machine/target fields, weights, and image row assignments stay aligned.
- Keep material/machine reference price edits scoped to the current quote while allowing normal editors to adjust them.
- Add delete controls for imported electronic detail rows and preserve mold fields when syncing into molding.

Tests:
- node --check apps/业务部/内部报价系统/frontend/workbench.js
- node --check apps/业务部/内部报价系统/backend/services/parseMoldSheet.js
- node --check apps/业务部/内部报价系统/backend/routes/quotes.js
- Smoke parsed 造模申请表-深圳雨禾伟业.xlsx: 23 rows, 23 images assigned to 23 rows.

Note: VQ-related local changes were intentionally excluded.