### PR TITLE
Fix internal quote assembly import grouping

### DIFF
--- a/apps/业务部/内部报价系统/backend/services/parseAssemblySheet.js
+++ b/apps/业务部/内部报价系统/backend/services/parseAssemblySheet.js
@@ -1,4 +1,4 @@
-// 解析"产品生产排拉工序表"型 xlsx → 返回 { steps: [{ name, count }] }
+// 解析"产品生产排拉工序表"型 xlsx → 返回 { groups, steps }
 // 文件常见结构：序号1 / 工序名称 / 工具 / 人数 / 物料规格 / 重点工位注意事项
 //             序号2 / 工序名称 / 工具 / 人数 / 物料规格 / 重点工位注意事项
 const ExcelJS = require('exceljs');
@@ -23,15 +23,30 @@ function isHeaderRow(values) {
   return /工序名称/.test(j) && /人数/.test(j);
 }
 
+function cleanGroupName(header) {
+  const s = toStr(header).replace(/工序名称/g, '').trim();
+  return s || '排拉工序';
+}
+
+function isPackagingGroup(name) {
+  return /包装|混装|入箱|装箱|彩盒|外箱|吸塑/.test(toStr(name));
+}
+
 // 找出表头里所有 "工序名称" 和 "人数" 的列位置（可能有 2 套）
 function indexHeader(values) {
-  const cols = []; // [{ nameCol, countCol }]
+  const cols = []; // [{ nameCol, countCol, noteCol, title }]
   let lastName = null;
   values.forEach((v, i) => {
     const s = toStr(v);
-    if (s.includes('工序名称')) lastName = i;
+    if (s.includes('工序名称')) lastName = { col: i, title: cleanGroupName(s) };
     else if (s.includes('人数') && lastName != null) {
-      cols.push({ nameCol: lastName, countCol: i });
+      cols.push({
+        nameCol: lastName.col,
+        countCol: i,
+        noteCol: i + 2,
+        title: lastName.title,
+        kind: isPackagingGroup(lastName.title) ? 'packaging' : 'assembly',
+      });
       lastName = null;
     }
   });
@@ -50,13 +65,11 @@ function sheetjsToRows(sheet) {
 
 async function parseWorkbook(buffer) {
   let sheets = [];
-  let usedExceljs = false;
   // 尝试 .xlsx（ExcelJS）
   try {
     const wb = new ExcelJS.Workbook();
     await wb.xlsx.load(buffer);
     if (wb.worksheets && wb.worksheets.length) {
-      usedExceljs = true;
       for (const ws of wb.worksheets) {
         const tmp = [];
         ws.eachRow({ includeEmpty: true }, (row) => {
@@ -90,8 +103,9 @@ async function parseWorkbook(buffer) {
   const ws = { name: pickedSheet.name };
   const rows = pickedSheet.rows;
 
-  let cols = null;
+  let activeGroups = null;
   let meta = {};
+  const groups = [];
   const steps = [];
 
   for (let i = 0; i < rows.length; i++) {
@@ -106,27 +120,53 @@ async function parseWorkbook(buffer) {
     const m5 = text.match(/人数[：:]?\s*(\d{1,3})\s*人/); if (m5) meta.total_people = Number(m5[1]);
     const m6 = text.match(/时间[：:]?\s*(\d{1,2})\s*[Hh小时]/); if (m6) meta.work_hours = Number(m6[1]);
 
-    if (!cols) {
-      if (isHeaderRow(r)) cols = indexHeader(r);
+    if (isHeaderRow(r)) {
+      activeGroups = indexHeader(r).map((c) => {
+        const group = {
+          product: c.title,
+          name: c.title,
+          kind: c.kind,
+          qty: Number(meta.target_qty) || 1,
+          steps: [],
+          _cols: c,
+        };
+        groups.push(group);
+        return group;
+      });
       continue;
     }
 
+    if (!activeGroups || !activeGroups.length) continue;
+
     // 数据行：遍历每组 (nameCol, countCol)
-    for (const { nameCol, countCol } of cols) {
+    for (const group of activeGroups) {
+      const { nameCol, countCol, noteCol } = group._cols;
       const name = toStr(r[nameCol]);
       const count = toNum(r[countCol]);
+      const sideLabel = toStr(r[countCol - 1]);
+      if (/产能/.test(sideLabel) && count != null && count > 0) {
+        group.qty = count;
+        continue;
+      }
+      if (/合计/.test(sideLabel)) continue;
       if (!name) continue;
       if (/序号|工序名称|^生产拉线$/.test(name)) continue;
+      if (/产品生产排拉工序表|产品图片|客名|货名|货号|目标数/.test(name)) continue;
       // 跳过说明/表头类行（非工序），如「功能及要求事项描述:」「注意事项」等
       if (/功能.*要求.*事项|要求事项描述|功能及要求|注意事项|^备注|^说明|描述[：:]\s*$/.test(name)) continue;
       // 工序必须有人数(>0)；人数 0/空 多为说明行或空行
       if (count == null || count <= 0) continue;
-      steps.push({ name, count });
+      const step = { name, count, note: toStr(r[noteCol]) };
+      group.steps.push(step);
+      steps.push(step);
     }
   }
 
   if (!steps.length) return { error: '未解析到任何工序行（请确认表头含 工序名称 / 人数）' };
-  return { meta, steps, count: steps.length, sheet_used: ws.name };
+  const nonEmptyGroups = groups
+    .filter(g => (g.steps || []).length)
+    .map(({ _cols, ...g }) => g);
+  return { meta, groups: nonEmptyGroups, steps, count: steps.length, group_count: nonEmptyGroups.length, sheet_used: ws.name };
 }
 
 module.exports = { parseWorkbook };

--- a/apps/业务部/内部报价系统/frontend/workbench.js
+++ b/apps/业务部/内部报价系统/frontend/workbench.js
@@ -2946,6 +2946,42 @@ function renderAssembly(host, payload, canEdit, onChange, fxRmbHkd) {
   };
   renderGroups();
 
+  const buildImportedStepGroups = (j, fallbackKind = 'assembly') => {
+    const m = j.meta || {};
+    const rawGroups = Array.isArray(j.groups) && j.groups.length
+      ? j.groups
+      : [{
+          product: m.quote_no ? `货号 ${m.quote_no}` : '排拉工序',
+          name: m.quote_no ? `货号 ${m.quote_no}` : '排拉工序',
+          kind: fallbackKind,
+          qty: Number(m.target_qty) || 1,
+          steps: j.steps || [],
+        }];
+    return rawGroups.map(g => ({
+      product: g.product || g.name || '排拉工序',
+      kind: g.kind === 'packaging' ? 'packaging' : 'assembly',
+      qty: Number(g.qty || m.target_qty) || 1,
+      team: Number(g.team) || 1,
+      steps: (g.steps || []).map(s => ({ name: s.name, count: s.count, note: s.note || '' })),
+    })).filter(g => g.steps.length);
+  };
+
+  const addImportedStepGroups = (j) => {
+    const groups = buildImportedStepGroups(j);
+    const asmGroups = groups.filter(g => g.kind !== 'packaging');
+    const pkgGroups = groups.filter(g => g.kind === 'packaging');
+    payload.assembly_step_groups.push(...asmGroups.map(({ kind, ...g }) => g));
+    payload.packaging_step_groups.push(...pkgGroups.map(({ kind, ...g }) => g));
+  };
+
+  const importGroupSummary = (j) => {
+    const groups = buildImportedStepGroups(j);
+    const asmGroups = groups.filter(g => g.kind !== 'packaging');
+    const pkgGroups = groups.filter(g => g.kind === 'packaging');
+    const rows = groups.map(g => `<li>${g.kind === 'packaging' ? '包装/混装' : '组装'}：${escapeHtml(g.product)}（${g.steps.length} 个工序，生产量 ${formatNum(g.qty)}）</li>`).join('');
+    return { asmGroups, pkgGroups, rows };
+  };
+
   if (canEdit) {
     host.querySelector('#asm-rate').oninput = (e) => { payload.assembly_base_rate = Number(e.target.value) || 0; onChange(); renderGroups(); };
     host.querySelector('#asm-time').oninput = (e) => { payload.assembly_std_time = Number(e.target.value) || 0; onChange(); renderGroups(); };
@@ -2965,27 +3001,21 @@ function renderAssembly(host, payload, canEdit, onChange, fxRmbHkd) {
         const j = await r.json();
         if (!r.ok) throw new Error(j.error || '解析失败');
         const m = j.meta || {};
+        const info = importGroupSummary(j);
         impPreview.innerHTML = `
           <div class="card" style="background:#f0fdf4;border:1px solid #86efac;margin-top:10px">
-            <p>解析到 <b>${j.count}</b> 个工序<br>
+            <p>解析到 <b>${j.group_count || (info.asmGroups.length + info.pkgGroups.length) || 1}</b> 个分组、<b>${j.count}</b> 个工序<br>
             ${m.customer ? `客名: ${escapeHtml(m.customer)} · ` : ''}${m.quote_no ? `货号: ${escapeHtml(m.quote_no)} · ` : ''}${m.target_qty ? `目标数: ${escapeHtml(m.target_qty)}` : ''}</p>
+            <ul style="margin:8px 0 0 18px">${info.rows}</ul>
             <div style="margin-top:10px;display:flex;gap:8px;align-items:center">
-              <label>归到产品组：
-                <input id="asm-imp-name" type="text" value="${escapeHtml(m.customer ? '货号 ' + (m.quote_no || '') : '排拉工序')}" style="width:200px"/>
-              </label>
-              <button id="asm-imp-add">作为新组添加</button>
+              <button id="asm-imp-add">按识别分组导入</button>
               <button id="asm-imp-cancel" class="mini danger">取消</button>
             </div>
           </div>`;
         impPreview.querySelector('#asm-imp-add').onclick = () => {
-          const grpName = impPreview.querySelector('#asm-imp-name').value.trim() || '排拉工序';
-          payload.assembly_step_groups.push({
-            product: grpName,
-            qty: Number(m.target_qty) || 1,
-            steps: j.steps.map(s => ({ name: s.name, count: s.count, note: '' })),
-          });
+          addImportedStepGroups(j);
           impPreview.innerHTML = ''; impFile.value = '';
-          onChange(); renderGroups();
+          onChange(); renderGroups(); renderPkgGroups();
         };
         impPreview.querySelector('#asm-imp-cancel').onclick = () => { impPreview.innerHTML = ''; impFile.value = ''; };
       } catch (err) {
@@ -3087,24 +3117,21 @@ function renderAssembly(host, payload, canEdit, onChange, fxRmbHkd) {
         const j = await r.json();
         if (!r.ok) throw new Error(j.error || '解析失败');
         const m = j.meta || {};
+        const info = importGroupSummary(j);
         impPreview.innerHTML = `
           <div class="card" style="background:#f0fdf4;border:1px solid #86efac;margin-top:10px">
-            <p>解析到 <b>${j.count}</b> 个工序<br>
+            <p>解析到 <b>${j.group_count || (info.asmGroups.length + info.pkgGroups.length) || 1}</b> 个分组、<b>${j.count}</b> 个工序<br>
             ${m.customer ? `客名: ${escapeHtml(m.customer)} · ` : ''}${m.quote_no ? `货号: ${escapeHtml(m.quote_no)} · ` : ''}${m.target_qty ? `目标数: ${escapeHtml(m.target_qty)}` : ''}</p>
+            <ul style="margin:8px 0 0 18px">${info.rows}</ul>
             <div style="margin-top:10px;display:flex;gap:8px;align-items:center">
-              <label>归到产品组：<input id="pkg-imp-name" type="text" value="${escapeHtml(m.quote_no ? '货号 ' + m.quote_no : '排拉工序')}" style="width:200px"/></label>
-              <button id="pkg-imp-add">作为新组添加</button>
+              <button id="pkg-imp-add">按识别分组导入</button>
               <button id="pkg-imp-cancel" class="mini danger">取消</button>
             </div>
           </div>`;
         impPreview.querySelector('#pkg-imp-add').onclick = () => {
-          const grpName = impPreview.querySelector('#pkg-imp-name').value.trim() || '排拉工序';
-          payload.packaging_step_groups.push({
-            product: grpName, qty: Number(m.target_qty) || 1,
-            steps: j.steps.map(s => ({ name: s.name, count: s.count, note: '' })),
-          });
+          addImportedStepGroups(j);
           impPreview.innerHTML = ''; impFile.value = '';
-          onChange(); renderPkgGroups();
+          onChange(); renderGroups(); renderPkgGroups();
         };
         impPreview.querySelector('#pkg-imp-cancel').onclick = () => { impPreview.innerHTML = ''; impFile.value = ''; };
       } catch (err) {

--- a/apps/业务部/内部报价系统/frontend/workbench.js
+++ b/apps/业务部/内部报价系统/frontend/workbench.js
@@ -2966,16 +2966,16 @@ function renderAssembly(host, payload, canEdit, onChange, fxRmbHkd) {
     })).filter(g => g.steps.length);
   };
 
-  const addImportedStepGroups = (j) => {
-    const groups = buildImportedStepGroups(j);
+  const addImportedStepGroups = (j, fallbackKind = 'assembly') => {
+    const groups = buildImportedStepGroups(j, fallbackKind);
     const asmGroups = groups.filter(g => g.kind !== 'packaging');
     const pkgGroups = groups.filter(g => g.kind === 'packaging');
     payload.assembly_step_groups.push(...asmGroups.map(({ kind, ...g }) => g));
     payload.packaging_step_groups.push(...pkgGroups.map(({ kind, ...g }) => g));
   };
 
-  const importGroupSummary = (j) => {
-    const groups = buildImportedStepGroups(j);
+  const importGroupSummary = (j, fallbackKind = 'assembly') => {
+    const groups = buildImportedStepGroups(j, fallbackKind);
     const asmGroups = groups.filter(g => g.kind !== 'packaging');
     const pkgGroups = groups.filter(g => g.kind === 'packaging');
     const rows = groups.map(g => `<li>${g.kind === 'packaging' ? '包装/混装' : '组装'}：${escapeHtml(g.product)}（${g.steps.length} 个工序，生产量 ${formatNum(g.qty)}）</li>`).join('');
@@ -3117,7 +3117,7 @@ function renderAssembly(host, payload, canEdit, onChange, fxRmbHkd) {
         const j = await r.json();
         if (!r.ok) throw new Error(j.error || '解析失败');
         const m = j.meta || {};
-        const info = importGroupSummary(j);
+        const info = importGroupSummary(j, 'packaging');
         impPreview.innerHTML = `
           <div class="card" style="background:#f0fdf4;border:1px solid #86efac;margin-top:10px">
             <p>解析到 <b>${j.group_count || (info.asmGroups.length + info.pkgGroups.length) || 1}</b> 个分组、<b>${j.count}</b> 个工序<br>
@@ -3129,7 +3129,7 @@ function renderAssembly(host, payload, canEdit, onChange, fxRmbHkd) {
             </div>
           </div>`;
         impPreview.querySelector('#pkg-imp-add').onclick = () => {
-          addImportedStepGroups(j);
+          addImportedStepGroups(j, 'packaging');
           impPreview.innerHTML = ''; impFile.value = '';
           onChange(); renderGroups(); renderPkgGroups();
         };

--- a/apps/业务部/内部报价系统/tests/workbench-assembly-import.test.js
+++ b/apps/业务部/内部报价系统/tests/workbench-assembly-import.test.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const workbenchPath = path.join(__dirname, '..', 'frontend', 'workbench.js');
+const source = fs.readFileSync(workbenchPath, 'utf8');
+
+test('packaging assembly import keeps the packaging fallback kind', () => {
+  assert.match(source, /const\s+addImportedStepGroups\s*=\s*\(j,\s*fallbackKind\s*=\s*'assembly'\)\s*=>\s*{/);
+  assert.match(source, /const\s+importGroupSummary\s*=\s*\(j,\s*fallbackKind\s*=\s*'assembly'\)\s*=>\s*{/);
+
+  const fallbackBuildCalls = source.match(/buildImportedStepGroups\(j,\s*fallbackKind\)/g) || [];
+  assert.equal(fallbackBuildCalls.length, 2);
+
+  assert.match(source, /const\s+info\s*=\s*importGroupSummary\(j,\s*'packaging'\);/);
+  assert.match(source, /addImportedStepGroups\(j,\s*'packaging'\);/);
+});


### PR DESCRIPTION
## Summary
- Parse assembly process sheets into separate step groups from each process-name/person-count header pair.
- Classify packaging groups separately from assembly groups and import them into the matching UI section.
- Use each group's capacity row as the imported production quantity.

## Checks
- node --check apps/业务部/内部报价系统/backend/services/parseAssemblySheet.js
- node --check apps/业务部/内部报价系统/frontend/workbench.js
- Parsed 水豚妈妈-装配工序表.xlsx into 4 groups with quantities 5000, 4000, 10000, and 5000.