### PR TITLE
Fix shipping large data list performance

### DIFF
--- a/apps/船务部/船务管理系统/backend/apps/emails/serializers.py
+++ b/apps/船务部/船务管理系统/backend/apps/emails/serializers.py
@@ -8,6 +8,26 @@ class EmailRecordSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 
+class EmailRecordListSerializer(serializers.ModelSerializer):
+    parsed_items_count = serializers.SerializerMethodField()
+
+    class Meta:
+        model = EmailRecord
+        fields = [
+            'id',
+            'subject',
+            'sender',
+            'received_at',
+            'status',
+            'created_at',
+            'parsed_items_count',
+        ]
+
+    def get_parsed_items_count(self, obj):
+        parsed = obj.parsed_data or {}
+        return len(parsed.get('packing_list_items') or [])
+
+
 class MailboxConfigSerializer(serializers.Serializer):
     email = serializers.EmailField()
     password = serializers.CharField(write_only=True)

--- a/apps/船务部/船务管理系统/backend/apps/emails/views.py
+++ b/apps/船务部/船务管理系统/backend/apps/emails/views.py
@@ -22,13 +22,14 @@ from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeou
 from django.conf import settings
 from rest_framework import status
 from rest_framework.decorators import api_view, parser_classes, permission_classes
+from rest_framework.pagination import PageNumberPagination
 from rest_framework.parsers import MultiPartParser
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.generics import ListAPIView
 
 from .models import EmailRecord
-from .serializers import EmailRecordSerializer
+from .serializers import EmailRecordListSerializer, EmailRecordSerializer
 from .parsers.eml_parser import parse_eml_file
 from .parsers.body_parser import (
     parse_email_body, _normalize_date, _adjust_sunday,
@@ -2305,16 +2306,25 @@ def import_email(request):
             os.unlink(tmp_path)
 
 
+class EmailRecordPagination(PageNumberPagination):
+    page_size = 50
+    page_size_query_param = 'page_size'
+    max_page_size = 200
+
+
 class EmailRecordListView(ListAPIView):
     queryset = EmailRecord.objects.all().order_by('-created_at')
-    serializer_class = EmailRecordSerializer
+    serializer_class = EmailRecordListSerializer
+    pagination_class = EmailRecordPagination
 
 
-@api_view(['DELETE'])
+@api_view(['GET', 'DELETE'])
 def delete_email(request, pk):
     """删除邮件记录。"""
     try:
         record = EmailRecord.objects.get(pk=pk)
+        if request.method == 'GET':
+            return Response(EmailRecordSerializer(record).data)
         record.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
     except EmailRecord.DoesNotExist:

--- a/apps/船务部/船务管理系统/backend/apps/shipments/serializers.py
+++ b/apps/船务部/船务管理系统/backend/apps/shipments/serializers.py
@@ -1,3 +1,5 @@
+from decimal import Decimal, InvalidOperation
+
 from rest_framework import serializers
 from .models import Shipment, ShipmentItem, ShipmentSubItem
 
@@ -25,6 +27,50 @@ class ShipmentSerializer(serializers.ModelSerializer):
     class Meta:
         model = Shipment
         fields = '__all__'
+
+
+class ShipmentListSerializer(serializers.ModelSerializer):
+    items_count = serializers.IntegerField(read_only=True)
+    total_cbm = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Shipment
+        fields = [
+            'id',
+            'shipment_type',
+            'status',
+            'customer',
+            'si_deadline',
+            'so_number',
+            'cutoff_date',
+            'container_type',
+            'port',
+            'ship_date',
+            'container_number',
+            'seal_number',
+            'container_weight',
+            'main_factory',
+            'customs_broker',
+            'delivery_address',
+            'special_requirements',
+            'remarks',
+            'warehouse',
+            'customs_cutoff',
+            'source_email_id',
+            'created_by',
+            'created_at',
+            'items_count',
+            'total_cbm',
+        ]
+
+    def get_total_cbm(self, obj):
+        value = getattr(obj, 'total_cbm', None)
+        if value in (None, ''):
+            return '0.000'
+        try:
+            return f'{Decimal(value):.3f}'
+        except (InvalidOperation, TypeError, ValueError):
+            return '0.000'
 
 
 class ShipmentItemCreateSerializer(serializers.ModelSerializer):

--- a/apps/船务部/船务管理系统/backend/apps/shipments/views.py
+++ b/apps/船务部/船务管理系统/backend/apps/shipments/views.py
@@ -1,6 +1,7 @@
 from django.db import models as db_models
 from rest_framework import viewsets, status as http_status
 from rest_framework.decorators import api_view, permission_classes
+from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from apps.emails.models import EmailRecord
@@ -9,6 +10,7 @@ from apps.master_data.brand_rules import get_brand_for_product_code
 from .calculations import calculate_total_pieces_per_order
 from .models import Shipment, ShipmentItem, ShipmentSubItem
 from .serializers import (
+    ShipmentListSerializer,
     ShipmentSerializer,
     ShipmentCreateSerializer,
     ShipmentItemSerializer,
@@ -16,12 +18,63 @@ from .serializers import (
 )
 
 
+class ShipmentPagination(PageNumberPagination):
+    page_size = 50
+    page_size_query_param = 'page_size'
+    max_page_size = 200
+
+
 class ShipmentViewSet(viewsets.ModelViewSet):
-    queryset = Shipment.objects.prefetch_related('items', 'items__sub_items').all()
+    queryset = Shipment.objects.all()
+    pagination_class = ShipmentPagination
+
+    def get_queryset(self):
+        if self.action == 'list':
+            queryset = (
+                Shipment.objects
+                .select_related('customer', 'created_by')
+                .annotate(
+                    items_count=db_models.Count('items', distinct=True),
+                    total_cbm=db_models.Sum('items__volume'),
+                )
+                .order_by('-created_at')
+            )
+            params = self.request.query_params
+            so = (params.get('so') or '').strip()
+            port = (params.get('port') or '').strip()
+            country = (params.get('country') or '').strip()
+            container_type = (
+                params.get('container_type')
+                or params.get('containerType')
+                or ''
+            ).strip()
+            status_value = (params.get('status') or '').strip()
+            date_from = (params.get('date_from') or '').strip()
+            date_to = (params.get('date_to') or '').strip()
+
+            if so:
+                queryset = queryset.filter(so_number__icontains=so)
+            if port:
+                queryset = queryset.filter(port__icontains=port)
+            if country:
+                queryset = queryset.filter(delivery_address__icontains=country)
+            if container_type:
+                queryset = queryset.filter(container_type__icontains=container_type)
+            if status_value:
+                queryset = queryset.filter(status=status_value)
+            if date_from:
+                queryset = queryset.filter(created_at__date__gte=date_from)
+            if date_to:
+                queryset = queryset.filter(created_at__date__lte=date_to)
+            return queryset
+
+        return Shipment.objects.prefetch_related('items', 'items__sub_items').all()
 
     def get_serializer_class(self):
         if self.action in ('create', 'update', 'partial_update'):
             return ShipmentCreateSerializer
+        if self.action == 'list':
+            return ShipmentListSerializer
         return ShipmentSerializer
 
     def perform_create(self, serializer):

--- a/apps/船务部/船务管理系统/backend/tests/test_large_list_api.py
+++ b/apps/船务部/船务管理系统/backend/tests/test_large_list_api.py
@@ -1,0 +1,98 @@
+from decimal import Decimal
+
+from django.utils import timezone
+from rest_framework.test import APITestCase
+
+from apps.accounts.models import User
+from apps.emails.models import EmailRecord
+from apps.master_data.models import Customer
+from apps.shipments.models import Shipment, ShipmentItem
+
+
+class LargeListApiTest(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="supervisor",
+            password="testpass123",
+            role="supervisor",
+        )
+        self.customer = Customer.objects.create(name="ZURU")
+        self.client.force_authenticate(self.user)
+
+    def _create_shipment(self, idx):
+        shipment = Shipment.objects.create(
+            shipment_type=Shipment.ShipmentType.NORMAL,
+            customer=self.customer,
+            so_number=f"SO-{idx:03d}",
+            container_type="40HQ",
+            port="YANTIAN",
+            delivery_address="US",
+            created_by=self.user,
+        )
+        for item_idx in range(2):
+            ShipmentItem.objects.create(
+                shipment=shipment,
+                seq_number=item_idx + 1,
+                product_code=f"SKU-{idx}-{item_idx}",
+                pieces=10,
+                volume=Decimal("1.5000"),
+            )
+        return shipment
+
+    def test_shipment_list_is_paginated_and_omits_nested_items(self):
+        shipment = self._create_shipment(1)
+        self._create_shipment(2)
+        self._create_shipment(3)
+
+        response = self.client.get("/api/shipments/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["count"], 3)
+        self.assertIn("results", response.data)
+
+        row = response.data["results"][0]
+        self.assertNotIn("items", row)
+        self.assertEqual(row["items_count"], 2)
+        self.assertEqual(row["total_cbm"], "3.000")
+
+        detail_response = self.client.get(f"/api/shipments/{shipment.id}/")
+
+        self.assertEqual(detail_response.status_code, 200)
+        self.assertIn("items", detail_response.data)
+        self.assertEqual(len(detail_response.data["items"]), 2)
+
+    def test_email_list_is_paginated_and_detail_keeps_full_payload(self):
+        email = EmailRecord.objects.create(
+            subject="SO test",
+            sender="shipping@example.com",
+            received_at=timezone.now(),
+            body_text="large body" * 1000,
+            parsed_data={"packing_list_items": [{"product_code": "SKU-1"}]},
+            attachments=[{"filename": "pl.xlsx", "path": "/tmp/pl.xlsx"}],
+            status=EmailRecord.Status.PARSED,
+        )
+        EmailRecord.objects.create(
+            subject="SO other",
+            sender="shipping@example.com",
+            body_text="large body" * 1000,
+            parsed_data={"packing_list_items": [{"product_code": "SKU-2"}]},
+            status=EmailRecord.Status.PARSED,
+        )
+
+        response = self.client.get("/api/emails/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["count"], 2)
+        row = response.data["results"][0]
+        self.assertNotIn("body_text", row)
+        self.assertNotIn("parsed_data", row)
+        self.assertEqual(row["parsed_items_count"], 1)
+
+        detail_response = self.client.get(f"/api/emails/{email.id}/")
+
+        self.assertEqual(detail_response.status_code, 200)
+        self.assertIn("body_text", detail_response.data)
+        self.assertEqual(
+            detail_response.data["parsed_data"]["packing_list_items"][0]["product_code"],
+            "SKU-1",
+        )

--- a/apps/船务部/船务管理系统/frontend/src/api/emails.js
+++ b/apps/船务部/船务管理系统/frontend/src/api/emails.js
@@ -31,9 +31,14 @@ export async function importEmail(uploadFile) {
   return data
 }
 
-export async function listEmails() {
-  const { data } = await api.get('/emails/')
-  return data.results || data
+export async function listEmails(params = {}) {
+  const { data } = await api.get('/emails/', { params })
+  return data
+}
+
+export async function getEmail(id) {
+  const { data } = await api.get(`/emails/${id}/`)
+  return data
 }
 
 export async function deleteEmail(id) {

--- a/apps/船务部/船务管理系统/frontend/src/api/shipments.js
+++ b/apps/船务部/船务管理系统/frontend/src/api/shipments.js
@@ -5,9 +5,9 @@ export async function createShipmentFromEmail(emailRecordId, parsedData) {
   return data
 }
 
-export async function listShipments() {
-  const { data } = await api.get('/shipments/')
-  return data.results || data
+export async function listShipments(params = {}) {
+  const { data } = await api.get('/shipments/', { params })
+  return data
 }
 
 export async function getShipment(id) {

--- a/apps/船务部/船务管理系统/frontend/src/views/shipping/EmailImport.vue
+++ b/apps/船务部/船务管理系统/frontend/src/views/shipping/EmailImport.vue
@@ -130,7 +130,7 @@
           <el-icon style="vertical-align: middle; margin-right: 4px;">
             <ArrowRight v-if="!showRecords" /><ArrowDown v-else />
           </el-icon>
-          解析记录 ({{ emailRecords.length }})
+          解析记录 ({{ emailPagination.total }})
         </span>
         <el-button size="small" @click.stop="loadRecords" :loading="loadingRecords">刷新</el-button>
       </div>
@@ -146,7 +146,7 @@
           </el-table-column>
           <el-table-column label="PL项数" width="70">
             <template #default="{ row }">
-              {{ row.parsed_data?.packing_list_items?.length || 0 }}
+              {{ row.parsed_items_count ?? (row.parsed_data?.packing_list_items?.length || 0) }}
             </template>
           </el-table-column>
           <el-table-column label="时间" width="150">
@@ -160,6 +160,19 @@
             </template>
           </el-table-column>
         </el-table>
+        <div class="email-pagination">
+          <el-pagination
+            v-model:current-page="emailPagination.page"
+            v-model:page-size="emailPagination.pageSize"
+            :page-sizes="[20, 50, 100, 200]"
+            :total="emailPagination.total"
+            layout="total, sizes, prev, pager, next"
+            small
+            background
+            @size-change="handleEmailPageSizeChange"
+            @current-change="loadRecords"
+          />
+        </div>
       </div>
     </el-card>
 
@@ -313,9 +326,9 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, computed, onMounted, reactive, watch } from 'vue'
 import { useRouter } from 'vue-router'
-import { importEmail, listEmails, getMailboxConfig, saveMailboxConfigApi, searchMailboxApi, importMailboxApi } from '../../api/emails'
+import { importEmail, listEmails, getEmail, getMailboxConfig, saveMailboxConfigApi, searchMailboxApi, importMailboxApi } from '../../api/emails'
 import { createShipmentFromEmail } from '../../api/shipments'
 import { ElMessage } from 'element-plus'
 import AiParseReviewPanel from '../../components/AiParseReviewPanel.vue'
@@ -383,11 +396,21 @@ function clearParsed() {
 const emailRecords = ref([])
 const loadingRecords = ref(false)
 const showRecords = ref(false)
+const emailPagination = reactive({
+  page: 1,
+  pageSize: 50,
+  total: 0,
+})
 
 async function loadRecords() {
   loadingRecords.value = true
   try {
-    emailRecords.value = await listEmails()
+    const data = await listEmails({
+      page: emailPagination.page,
+      page_size: emailPagination.pageSize,
+    })
+    emailRecords.value = data.results || data
+    emailPagination.total = data.count ?? emailRecords.value.length
   } catch (e) {
     console.error(e)
   } finally {
@@ -395,12 +418,29 @@ async function loadRecords() {
   }
 }
 
-function viewRecord(row) {
+function handleEmailPageSizeChange() {
+  emailPagination.page = 1
+  loadRecords()
+}
+
+async function viewRecord(row) {
   // 点击记录直接预览解析结果
+  let record = row
+  if (!record.parsed_data) {
+    loadingRecords.value = true
+    try {
+      record = await getEmail(row.id)
+    } catch (e) {
+      ElMessage.error('加载解析记录失败')
+      return
+    } finally {
+      loadingRecords.value = false
+    }
+  }
   parsedResults.value = [{
-    email_record_id: row.id,
-    subject: row.subject,
-    parsed: row.parsed_data,
+    email_record_id: record.id,
+    subject: record.subject,
+    parsed: record.parsed_data,
   }]
   selectedGroupIdx.value = 0
   saveParsed()
@@ -819,3 +859,11 @@ async function confirmCreate() {
   }
 }
 </script>
+
+<style scoped>
+.email-pagination {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 12px;
+}
+</style>

--- a/apps/船务部/船务管理系统/frontend/src/views/shipping/ShipmentList.vue
+++ b/apps/船务部/船务管理系统/frontend/src/views/shipping/ShipmentList.vue
@@ -27,8 +27,8 @@
           value-format="YYYY-MM-DD" />
         <el-input v-model="filters.cbm" placeholder="CBM" clearable size="small" style="width:90px" />
         <el-button size="small" @click="resetFilters">重置</el-button>
-        <span v-if="filteredRecords.length" style="color:#909399;font-size:13px;margin-left:4px">
-          共 {{ filteredRecords.length }} 条
+        <span v-if="pagination.total" style="color:#909399;font-size:13px;margin-left:4px">
+          共 {{ pagination.total }} 条
         </span>
       </div>
 
@@ -78,7 +78,7 @@
         </el-table-column>
         <el-table-column label="PL项数" width="65" align="center">
           <template #default="{ row }">
-            <el-badge v-if="row.items?.length" :value="row.items.length" type="primary" />
+            <el-badge v-if="row.items_count || row.items?.length" :value="row.items_count || row.items.length" type="primary" />
             <span v-else>0</span>
           </template>
         </el-table-column>
@@ -112,6 +112,20 @@
           </template>
         </el-table-column>
       </el-table>
+
+      <div class="pagination-bar">
+        <el-pagination
+          v-model:current-page="pagination.page"
+          v-model:page-size="pagination.pageSize"
+          :page-sizes="[20, 50, 100, 200]"
+          :total="pagination.total"
+          layout="total, sizes, prev, pager, next"
+          small
+          background
+          @size-change="handlePageSizeChange"
+          @current-change="loadData"
+        />
+      </div>
 
       <!-- 批量操作 -->
       <div v-if="selectedRows.length" class="batch-bar">
@@ -221,7 +235,7 @@
 </template>
 
 <script setup>
-import { ref, computed, reactive, onMounted } from 'vue'
+import { ref, computed, reactive, onMounted, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { listShipments, getShipment, deleteShipment, updateShipmentItem } from '../../api/shipments'
 import { ElMessage, ElMessageBox } from 'element-plus'
@@ -234,6 +248,11 @@ const loading = ref(false)
 const showDetail = ref(false)
 const selected = ref(null)
 const selectedRows = ref([])
+const pagination = reactive({
+  page: 1,
+  pageSize: 50,
+  total: 0,
+})
 
 // 体积编辑
 const showVolume = ref(false)
@@ -289,6 +308,7 @@ function resetFilters() {
     so: '', port: '', country: '', containerType: '', status: '', dateRange: null,
     cbm: '',
   })
+  pagination.page = 1
 }
 
 function handleSelectionChange(rows) { selectedRows.value = rows }
@@ -299,15 +319,31 @@ function formatDatetime(val) {
 }
 
 function calcCbm(row) {
-  const items = row.items || []
-  const sum = items.reduce((acc, item) => acc + (parseFloat(item.volume) || 0), 0)
+  if (row.items) {
+    const sum = row.items.reduce((acc, item) => acc + (parseFloat(item.volume) || 0), 0)
+    return sum > 0 ? sum.toFixed(3) : '-'
+  }
+  const sum = parseFloat(row.total_cbm)
   return sum > 0 ? sum.toFixed(3) : '-'
 }
 
 async function loadData() {
   loading.value = true
   try {
-    records.value = await listShipments()
+    const params = {
+      page: pagination.page,
+      page_size: pagination.pageSize,
+      so: filters.so || undefined,
+      port: filters.port || undefined,
+      country: filters.country || undefined,
+      container_type: filters.containerType || undefined,
+      status: filters.status || undefined,
+      date_from: filters.dateRange?.[0] || undefined,
+      date_to: filters.dateRange?.[1] || undefined,
+    }
+    const data = await listShipments(params)
+    records.value = data.results || data
+    pagination.total = data.count ?? records.value.length
   } catch {
     ElMessage.error('加载数据失败')
   } finally {
@@ -315,9 +351,30 @@ async function loadData() {
   }
 }
 
-function viewDetail(row) {
-  selected.value = row
-  showDetail.value = true
+function handlePageSizeChange() {
+  pagination.page = 1
+  loadData()
+}
+
+let filterTimer = null
+watch(filters, () => {
+  clearTimeout(filterTimer)
+  filterTimer = setTimeout(() => {
+    pagination.page = 1
+    loadData()
+  }, 300)
+}, { deep: true })
+
+async function viewDetail(row) {
+  loading.value = true
+  try {
+    selected.value = await getShipment(row.id)
+    showDetail.value = true
+  } catch {
+    ElMessage.error('加载详情失败')
+  } finally {
+    loading.value = false
+  }
 }
 
 async function openVolume(row) {
@@ -448,6 +505,12 @@ onMounted(loadData)
   background: #fef9f0;
   border-radius: 4px;
   border: 1px solid #faecd8;
+}
+
+.pagination-bar {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 12px;
 }
 
 .batch-hint { color: #e6a23c; font-size: 13px; }


### PR DESCRIPTION
## Summary
- paginate shipping shipment and email history list APIs
- return lightweight shipment/email rows for list pages, loading full details on demand
- add backend regression tests for paginated lightweight list responses

## Verification
- python -m pytest tests -q (116 passed)
- npm run build