### PR TITLE
Fix internal quote default material price upgrade

### DIFF
--- a/apps/业务部/内部报价系统/backend/db/index.js
+++ b/apps/业务部/内部报价系统/backend/db/index.js
@@ -3,6 +3,7 @@ const { DatabaseSync } = require('node:sqlite');
 const path = require('path');
 const fs = require('fs');
 const bcrypt = require('bcryptjs');
+const { refSeedUpgrades, appendMissingRefDefaults } = require('./ref-defaults');
 
 const DB_PATH = process.env.DB_FILE || path.join(__dirname, '..', 'data.db');
 const SCHEMA_PATH = path.join(__dirname, 'schema.sql');
@@ -126,6 +127,12 @@ for (const [key, data] of Object.entries(refSeeds)) {
   if (!exists) {
     db.prepare('INSERT INTO ref_tables (key, data_json, updated_by) VALUES (?, ?, ?)').run(key, JSON.stringify(data), '[seed]');
     console.log('[seed] 全局参考表 ' + key + ' 已种入 ' + data.length + ' 条');
+  }
+}
+for (const [key, data] of Object.entries(refSeedUpgrades)) {
+  const added = appendMissingRefDefaults(db, key, data);
+  if (added > 0) {
+    console.log('[seed-upgrade] global ref table ' + key + ' appended ' + added + ' default item(s)');
   }
 }
 

--- a/apps/业务部/内部报价系统/backend/db/ref-defaults.js
+++ b/apps/业务部/内部报价系统/backend/db/ref-defaults.js
@@ -1,0 +1,63 @@
+const refSeedUpgrades = {
+  material_prices: [
+    { name: 'ABS', model: '抽粒料', price: 4.60 },
+  ],
+};
+
+function normalizeRefValue(value) {
+  return String(value ?? '').trim().toLowerCase();
+}
+
+function refItemKey(tableKey, item) {
+  if (tableKey === 'material_prices') {
+    return `${normalizeRefValue(item.name)}\u0000${normalizeRefValue(item.model)}`;
+  }
+  if (tableKey === 'machine_prices') {
+    return `${normalizeRefValue(item.model)}`;
+  }
+  return JSON.stringify(item);
+}
+
+function mergeMissingRefDefaults(existing, defaults, tableKey = 'material_prices') {
+  const rows = Array.isArray(existing) ? existing.slice() : [];
+  const seen = new Set(rows.map((item) => refItemKey(tableKey, item)));
+  for (const item of defaults || []) {
+    const key = refItemKey(tableKey, item);
+    if (!seen.has(key)) {
+      rows.push({ ...item });
+      seen.add(key);
+    }
+  }
+  return rows;
+}
+
+function parseRefRows(raw) {
+  try {
+    const rows = JSON.parse(raw || '[]');
+    return Array.isArray(rows) ? rows : [];
+  } catch {
+    return [];
+  }
+}
+
+function appendMissingRefDefaults(db, tableKey, defaults) {
+  const row = db.prepare('SELECT data_json FROM ref_tables WHERE key = ?').get(tableKey);
+  if (!row) return 0;
+  const existing = parseRefRows(row.data_json);
+  const merged = mergeMissingRefDefaults(existing, defaults, tableKey);
+  const added = merged.length - existing.length;
+  if (added > 0) {
+    db.prepare(`
+      UPDATE ref_tables
+      SET data_json = ?, updated_at = datetime('now'), updated_by = ?
+      WHERE key = ?
+    `).run(JSON.stringify(merged), '[seed-upgrade]', tableKey);
+  }
+  return added;
+}
+
+module.exports = {
+  refSeedUpgrades,
+  mergeMissingRefDefaults,
+  appendMissingRefDefaults,
+};

--- a/apps/业务部/内部报价系统/tests/ref-defaults.test.js
+++ b/apps/业务部/内部报价系统/tests/ref-defaults.test.js
@@ -1,0 +1,36 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { mergeMissingRefDefaults } = require('../backend/db/ref-defaults');
+
+test('mergeMissingRefDefaults appends missing material defaults without replacing existing rows', () => {
+  const existing = [
+    { name: 'ABS', model: '750SW', price: 8.8 },
+    { name: 'C-ABS', model: 'TR558/920', price: 12.5 },
+  ];
+  const defaults = [
+    { name: 'ABS', model: '750SW', price: 8.5 },
+    { name: 'ABS', model: '抽粒料', price: 4.6 },
+  ];
+
+  const merged = mergeMissingRefDefaults(existing, defaults);
+
+  assert.deepEqual(merged, [
+    { name: 'ABS', model: '750SW', price: 8.8 },
+    { name: 'C-ABS', model: 'TR558/920', price: 12.5 },
+    { name: 'ABS', model: '抽粒料', price: 4.6 },
+  ]);
+});
+
+test('mergeMissingRefDefaults is idempotent', () => {
+  const existing = [
+    { name: 'ABS', model: '750SW', price: 8.5 },
+    { name: 'ABS', model: '抽粒料', price: 4.6 },
+  ];
+  const defaults = [
+    { name: 'ABS', model: '750SW', price: 8.5 },
+    { name: 'ABS', model: '抽粒料', price: 4.6 },
+  ];
+
+  assert.deepEqual(mergeMissingRefDefaults(existing, defaults), existing);
+});


### PR DESCRIPTION
## Summary
- Add a seed-upgrade guard for internal quote reference tables so existing production material_prices rows receive new default entries
- Append ABS / 抽粒料 / 4.60 only when the same name+model is missing, without overwriting user-edited prices
- Add node:test coverage for idempotent default merging

## Tests
- node --test apps/业务部/内部报价系统/tests/ref-defaults.test.js
- node --check apps/业务部/内部报价系统/backend/db/index.js
- node --check apps/业务部/内部报价系统/backend/db/ref-defaults.js
- node --check apps/业务部/内部报价系统/frontend/workbench.js
- git diff --check