### PR TITLE
Fix shipping review save rate limit

### DIFF
--- a/apps/船务部/船务管理系统/backend/apps/shipments/urls.py
+++ b/apps/船务部/船务管理系统/backend/apps/shipments/urls.py
@@ -30,6 +30,7 @@ urlpatterns = [
     path('items/<int:item_pk>/sub-items/', views.ShipmentSubItemViewSet.as_view({'get': 'list', 'post': 'create'})),
     path('items/<int:item_pk>/sub-items/<int:pk>/', views.ShipmentSubItemViewSet.as_view({'get': 'retrieve', 'put': 'update', 'patch': 'partial_update', 'delete': 'destroy'})),
     path('<int:shipment_pk>/items/', views.ShipmentItemViewSet.as_view({'get': 'list', 'post': 'create'})),
+    path('<int:shipment_pk>/items/bulk-update/', views.bulk_update_items, name='bulk-update-items'),
     path('<int:shipment_pk>/items/<int:pk>/', views.ShipmentItemViewSet.as_view({'get': 'retrieve', 'put': 'update', 'patch': 'partial_update', 'delete': 'destroy'})),
     path('', include(router.urls)),
 ]

--- a/apps/船务部/船务管理系统/backend/apps/shipments/views.py
+++ b/apps/船务部/船务管理系统/backend/apps/shipments/views.py
@@ -1,4 +1,4 @@
-from django.db import models as db_models
+from django.db import models as db_models, transaction
 from rest_framework import viewsets, status as http_status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.pagination import PageNumberPagination
@@ -89,6 +89,88 @@ class ShipmentItemViewSet(viewsets.ModelViewSet):
 
     def perform_create(self, serializer):
         serializer.save(shipment_id=self.kwargs['shipment_pk'])
+
+
+@api_view(['PATCH'])
+@permission_classes([IsAuthenticated])
+def bulk_update_items(request, shipment_pk):
+    """Update many existing shipment items in one request.
+
+    The cabinet-review page can contain dozens of rows. Sending one PATCH per
+    row in parallel trips the nginx API rate limit, so this endpoint keeps a
+    single user save as a single API request.
+    """
+    items_data = request.data.get('items')
+    if not isinstance(items_data, list):
+        return Response(
+            {'detail': 'items must be a list'},
+            status=http_status.HTTP_400_BAD_REQUEST,
+        )
+    if not items_data:
+        return Response({'updated': 0, 'items': []})
+
+    item_ids = []
+    seen_ids = set()
+    for index, item_data in enumerate(items_data, start=1):
+        if not isinstance(item_data, dict):
+            return Response(
+                {'detail': f'items[{index}] must be an object'},
+                status=http_status.HTTP_400_BAD_REQUEST,
+            )
+        item_id = item_data.get('id')
+        if not item_id:
+            return Response(
+                {'detail': f'items[{index}].id is required'},
+                status=http_status.HTTP_400_BAD_REQUEST,
+            )
+        try:
+            item_id = int(item_id)
+        except (TypeError, ValueError):
+            return Response(
+                {'detail': f'items[{index}].id must be an integer'},
+                status=http_status.HTTP_400_BAD_REQUEST,
+            )
+        if item_id in seen_ids:
+            return Response(
+                {'detail': f'duplicate item id: {item_id}'},
+                status=http_status.HTTP_400_BAD_REQUEST,
+            )
+        seen_ids.add(item_id)
+        item_ids.append(item_id)
+
+    existing = {
+        item.id: item
+        for item in ShipmentItem.objects.filter(
+            shipment_id=shipment_pk,
+            id__in=item_ids,
+        )
+    }
+    missing_ids = [item_id for item_id in item_ids if item_id not in existing]
+    if missing_ids:
+        return Response(
+            {'detail': 'some items do not belong to this shipment', 'ids': missing_ids},
+            status=http_status.HTTP_400_BAD_REQUEST,
+        )
+
+    updated_items = []
+    with transaction.atomic():
+        for item_data in items_data:
+            item_id = int(item_data['id'])
+            payload = dict(item_data)
+            payload.pop('id', None)
+            payload.pop('shipment', None)
+            serializer = ShipmentItemSerializer(
+                existing[item_id],
+                data=payload,
+                partial=True,
+            )
+            serializer.is_valid(raise_exception=True)
+            updated_items.append(serializer.save())
+
+    return Response({
+        'updated': len(updated_items),
+        'items': ShipmentItemSerializer(updated_items, many=True).data,
+    })
 
 
 @api_view(['POST'])

--- a/apps/船务部/船务管理系统/backend/tests/test_large_list_api.py
+++ b/apps/船务部/船务管理系统/backend/tests/test_large_list_api.py
@@ -96,3 +96,67 @@ class LargeListApiTest(APITestCase):
             detail_response.data["parsed_data"]["packing_list_items"][0]["product_code"],
             "SKU-1",
         )
+
+    def test_bulk_update_shipment_items_saves_large_review_without_many_requests(self):
+        shipment = self._create_shipment(1)
+        ShipmentItem.objects.all().delete()
+        items = [
+            ShipmentItem.objects.create(
+                shipment=shipment,
+                seq_number=idx + 1,
+                product_code=f"SKU-{idx:02d}",
+                pieces=1,
+                volume=Decimal("0.1000"),
+            )
+            for idx in range(75)
+        ]
+
+        payload = {
+            "items": [
+                {
+                    "id": item.id,
+                    "product_code": item.product_code,
+                    "contract_number": f"4500{idx:04d}",
+                    "customer_po": f"PO-{idx:04d}",
+                    "quantity": idx + 10,
+                    "pieces": idx + 1,
+                    "pallet_count": idx % 5,
+                    "volume": "0.3050",
+                    "factory_remark": "兴信",
+                    "spec": "52",
+                    "box_dimensions": "10x20x30",
+                }
+                for idx, item in enumerate(items)
+            ]
+        }
+
+        response = self.client.patch(
+            f"/api/shipments/{shipment.id}/items/bulk-update/",
+            payload,
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["updated"], 75)
+        first = ShipmentItem.objects.get(id=items[0].id)
+        last = ShipmentItem.objects.get(id=items[-1].id)
+        self.assertEqual(first.contract_number, "45000000")
+        self.assertEqual(first.quantity, 10)
+        self.assertEqual(first.volume, Decimal("0.3050"))
+        self.assertEqual(last.contract_number, "45000074")
+        self.assertEqual(last.pieces, 75)
+
+    def test_bulk_update_rejects_item_from_another_shipment(self):
+        shipment = self._create_shipment(1)
+        other = self._create_shipment(2)
+        foreign_item = other.items.first()
+
+        response = self.client.patch(
+            f"/api/shipments/{shipment.id}/items/bulk-update/",
+            {"items": [{"id": foreign_item.id, "pieces": 99}]},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        foreign_item.refresh_from_db()
+        self.assertNotEqual(foreign_item.pieces, 99)

--- a/apps/船务部/船务管理系统/frontend/src/api/shipments.js
+++ b/apps/船务部/船务管理系统/frontend/src/api/shipments.js
@@ -49,6 +49,11 @@ export async function updateShipmentItem(shipmentId, itemId, payload) {
   return data
 }
 
+export async function bulkUpdateShipmentItems(shipmentId, items) {
+  const { data } = await api.patch(`/shipments/${shipmentId}/items/bulk-update/`, { items })
+  return data
+}
+
 export async function deleteShipmentItem(shipmentId, itemId) {
   await api.delete(`/shipments/${shipmentId}/items/${itemId}/`)
 }

--- a/apps/船务部/船务管理系统/frontend/src/views/shipping/ContainerSheetReview.vue
+++ b/apps/船务部/船务管理系统/frontend/src/views/shipping/ContainerSheetReview.vue
@@ -166,7 +166,7 @@ import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import api from '../../api/auth'
 import { apiPath } from '../../api/request'
-import { updateShipment, updateShipmentItem, deleteShipmentItem } from '../../api/shipments'
+import { updateShipment, bulkUpdateShipmentItems, deleteShipmentItem } from '../../api/shipments'
 import { ElMessage } from 'element-plus'
 import { Download } from '@element-plus/icons-vue'
 
@@ -311,8 +311,8 @@ async function doSave() {
   const itemsToSave = form.value.items.filter(it => it.id && it.id > 0)
   console.log('[doSave] items to save:', itemsToSave.map(it => it.id))
   if (itemsToSave.length) {
-    await Promise.all(itemsToSave.map(it =>
-      updateShipmentItem(shipmentId, it.id, {
+    await bulkUpdateShipmentItems(shipmentId, itemsToSave.map(it => ({
+        id: it.id,
         product_code: it.product_code,
         contract_number: it.contract_number,
         customer_po: it.customer_po,
@@ -323,8 +323,7 @@ async function doSave() {
         factory_remark: it.factory_remark || '',
         spec: it.spec || '',
         box_dimensions: it.box_dimensions || '',
-      })
-    ))
+      })))
   }
 }
 


### PR DESCRIPTION
## Summary
- add a bulk shipment item update endpoint for cabinet review saves
- switch the review page from many parallel item PATCH requests to one bulk PATCH
- cover large 75-row saves and cross-shipment rejection with regression tests

## Verification
- python -m pytest tests/test_large_list_api.py -q
- python -m pytest -q
- npm run build