### PR TITLE
Force install shipping history seed when live data is sparse

### DIFF
--- a/deploy/install-shipping-history-seed.sh
+++ b/deploy/install-shipping-history-seed.sh
@@ -13,13 +13,30 @@ MARKER="${APP_DIR}/data/.history_seeded"
 
 cd "$INSTALL_DIR"
 
+count_shipments() {
+  local db_path="$1"
+  if [[ ! -f "$db_path" ]]; then
+    echo 0
+    return 0
+  fi
+
+  SHIPPING_COUNT_DB="$db_path" python3 -c '
+import os
+import sqlite3
+
+db_path = os.environ["SHIPPING_COUNT_DB"]
+try:
+    con = sqlite3.connect(db_path)
+    rows = con.execute("select count(*) from shipments_shipment").fetchone()[0]
+    con.close()
+    print(rows)
+except Exception:
+    print(0)
+'
+}
+
 if [[ ! -f "$SEED_BLOB" ]]; then
   echo "[shipping-history] encrypted seed not present; skipping."
-  exit 0
-fi
-
-if [[ -f "$MARKER" ]]; then
-  echo "[shipping-history] marker exists; history already imported."
   exit 0
 fi
 
@@ -63,36 +80,54 @@ if integrity != "ok" or shipments <= 0 or items <= 0:
     sys.exit(1)
 '
 
+seed_shipments=$(SEED_CHECK_DB="${tmp_dir}/history.sqlite3" python3 -c '
+import os
+import sqlite3
+
+con = sqlite3.connect(os.environ["SEED_CHECK_DB"])
+rows = con.execute("select count(*) from shipments_shipment").fetchone()[0]
+con.close()
+print(rows)
+')
+
 mv "${tmp_dir}/history.sqlite3" "$TARGET_DB"
 chmod 666 "$TARGET_DB"
 echo "[shipping-history] seed installed at $TARGET_DB"
+
+current_shipments="$(count_shipments "$SHIPPING_DB")"
+if [[ -f "$MARKER" ]] && [[ "${current_shipments:-0}" -ge "$seed_shipments" ]]; then
+  echo "[shipping-history] marker exists and shipping.db already has shipments=$current_shipments; skipping replace."
+  exit 0
+fi
+
+if [[ "${current_shipments:-0}" -lt "$seed_shipments" ]]; then
+  if [[ -f "$SHIPPING_DB" ]]; then
+    backup="${SHIPPING_DB}.pre-history-seed.$(date +%Y%m%d-%H%M%S)"
+    cp "$SHIPPING_DB" "$backup"
+    echo "[shipping-history] backed up existing shipping.db (shipments=$current_shipments) to $backup"
+  fi
+
+  cp "$TARGET_DB" "$SHIPPING_DB"
+  chmod 666 "$SHIPPING_DB"
+  printf 'seed_db=%s\nseed_shipments=%s\ninstalled_at=%s\n' \
+    "$TARGET_DB" "$seed_shipments" "$(date -Iseconds)" > "$MARKER"
+  echo "[shipping-history] replaced shipping.db with history seed (shipments=$seed_shipments)"
+else
+  echo "[shipping-history] shipping.db has shipments=$current_shipments, seed has shipments=$seed_shipments; leaving existing db in place."
+fi
 
 echo "[shipping-history] recreating shipping-management to trigger import..."
 docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" up -d --no-deps --force-recreate shipping-management
 
 for _ in $(seq 1 30); do
-  if [[ -f "$SHIPPING_DB" ]]; then
-    rows=$(SHIPPING_DB="$SHIPPING_DB" python3 -c '
-import os
-import sqlite3
-
-db_path = os.environ["SHIPPING_DB"]
-try:
-    con = sqlite3.connect(db_path)
-    rows = con.execute("select count(*) from shipments_shipment").fetchone()[0]
-    con.close()
-    print(rows)
-except Exception:
-    print(0)
-')
-    if [[ "${rows:-0}" -gt 0 ]]; then
-      echo "[shipping-history] import visible in shipping.db: shipments=$rows"
-      exit 0
-    fi
+  rows="$(count_shipments "$SHIPPING_DB")"
+  if [[ "${rows:-0}" -ge "$seed_shipments" ]]; then
+    echo "[shipping-history] history visible in shipping.db: shipments=$rows"
+    exit 0
   fi
   sleep 2
 done
 
-echo "[shipping-history][FAIL] history rows did not appear in shipping.db after restart." >&2
+echo "[shipping-history][FAIL] shipping.db did not reach seed shipment count ($seed_shipments) after restart." >&2
 docker logs rr-portal-shipping-management-1 --tail 120 2>&1 || true
 exit 1


### PR DESCRIPTION
## Summary
- update the shipping history seed installer to compare the live DB count against the encrypted seed count
- back up and replace sparse live `shipping.db` files when the encrypted seed contains more historical shipments
- wait for the live DB to reach the seed shipment count instead of accepting any non-zero count

## Context
The first encrypted seed deploy decrypted the seed correctly (`shipments=1416`) but the existing live DB had 5 rows, so the app-level non-empty guard skipped import. This fix treats that sparse DB as an empty shell, backs it up, and installs the full history seed.

## Tests
- `bash -n deploy/install-shipping-history-seed.sh`