### PR TITLE
录入页按贴纸和PCBA分开

### DIFF
--- a/apps/PMC跟仓管/加工管理/pcba/static/app.html
+++ b/apps/PMC跟仓管/加工管理/pcba/static/app.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>唱片机管理系统</title>
-<link rel="stylesheet" href="/static/style.css?v=16">
+<link rel="stylesheet" href="/static/style.css?v=17">
 </head>
 <body class="app-page">
 <header class="app-header">
@@ -57,11 +57,12 @@
     </div>
 
     <div id="entryTypeTabs" class="entry-type-tabs"></div>
+    <div id="entryMaterialTabs" class="entry-type-tabs material-tabs"></div>
 
     <div class="form-grid">
       <select id="recType" style="display:none"></select>
       <select id="locationId"></select>
-      <select id="material" title="物料名称" onchange="onMaterialChange()"></select>
+      <select id="material" title="物料名称" style="display:none" onchange="onMaterialChange()"></select>
       <select id="supplier" title="供应商" style="display:none"></select>
       <input id="recDate" type="date" title="日期">
       <input id="docNo" placeholder="单据编号">
@@ -240,6 +241,6 @@
   </section>
 </main>
 
-<script src="/static/app.js?v=17"></script>
+<script src="/static/app.js?v=18"></script>
 </body>
 </html>

--- a/apps/PMC跟仓管/加工管理/pcba/static/app.js
+++ b/apps/PMC跟仓管/加工管理/pcba/static/app.js
@@ -31,6 +31,7 @@ let ME = null;
 let RECORDS = [];
 let ENTRY_TYPE_OPTIONS = [];
 let ACTIVE_ENTRY_TYPE = '';
+let ACTIVE_ENTRY_MATERIAL = '';
 let DEPARTMENTS = [];
 let SUPPLIERS = [];
 let MATERIALS = [];
@@ -167,6 +168,38 @@ function setEntryType(type) {
   renderRecordsTable();
 }
 
+function entryMaterialOptions() {
+  const preferred = [NFC_MATERIAL, PCBA_MATERIAL];
+  const byName = new Map(MATERIALS.map(m => [m.name, m]));
+  const ordered = preferred
+    .filter(name => byName.has(name))
+    .map(name => byName.get(name));
+  MATERIALS.forEach(m => {
+    if (!preferred.includes(m.name)) ordered.push(m);
+  });
+  return ordered;
+}
+
+function renderEntryMaterialTabs() {
+  const tabs = el('entryMaterialTabs');
+  if (!tabs) return;
+  const materials = entryMaterialOptions();
+  tabs.innerHTML = materials.map(mat => {
+    const active = mat.name === ACTIVE_ENTRY_MATERIAL ? ' active' : '';
+    return `<button type="button" class="entry-type-tab${active}" onclick="setEntryMaterial('${esc(mat.name)}')">${esc(mat.name)}</button>`;
+  }).join('');
+}
+
+function setEntryMaterial(material) {
+  if (!entryMaterialOptions().some(mat => mat.name === material)) return;
+  if (editingId && ACTIVE_ENTRY_MATERIAL !== material) cancelEdit();
+  ACTIVE_ENTRY_MATERIAL = material;
+  el('material').value = material;
+  onMaterialChange();
+  renderEntryMaterialTabs();
+  renderRecordsTable();
+}
+
 async function api(path, opts) {
   const r = await fetch(appPath(path), opts);
   if (r.status === 401) {
@@ -279,6 +312,11 @@ async function loadMaterials() {
   el('material').innerHTML = mats
     .map(m => `<option value="${esc(m.name)}">${esc(m.name)}</option>`)
     .join('');
+  if (!mats.some(m => m.name === ACTIVE_ENTRY_MATERIAL)) {
+    ACTIVE_ENTRY_MATERIAL = mats[0] ? mats[0].name : '';
+  }
+  el('material').value = ACTIVE_ENTRY_MATERIAL;
+  renderEntryMaterialTabs();
 
   const form = el('materialForm');
   if (form) form.style.display = '';
@@ -624,6 +662,10 @@ function startEdit(id) {
     ACTIVE_ENTRY_TYPE = rec.rec_type;
     renderEntryTypeTabs();
   }
+  if (entryMaterialOptions().some(mat => mat.name === rec.material)) {
+    ACTIVE_ENTRY_MATERIAL = rec.material;
+    renderEntryMaterialTabs();
+  }
   el('recType').value = rec.rec_type;
   onTypeChange();
   if (rec.location_id) el('locationId').value = rec.location_id;
@@ -674,7 +716,10 @@ function renderRecordsTable() {
   renderRecordHeader();
   const tb = document.querySelector('#recTable tbody');
   const emptyColspan = 10 + (isXingxin() ? 1 : 0) + (supportsPoCustomer() ? 2 : 0);
-  const visibleRecords = RECORDS.filter(x => !ACTIVE_ENTRY_TYPE || x.rec_type === ACTIVE_ENTRY_TYPE);
+  const visibleRecords = RECORDS.filter(x =>
+    (!ACTIVE_ENTRY_TYPE || x.rec_type === ACTIVE_ENTRY_TYPE) &&
+    (!ACTIVE_ENTRY_MATERIAL || x.material === ACTIVE_ENTRY_MATERIAL)
+  );
   tb.innerHTML = visibleRecords.map(x => {
     const canEdit = ME.role === 'admin' || x.created_by === ME.id;
     const ops = canEdit

--- a/apps/PMC跟仓管/加工管理/pcba/static/style.css
+++ b/apps/PMC跟仓管/加工管理/pcba/static/style.css
@@ -604,6 +604,11 @@ tr.subtotal {
   background: rgba(241, 245, 249, 0.78);
 }
 
+.entry-type-tabs.material-tabs {
+  margin-top: -6px;
+  background: rgba(255, 255, 255, 0.72);
+}
+
 .entry-type-tab {
   min-height: 38px;
   padding: 0 18px;

--- a/apps/PMC跟仓管/加工管理/tests/test_static_entry_subpages.py
+++ b/apps/PMC跟仓管/加工管理/tests/test_static_entry_subpages.py
@@ -8,13 +8,18 @@ def test_entry_page_exposes_type_subpage_container():
     html = (ROOT / "pcba/static/app.html").read_text(encoding="utf-8")
 
     assert 'id="entryTypeTabs"' in html
+    assert 'id="entryMaterialTabs"' in html
     assert 'id="recType" style="display:none"' in html
+    assert 'id="material" title="物料名称" style="display:none"' in html
 
 
 def test_entry_records_are_filtered_by_active_type():
     js = (ROOT / "pcba/static/app.js").read_text(encoding="utf-8")
 
     assert "let ACTIVE_ENTRY_TYPE" in js
+    assert "let ACTIVE_ENTRY_MATERIAL" in js
     assert "function setEntryType(type)" in js
+    assert "function setEntryMaterial(material)" in js
     assert "function renderRecordsTable()" in js
     assert "x.rec_type === ACTIVE_ENTRY_TYPE" in js
+    assert "x.material === ACTIVE_ENTRY_MATERIAL" in js


### PR DESCRIPTION
## 变更内容
- 录入页在业务类型下面新增物料页签：NFC贴纸 / 77794-PCBA板
- NFC贴纸页签显示贴纸多选数量区；PCBA页签显示普通数量输入
- 流水表按业务类型和当前物料页签分别展示，避免贴纸和PCBA混在一起

## 验证
- node --check pcba/static/app.js
- python -m pytest tests/test_static_entry_subpages.py -q
- python -m pytest -q