### PR TITLE
Fix ABS default price in existing quotes

### DIFF
--- a/apps/业务部/内部报价系统/backend/db/index.js
+++ b/apps/业务部/内部报价系统/backend/db/index.js
@@ -3,7 +3,11 @@ const { DatabaseSync } = require('node:sqlite');
 const path = require('path');
 const fs = require('fs');
 const bcrypt = require('bcryptjs');
-const { refSeedUpgrades, appendMissingRefDefaults } = require('./ref-defaults');
+const {
+  appendMissingRefDefaults,
+  appendMissingRefDefaultsToSectionPayloads,
+  refSeedUpgrades,
+} = require('./ref-defaults');
 
 const DB_PATH = process.env.DB_FILE || path.join(__dirname, '..', 'data.db');
 const SCHEMA_PATH = path.join(__dirname, 'schema.sql');
@@ -133,6 +137,13 @@ for (const [key, data] of Object.entries(refSeedUpgrades)) {
   const added = appendMissingRefDefaults(db, key, data);
   if (added > 0) {
     console.log('[seed-upgrade] global ref table ' + key + ' appended ' + added + ' default item(s)');
+  }
+  if (key === 'material_prices') {
+    const sectionAdded = appendMissingRefDefaultsToSectionPayloads(db, 'molding', key, data);
+    if (sectionAdded.itemsAdded > 0) {
+      console.log('[seed-upgrade] molding quote payload ' + key + ' appended '
+        + sectionAdded.itemsAdded + ' default item(s) in ' + sectionAdded.rowsChanged + ' section(s)');
+    }
   }
 }
 

--- a/apps/业务部/内部报价系统/backend/db/ref-defaults.js
+++ b/apps/业务部/内部报价系统/backend/db/ref-defaults.js
@@ -56,7 +56,41 @@ function appendMissingRefDefaults(db, tableKey, defaults) {
   return added;
 }
 
+function parseSectionPayload(raw) {
+  try {
+    const payload = JSON.parse(raw || '{}');
+    return payload && typeof payload === 'object' && !Array.isArray(payload) ? payload : {};
+  } catch {
+    return {};
+  }
+}
+
+function appendMissingRefDefaultsToSectionPayloads(db, dept, tableKey, defaults) {
+  const rows = db.prepare('SELECT id, payload_json FROM quote_sections WHERE dept = ?').all(dept);
+  const update = db.prepare('UPDATE quote_sections SET payload_json = ? WHERE id = ?');
+  let rowsChanged = 0;
+  let itemsAdded = 0;
+
+  for (const row of rows) {
+    const payload = parseSectionPayload(row.payload_json);
+    const existing = payload[tableKey];
+    if (!Array.isArray(existing) || existing.length === 0) continue;
+
+    const merged = mergeMissingRefDefaults(existing, defaults, tableKey);
+    const added = merged.length - existing.length;
+    if (added > 0) {
+      payload[tableKey] = merged;
+      update.run(JSON.stringify(payload), row.id);
+      rowsChanged += 1;
+      itemsAdded += added;
+    }
+  }
+
+  return { rowsChanged, itemsAdded };
+}
+
 module.exports = {
+  appendMissingRefDefaultsToSectionPayloads,
   refSeedUpgrades,
   mergeMissingRefDefaults,
   appendMissingRefDefaults,

--- a/apps/业务部/内部报价系统/tests/ref-defaults.test.js
+++ b/apps/业务部/内部报价系统/tests/ref-defaults.test.js
@@ -1,7 +1,13 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const { DatabaseSync } = require('node:sqlite');
 
-const { mergeMissingRefDefaults } = require('../backend/db/ref-defaults');
+const {
+  appendMissingRefDefaultsToSectionPayloads,
+  mergeMissingRefDefaults,
+} = require('../backend/db/ref-defaults');
+
+const recycledAbsModel = '\u62bd\u7c92\u6599';
 
 test('mergeMissingRefDefaults appends missing material defaults without replacing existing rows', () => {
   const existing = [
@@ -33,4 +39,49 @@ test('mergeMissingRefDefaults is idempotent', () => {
   ];
 
   assert.deepEqual(mergeMissingRefDefaults(existing, defaults), existing);
+});
+
+test('appendMissingRefDefaultsToSectionPayloads upgrades existing molding quote payload copies', () => {
+  const db = new DatabaseSync(':memory:');
+  db.exec(`
+    CREATE TABLE quote_sections (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      dept TEXT NOT NULL,
+      payload_json TEXT NOT NULL DEFAULT '{}'
+    )
+  `);
+
+  const oldMoldingPayload = {
+    material_prices: [
+      { name: 'ABS', model: '750SW', price: 8.8 },
+      { name: 'C-ABS', model: 'TR558/920', price: 12.5 },
+    ],
+    machine_prices: [{ model: '4A-6A', price: 940 }],
+  };
+  const otherDeptPayload = {
+    material_prices: [
+      { name: 'ABS', model: '750SW', price: 8.5 },
+    ],
+  };
+
+  db.prepare('INSERT INTO quote_sections (dept, payload_json) VALUES (?, ?)').run('molding', JSON.stringify(oldMoldingPayload));
+  db.prepare('INSERT INTO quote_sections (dept, payload_json) VALUES (?, ?)').run('sales', JSON.stringify(otherDeptPayload));
+
+  const result = appendMissingRefDefaultsToSectionPayloads(db, 'molding', 'material_prices', [
+    { name: 'ABS', model: '750SW', price: 8.5 },
+    { name: 'ABS', model: recycledAbsModel, price: 4.6 },
+  ]);
+
+  assert.deepEqual(result, { rowsChanged: 1, itemsAdded: 1 });
+
+  const molding = JSON.parse(db.prepare("SELECT payload_json FROM quote_sections WHERE dept = 'molding'").get().payload_json);
+  assert.deepEqual(molding.material_prices, [
+    { name: 'ABS', model: '750SW', price: 8.8 },
+    { name: 'C-ABS', model: 'TR558/920', price: 12.5 },
+    { name: 'ABS', model: recycledAbsModel, price: 4.6 },
+  ]);
+  assert.deepEqual(molding.machine_prices, oldMoldingPayload.machine_prices);
+
+  const sales = JSON.parse(db.prepare("SELECT payload_json FROM quote_sections WHERE dept = 'sales'").get().payload_json);
+  assert.deepEqual(sales, otherDeptPayload);
 });


### PR DESCRIPTION
## Summary
- Append missing material price defaults into existing molding quote payload copies on startup
- Preserve existing user-edited prices and only add absent name/model rows
- Add a regression test covering old quote payload data

## Tests
- node --no-warnings --test apps/业务部/内部报价系统/tests/ref-defaults.test.js
- node --no-warnings --test apps/业务部/内部报价系统/tests/workbench-assembly-import.test.js
- node --check apps/业务部/内部报价系统/backend/db/ref-defaults.js
- node --check apps/业务部/内部报价系统/backend/db/index.js
- git diff --check