### PR TITLE
Fix shipping portal route refresh

### DIFF
--- a/frontend/index.cloud.html
+++ b/frontend/index.cloud.html
@@ -953,7 +953,7 @@
       </div>
       <div class="detail-plugin-right">
         <div class="detail-plugin-status"><div class="plugin-dot gray" id="shippingManagementDetailDot"></div> 检查中...</div>
-        <a href="/shipping/" target="_blank" class="btn btn-primary">打开系统</a>
+        <a href="/shipping/" target="_blank" rel="noopener" class="btn btn-primary">打开系统</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- touch the deployed portal HTML for the shipping entry so the deploy script treats frontend as changed
- this forces the nginx container to be recreated, refreshing file-level bind mounts from PR #231 after the earlier deploy timed out before nginx/frontend refresh

## Verification
- git diff --check
- confirmed #232 deploy rebuilt shipping-management only and left nginx/frontend unchanged
- live smoke before this fix still returned 401 for /shipping/health because the running nginx config had not refreshed