### PR TITLE
Reuse blank material row for ABS default

### DIFF
--- a/apps/业务部/内部报价系统/backend/db/ref-defaults.js
+++ b/apps/业务部/内部报价系统/backend/db/ref-defaults.js
@@ -18,17 +18,38 @@ function refItemKey(tableKey, item) {
   return JSON.stringify(item);
 }
 
-function mergeMissingRefDefaults(existing, defaults, tableKey = 'material_prices') {
+function isBlankRefItem(item) {
+  if (!item || typeof item !== 'object' || Array.isArray(item)) return false;
+  const values = Object.values(item);
+  return values.length === 0 || values.every((value) => value === '' || value === null || value === undefined);
+}
+
+function mergeMissingRefDefaultsWithStats(existing, defaults, tableKey = 'material_prices') {
   const rows = Array.isArray(existing) ? existing.slice() : [];
-  const seen = new Set(rows.map((item) => refItemKey(tableKey, item)));
+  let added = 0;
+  let changed = false;
   for (const item of defaults || []) {
     const key = refItemKey(tableKey, item);
-    if (!seen.has(key)) {
-      rows.push({ ...item });
-      seen.add(key);
+    const existingIndex = rows.findIndex((row) => !isBlankRefItem(row) && refItemKey(tableKey, row) === key);
+    const blankIndex = rows.findIndex(isBlankRefItem);
+    if (existingIndex >= 0) {
+      if (blankIndex >= 0 && blankIndex < existingIndex) {
+        rows[blankIndex] = rows[existingIndex];
+        rows.splice(existingIndex, 1);
+        changed = true;
+      }
+    } else {
+      if (blankIndex >= 0) rows[blankIndex] = { ...item };
+      else rows.push({ ...item });
+      added += 1;
+      changed = true;
     }
   }
-  return rows;
+  return { rows, added, changed };
+}
+
+function mergeMissingRefDefaults(existing, defaults, tableKey = 'material_prices') {
+  return mergeMissingRefDefaultsWithStats(existing, defaults, tableKey).rows;
 }
 
 function parseRefRows(raw) {
@@ -44,9 +65,8 @@ function appendMissingRefDefaults(db, tableKey, defaults) {
   const row = db.prepare('SELECT data_json FROM ref_tables WHERE key = ?').get(tableKey);
   if (!row) return 0;
   const existing = parseRefRows(row.data_json);
-  const merged = mergeMissingRefDefaults(existing, defaults, tableKey);
-  const added = merged.length - existing.length;
-  if (added > 0) {
+  const { rows: merged, added, changed } = mergeMissingRefDefaultsWithStats(existing, defaults, tableKey);
+  if (changed) {
     db.prepare(`
       UPDATE ref_tables
       SET data_json = ?, updated_at = datetime('now'), updated_by = ?
@@ -76,9 +96,8 @@ function appendMissingRefDefaultsToSectionPayloads(db, dept, tableKey, defaults)
     const existing = payload[tableKey];
     if (!Array.isArray(existing) || existing.length === 0) continue;
 
-    const merged = mergeMissingRefDefaults(existing, defaults, tableKey);
-    const added = merged.length - existing.length;
-    if (added > 0) {
+    const { rows: merged, added, changed } = mergeMissingRefDefaultsWithStats(existing, defaults, tableKey);
+    if (changed) {
       payload[tableKey] = merged;
       update.run(JSON.stringify(payload), row.id);
       rowsChanged += 1;

--- a/apps/业务部/内部报价系统/tests/ref-defaults.test.js
+++ b/apps/业务部/内部报价系统/tests/ref-defaults.test.js
@@ -28,6 +28,41 @@ test('mergeMissingRefDefaults appends missing material defaults without replacin
   ]);
 });
 
+test('mergeMissingRefDefaults reuses the first blank material row for missing defaults', () => {
+  const existing = [
+    { name: 'ABS', model: '750SW', price: 8.5 },
+    {},
+  ];
+  const defaults = [
+    { name: 'ABS', model: recycledAbsModel, price: 4.6 },
+  ];
+
+  const merged = mergeMissingRefDefaults(existing, defaults);
+
+  assert.deepEqual(merged, [
+    { name: 'ABS', model: '750SW', price: 8.5 },
+    { name: 'ABS', model: recycledAbsModel, price: 4.6 },
+  ]);
+});
+
+test('mergeMissingRefDefaults moves an appended default into an earlier blank material row', () => {
+  const existing = [
+    { name: 'ABS', model: '750SW', price: 8.5 },
+    {},
+    { name: 'ABS', model: recycledAbsModel, price: 4.6 },
+  ];
+  const defaults = [
+    { name: 'ABS', model: recycledAbsModel, price: 4.6 },
+  ];
+
+  const merged = mergeMissingRefDefaults(existing, defaults);
+
+  assert.deepEqual(merged, [
+    { name: 'ABS', model: '750SW', price: 8.5 },
+    { name: 'ABS', model: recycledAbsModel, price: 4.6 },
+  ]);
+});
+
 test('mergeMissingRefDefaults is idempotent', () => {
   const existing = [
     { name: 'ABS', model: '750SW', price: 8.5 },
@@ -84,4 +119,65 @@ test('appendMissingRefDefaultsToSectionPayloads upgrades existing molding quote 
 
   const sales = JSON.parse(db.prepare("SELECT payload_json FROM quote_sections WHERE dept = 'sales'").get().payload_json);
   assert.deepEqual(sales, otherDeptPayload);
+});
+
+test('appendMissingRefDefaultsToSectionPayloads persists defaults into blank material rows', () => {
+  const db = new DatabaseSync(':memory:');
+  db.exec(`
+    CREATE TABLE quote_sections (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      dept TEXT NOT NULL,
+      payload_json TEXT NOT NULL DEFAULT '{}'
+    )
+  `);
+
+  db.prepare('INSERT INTO quote_sections (dept, payload_json) VALUES (?, ?)').run('molding', JSON.stringify({
+    material_prices: [
+      { name: 'ABS', model: '750SW', price: 8.5 },
+      {},
+    ],
+  }));
+
+  const result = appendMissingRefDefaultsToSectionPayloads(db, 'molding', 'material_prices', [
+    { name: 'ABS', model: recycledAbsModel, price: 4.6 },
+  ]);
+
+  assert.deepEqual(result, { rowsChanged: 1, itemsAdded: 1 });
+
+  const molding = JSON.parse(db.prepare("SELECT payload_json FROM quote_sections WHERE dept = 'molding'").get().payload_json);
+  assert.deepEqual(molding.material_prices, [
+    { name: 'ABS', model: '750SW', price: 8.5 },
+    { name: 'ABS', model: recycledAbsModel, price: 4.6 },
+  ]);
+});
+
+test('appendMissingRefDefaultsToSectionPayloads persists moving appended defaults into earlier blank rows', () => {
+  const db = new DatabaseSync(':memory:');
+  db.exec(`
+    CREATE TABLE quote_sections (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      dept TEXT NOT NULL,
+      payload_json TEXT NOT NULL DEFAULT '{}'
+    )
+  `);
+
+  db.prepare('INSERT INTO quote_sections (dept, payload_json) VALUES (?, ?)').run('molding', JSON.stringify({
+    material_prices: [
+      { name: 'ABS', model: '750SW', price: 8.5 },
+      {},
+      { name: 'ABS', model: recycledAbsModel, price: 4.6 },
+    ],
+  }));
+
+  const result = appendMissingRefDefaultsToSectionPayloads(db, 'molding', 'material_prices', [
+    { name: 'ABS', model: recycledAbsModel, price: 4.6 },
+  ]);
+
+  assert.deepEqual(result, { rowsChanged: 1, itemsAdded: 0 });
+
+  const molding = JSON.parse(db.prepare("SELECT payload_json FROM quote_sections WHERE dept = 'molding'").get().payload_json);
+  assert.deepEqual(molding.material_prices, [
+    { name: 'ABS', model: '750SW', price: 8.5 },
+    { name: 'ABS', model: recycledAbsModel, price: 4.6 },
+  ]);
 });


### PR DESCRIPTION
## Summary
- Reuse the first blank material price row when applying missing default material prices
- Move an already-appended default back into an earlier blank row, covering data already touched by PR #248
- Keep user-edited nonblank rows unchanged

## Tests
- node --no-warnings --test apps/业务部/内部报价系统/tests/ref-defaults.test.js
- node --no-warnings --test apps/业务部/内部报价系统/tests/workbench-assembly-import.test.js
- node --check apps/业务部/内部报价系统/backend/db/ref-defaults.js
- node --check apps/业务部/内部报价系统/backend/db/index.js
- git diff --check