### PR TITLE
完善唱片机管理系统分部门导入导出

### DIFF
--- a/apps/PMC跟仓管/加工管理/.gitignore
+++ b/apps/PMC跟仓管/加工管理/.gitignore
@@ -1,6 +1,7 @@
 __pycache__/
 *.pyc
 .pytest_cache/
+.codex_deps/
 data/*.db
 data/*.db-wal
 data/*.db-shm

--- a/apps/PMC跟仓管/加工管理/pcba/db.py
+++ b/apps/PMC跟仓管/加工管理/pcba/db.py
@@ -56,6 +56,7 @@ CREATE TABLE IF NOT EXISTS records (
     supplier TEXT,
     po_no TEXT,
     customer_name TEXT,
+    summary_month INTEGER,
     created_by INTEGER,
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     FOREIGN KEY (location_id) REFERENCES locations(id),
@@ -115,6 +116,8 @@ def _migrate_schema(conn):
         conn.execute("ALTER TABLE records ADD COLUMN po_no TEXT")
     if not _column_exists(conn, "records", "customer_name"):
         conn.execute("ALTER TABLE records ADD COLUMN customer_name TEXT")
+    if not _column_exists(conn, "records", "summary_month"):
+        conn.execute("ALTER TABLE records ADD COLUMN summary_month INTEGER")
     if not _column_exists(conn, "semi_finished_monthly_totals", "opening_stock"):
         conn.execute(
             "ALTER TABLE semi_finished_monthly_totals "

--- a/apps/PMC跟仓管/加工管理/pcba/export.py
+++ b/apps/PMC跟仓管/加工管理/pcba/export.py
@@ -1,5 +1,96 @@
 import io
+from datetime import date, datetime
 from openpyxl import Workbook
+
+SUMMARY_MONTHS = (6, 7, 8, 9, 10, 11, 12)
+
+
+def _record_export_date(record):
+    rec_date = record.get("rec_date")
+    if rec_date:
+        return rec_date
+    text = f"{record.get('doc_no') or ''} {record.get('remark') or ''}"
+    if "期初" in text:
+        return date(date.today().year, 6, 27).isoformat()
+    return None
+
+
+def _record_month(record):
+    summary_month = record.get("summary_month")
+    if summary_month:
+        try:
+            month = int(summary_month)
+            if month in SUMMARY_MONTHS:
+                return month
+        except (TypeError, ValueError):
+            pass
+    value = _record_export_date(record)
+    if not value:
+        return 6
+    if isinstance(value, datetime):
+        return value.month
+    if isinstance(value, date):
+        return value.month
+    try:
+        return date.fromisoformat(str(value)).month
+    except ValueError:
+        return 6
+
+
+def _record_qty(record):
+    return int(record.get("qty") or 0)
+
+
+def _month_values(records):
+    values = []
+    for month in SUMMARY_MONTHS:
+        values.append(sum(_record_qty(row) for row in records if _record_month(row) == month))
+    return values
+
+
+def _summary_month_row(scope, item, records, remark=""):
+    values = _month_values(records)
+    return [scope, item, sum(values), *values, remark]
+
+
+def _balance_month_row(scope, item, inbound_records, outbound_records, remark=""):
+    inbound_values = _month_values(inbound_records)
+    outbound_values = _month_values(outbound_records)
+    values = [
+        inbound_value - outbound_value
+        for inbound_value, outbound_value in zip(inbound_values, outbound_values)
+    ]
+    return [scope, item, sum(values), *values, remark]
+
+
+def _build_supplier_monthly_summary(ws, detail_records, location_names):
+    ws.append(["范围", "项目", "累计总数", "6月月结", "7月", "8月", "9月", "10月", "11月", "12月", "备注"])
+    all_issues = []
+    all_finished = []
+    for name in location_names:
+        issues = [
+            row for row in detail_records
+            if row["rec_type"] == "issue" and row.get("location_name") == name
+        ]
+        finished = [
+            row for row in detail_records
+            if row["rec_type"] in ("finished", "semi_finished")
+            and row.get("location_name") == name
+        ]
+        all_issues.extend(issues)
+        all_finished.extend(finished)
+        ws.append(_summary_month_row(name, "领料数", issues))
+        ws.append(_summary_month_row(name, "成品完成数", finished))
+        ws.append(_balance_month_row(name, "应存数", issues, finished))
+    ws.append(_summary_month_row("小计", "领料数", all_issues))
+    ws.append(_summary_month_row("小计", "成品完成数", all_finished))
+    ws.append(_balance_month_row("小计", "应存数", all_issues, all_finished))
+    ws.append([])
+
+    inbound = [row for row in detail_records if row["rec_type"] == "inbound_raw"]
+    ws.append(_summary_month_row("来料仓", "入仓总数", inbound))
+    ws.append(_summary_month_row("来料仓", "出库总数", all_issues))
+    ws.append(_balance_month_row("货仓", "应存", inbound, all_issues))
 
 
 def build_workbook(
@@ -17,6 +108,8 @@ def build_workbook(
     raw = summary["raw"]
     if outsource_mode:
         ws.append(["成品入库总数", "半成品入库总数", "入库合计"])
+    elif include_supplier:
+        _build_supplier_monthly_summary(ws, detail_records, location_names)
     else:
         ws.append(["范围", "领料数", "成品完成数", "应存数", "备注"])
         for row in summary["locations"]:
@@ -32,7 +125,7 @@ def build_workbook(
     elif warehouse_mode:
         ws.append(["半成品入库总数", "半成品出库总数", "半成品应存"])
         ws.append([raw["inbound"], raw["outbound"], raw["balance"]])
-    else:
+    elif not include_supplier:
         ws.append(["来料仓入仓总数", "来料仓出库总数", "货仓应存"])
         ws.append([raw["inbound"], raw["outbound"], raw["balance"]])
 
@@ -52,7 +145,7 @@ def build_workbook(
         s.append(headers)
         total = 0
         for r in recs:
-            row = [r.get("rec_date"), r.get("doc_no"), r.get("material")]
+            row = [_record_export_date(r), r.get("doc_no"), r.get("material")]
             if has_sticker_type:
                 row.append(r.get("sticker_type"))
             if include_po_customer:

--- a/apps/PMC跟仓管/加工管理/pcba/main.py
+++ b/apps/PMC跟仓管/加工管理/pcba/main.py
@@ -1,12 +1,15 @@
 import os
 import io
+import re
 from datetime import date, datetime
 from typing import List, Optional
+from urllib.parse import quote
 
-from fastapi import FastAPI, HTTPException, Request, Depends, File, UploadFile
+from fastapi import FastAPI, HTTPException, Request, Depends, File, Form, UploadFile
 from fastapi.responses import HTMLResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from openpyxl import Workbook, load_workbook
+from openpyxl.styles import Alignment, Border, PatternFill, Side
 from openpyxl.utils.datetime import from_excel
 from starlette.middleware.sessions import SessionMiddleware
 from pydantic import BaseModel
@@ -21,6 +24,10 @@ from pcba.summary import (
 )
 from pcba.db import DEPARTMENTS, LOCATIONS
 from pcba.export import build_workbook
+from pcba.shaoyang_reconcile import (
+    build_shaoyang_cd_reconcile,
+    build_shaoyang_issue_export_workbook,
+)
 
 app = FastAPI(title="唱片机管理系统")
 BASE_PATH = os.environ.get("PCBA_BASE_PATH", "").rstrip("/")
@@ -359,7 +366,7 @@ def _xlsx_response(wb: Workbook, filename: str):
     return StreamingResponse(
         buf,
         media_type=XLSX_MEDIA_TYPE,
-        headers={"Content-Disposition": f"attachment; filename={filename}"},
+        headers={"Content-Disposition": f"attachment; filename*=UTF-8''{quote(filename)}"},
     )
 
 
@@ -521,6 +528,40 @@ def _legacy_excel_date(value):
         except ValueError:
             pass
     return None
+
+
+def _legacy_cutoff_date(value, default_year=None):
+    rec_date = _legacy_excel_date(value)
+    if rec_date:
+        return rec_date
+    text = _cell_text(value)
+    if not text:
+        return None
+    match = re.search(
+        r"(?:(19\d{2}|20\d{2})\s*[年/-])?(\d{1,2})\s*(?:月|/|-)\s*(\d{1,2})\s*(?:日|号)?",
+        text,
+    )
+    if not match:
+        return None
+    year = int(match.group(1) or default_year or date.today().year)
+    month = int(match.group(2))
+    day = int(match.group(3))
+    try:
+        return date(year, month, day).isoformat()
+    except ValueError:
+        return None
+
+
+def _legacy_workbook_year(wb):
+    for ws in wb.worksheets:
+        for row in ws.iter_rows():
+            for cell in row:
+                rec_date = _legacy_excel_date(cell.value)
+                if rec_date:
+                    year = date.fromisoformat(rec_date).year
+                    if 2000 <= year <= 2100:
+                        return year
+    return date.today().year
 
 
 def _find_legacy_item_header_row(ws):
@@ -917,8 +958,90 @@ def _parse_legacy_heyuan_workbook(conn, wb, department):
     return bodies
 
 
+def _pcba_summary_key_from_label(label):
+    text = _cell_text(label)
+    if not text:
+        return None
+    compact = re.sub(r"\s+", "", text)
+    if "入仓" in compact or "入库" in compact:
+        return ("inbound_raw", None)
+    if "邵阳" in compact:
+        return ("issue", "邵阳华登")
+    if "河源" in compact:
+        return ("issue", "河源华兴")
+    if "利鸿" in compact or "加工厂" in compact:
+        return ("issue", "东莞加工厂利鸿")
+    if "东莞车间" in compact or "车间领料" in compact:
+        return ("issue", "东莞车间")
+    return None
+
+
+def _pcba_summary_month_from_header(value):
+    text = _cell_text(value)
+    match = re.search(r"(\d{1,2})月", text)
+    if not match:
+        return None
+    month = int(match.group(1))
+    return month if month in SUMMARY_MONTHS else None
+
+
+def _pcba_summary_month_totals(wb):
+    if "总表" not in wb.sheetnames:
+        return {}
+    ws = wb["总表"]
+    month_columns = []
+    for col_no in range(1, ws.max_column + 1):
+        month = _pcba_summary_month_from_header(ws.cell(1, col_no).value)
+        if month:
+            month_columns.append((month, col_no))
+    if not month_columns:
+        return {}
+
+    totals = {}
+    for row_no in range(2, ws.max_row + 1):
+        key = _pcba_summary_key_from_label(
+            ws.cell(row_no, 2).value or ws.cell(row_no, 1).value
+        )
+        if not key:
+            continue
+        month_values = {}
+        for month, col_no in month_columns:
+            month_values[month] = _legacy_int(
+                ws.cell(row_no, col_no).value,
+                row_no,
+                f"{month}月",
+            ) or 0
+        totals[key] = month_values
+    return totals
+
+
+def _assign_pcba_summary_months(groups, totals):
+    for key, bodies in groups.items():
+        month_totals = totals.get(key)
+        if not month_totals:
+            continue
+        months = [
+            month for month in SUMMARY_MONTHS
+            if int(month_totals.get(month) or 0) != 0
+        ]
+        if not months:
+            continue
+        month_index = 0
+        remaining = int(month_totals[months[month_index]] or 0)
+        for body in bodies:
+            while month_index < len(months) and remaining == 0:
+                month_index += 1
+                if month_index < len(months):
+                    remaining = int(month_totals[months[month_index]] or 0)
+            if month_index >= len(months):
+                break
+            body.summary_month = months[month_index]
+            remaining -= int(body.qty or 0)
+
+
 def _parse_legacy_supplier_pcba_workbook(conn, wb, department):
     bodies = []
+    groups = {}
     inbound_ws = wb["入仓明细"] if "入仓明细" in wb.sheetnames else None
     if inbound_ws:
         headers = _legacy_header_map(inbound_ws)
@@ -952,13 +1075,13 @@ def _parse_legacy_supplier_pcba_workbook(conn, wb, department):
                 ) or f"{inbound_ws.title}导入",
             )
             _add_record_body(bodies, body, department, validate_positive=False)
+            groups.setdefault(("inbound_raw", None), []).append(body)
 
     for ws in wb.worksheets:
         if "领料" not in ws.title:
             continue
-        location_id = _location_id_from_name(
-            conn, _legacy_location_from_sheet(ws.title), 1
-        )
+        location_name = _legacy_location_from_sheet(ws.title)
+        location_id = _location_id_from_name(conn, location_name, 1)
         headers = _legacy_header_map(ws)
         for row_no in range(2, ws.max_row + 1):
             material = _cell_text(_legacy_header_value(ws, headers, row_no, "物料名称"))
@@ -992,6 +1115,8 @@ def _parse_legacy_supplier_pcba_workbook(conn, wb, department):
                 ) or f"{ws.title}导入",
             )
             _add_record_body(bodies, body, department, validate_positive=False)
+            groups.setdefault(("issue", location_name), []).append(body)
+    _assign_pcba_summary_months(groups, _pcba_summary_month_totals(wb))
     return bodies
 
 
@@ -1018,6 +1143,14 @@ def _parse_supplier_nfc_total_rows(conn, wb, department):
     if "总表" not in wb.sheetnames:
         return bodies
     ws = wb["总表"]
+    workbook_year = _legacy_workbook_year(wb)
+    opening_inbound_date = _legacy_cutoff_date(ws.cell(2, 3).value, workbook_year)
+    dongguan_opening_date = _legacy_cutoff_date(ws.cell(2, 13).value, workbook_year)
+    shaoyang_opening_date = (
+        _legacy_cutoff_date(ws.cell(2, 14).value, workbook_year)
+        or dongguan_opening_date
+        or opening_inbound_date
+    )
     dongguan_id = _location_id_from_name(conn, "东莞车间", 1)
     shaoyang_id = _location_id_from_name(conn, "邵阳华登", 1)
     for row_no in range(3, ws.max_row + 1):
@@ -1034,6 +1167,7 @@ def _parse_supplier_nfc_total_rows(conn, wb, department):
                     rec_type="inbound_raw",
                     material=NFC_MATERIAL,
                     sticker_type=sticker_type,
+                    rec_date=opening_inbound_date,
                     doc_no=f"{sticker_type}-期初入仓",
                     qty=values["opening_inbound"],
                     remark="总表期初入仓导入",
@@ -1048,6 +1182,7 @@ def _parse_supplier_nfc_total_rows(conn, wb, department):
                     location_id=dongguan_id,
                     material=NFC_MATERIAL,
                     sticker_type=sticker_type,
+                    rec_date=dongguan_opening_date,
                     doc_no=f"{sticker_type}-东莞期初出仓",
                     qty=values["dongguan_opening_outbound"],
                     remark="总表东莞期初出仓导入",
@@ -1062,6 +1197,7 @@ def _parse_supplier_nfc_total_rows(conn, wb, department):
                     location_id=shaoyang_id,
                     material=NFC_MATERIAL,
                     sticker_type=sticker_type,
+                    rec_date=shaoyang_opening_date,
                     doc_no=f"{sticker_type}-邵阳期初领料",
                     qty=values["shaoyang_opening_outbound"],
                     remark="总表邵阳期初领料导入",
@@ -1133,8 +1269,8 @@ def _parse_legacy_supplier_workbook(conn, wb, department):
     return bodies
 
 
-def _record_duplicate_exists(conn, body, user):
-    return conn.execute(
+def _record_duplicate_id(conn, body, user):
+    row = conn.execute(
         "SELECT id FROM records WHERE department=? AND rec_type=? "
         "AND COALESCE(rec_date, '')=? AND COALESCE(doc_no, '')=? "
         "AND material=? AND COALESCE(sticker_type, '')=? AND qty=? "
@@ -1150,20 +1286,50 @@ def _record_duplicate_exists(conn, body, user):
             body.location_id or 0,
             body.remark or "",
         ),
-    ).fetchone() is not None
+    ).fetchone()
+    if row:
+        return row["id"]
+    if body.rec_date is None and body.doc_no:
+        legacy_row = conn.execute(
+            "SELECT id FROM records WHERE department=? AND rec_type=? "
+            "AND COALESCE(rec_date, '')='' AND COALESCE(doc_no, '')='' "
+            "AND material=? AND COALESCE(sticker_type, '')=? AND qty=? "
+            "AND COALESCE(location_id, 0)=? AND COALESCE(remark, '')=?",
+            (
+                user["department"],
+                body.rec_type,
+                body.material,
+                body.sticker_type or "",
+                body.qty,
+                body.location_id or 0,
+                body.remark or "",
+            ),
+        ).fetchone()
+        if legacy_row:
+            return legacy_row["id"]
+    return None
 
 
 def _insert_record_body(conn, body, user, skip_duplicate=False):
-    if skip_duplicate and _record_duplicate_exists(conn, body, user):
-        return None
+    if skip_duplicate:
+        duplicate_id = _record_duplicate_id(conn, body, user)
+        if duplicate_id:
+            if body.summary_month is not None:
+                conn.execute(
+                    "UPDATE records SET summary_month=? WHERE id=?",
+                    (body.summary_month, duplicate_id),
+                )
+            return None
     supplier, po_no, customer_name = _record_extras(body, user["department"])
     sticker_type = _normalize_sticker_type(conn, body.material, body.sticker_type)
     cur = conn.execute(
         "INSERT INTO records(rec_type, location_id, rec_date, doc_no, "
-        "material, sticker_type, qty, remark, supplier, po_no, customer_name, department, created_by) "
-        "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
+        "material, sticker_type, qty, remark, supplier, po_no, customer_name, "
+        "summary_month, department, created_by) "
+        "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
         (body.rec_type, body.location_id, body.rec_date, body.doc_no,
          body.material, sticker_type, body.qty, body.remark, supplier, po_no, customer_name,
+         body.summary_month,
          user["department"], user["id"]),
     )
     return cur.lastrowid
@@ -1577,6 +1743,7 @@ class RecordIn(BaseModel):
     supplier: Optional[str] = None
     po_no: Optional[str] = None
     customer_name: Optional[str] = None
+    summary_month: Optional[int] = None
 
 
 def _validate_record(body: RecordIn, department: Optional[str] = None):
@@ -1691,10 +1858,12 @@ def create_record(body: RecordIn, user=Depends(current_user)):
         sticker_type = _normalize_sticker_type(conn, body.material, body.sticker_type)
         cur = conn.execute(
             "INSERT INTO records(rec_type, location_id, rec_date, doc_no, "
-            "material, sticker_type, qty, remark, supplier, po_no, customer_name, department, created_by) "
-            "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
+            "material, sticker_type, qty, remark, supplier, po_no, customer_name, "
+            "summary_month, department, created_by) "
+            "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
             (body.rec_type, body.location_id, body.rec_date, body.doc_no,
              body.material, sticker_type, body.qty, body.remark, supplier, po_no, customer_name,
+             body.summary_month,
              user["department"], user["id"]),
         )
         conn.commit()
@@ -1742,10 +1911,12 @@ def create_records_batch(body: RecordBatchIn, user=Depends(current_user)):
         for sticker_type, qty in valid_items:
             cur = conn.execute(
                 "INSERT INTO records(rec_type, location_id, rec_date, doc_no, "
-                "material, sticker_type, qty, remark, supplier, po_no, customer_name, department, created_by) "
-                "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                "material, sticker_type, qty, remark, supplier, po_no, customer_name, "
+                "summary_month, department, created_by) "
+                "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
                 (common.rec_type, common.location_id, common.rec_date, common.doc_no,
                  NFC_MATERIAL, sticker_type, qty, common.remark, supplier, po_no, customer_name,
+                 common.summary_month,
                  user["department"], user["id"]),
             )
             ids.append(cur.lastrowid)
@@ -1766,6 +1937,708 @@ def record_import_template(_user=Depends(current_user)):
         "2026-07-08", "示例单号001", 100, "示例行，可删除", "", "",
     ])
     return _xlsx_response(wb, "records_import_template.xlsx")
+
+
+def _record_export_type_label(rec_type, department):
+    if rec_type == "issue":
+        return "出库" if department == SUPPLIER_DEPARTMENT else "领料"
+    labels = {
+        "inbound_raw": "入库",
+        "finished": "成品入库",
+        "semi_finished": "半成品入库",
+        "semi_inbound": "入库",
+        "semi_outbound": "出库",
+    }
+    return labels.get(rec_type, rec_type)
+
+
+def _records_export_workbook(records, department):
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "流水导出"
+    ws.append(RECORD_IMPORT_HEADERS)
+    for row in records:
+        ws.append([
+            _record_export_type_label(row["rec_type"], department),
+            row["material"],
+            row["sticker_type"],
+            row["location_name"],
+            row["supplier"],
+            _record_export_date(row),
+            row["doc_no"],
+            row["qty"],
+            row["remark"],
+            row["po_no"],
+            row["customer_name"],
+        ])
+    return wb
+
+
+EXPORT_MONTHS = tuple(range(7, 13))
+SUMMARY_MONTHS = (6, *EXPORT_MONTHS)
+SUMMARY_MONTH_LABELS = {
+    6: "6月月结",
+    **{month: f"{month}月" for month in EXPORT_MONTHS},
+}
+
+
+def _export_date(value):
+    if not value:
+        return None
+    try:
+        return date.fromisoformat(str(value))
+    except ValueError:
+        return value
+
+
+def _legacy_opening_record_date(row):
+    if row.get("rec_date"):
+        return None
+    text = f"{row.get('doc_no') or ''} {row.get('remark') or ''}"
+    if "期初" in text:
+        return date(date.today().year, 6, 27).isoformat()
+    return None
+
+
+def _record_export_date(row):
+    return row.get("rec_date") or _legacy_opening_record_date(row)
+
+
+def _export_month(value):
+    if not value:
+        return 6
+    try:
+        return date.fromisoformat(str(value)).month
+    except ValueError:
+        return 6
+
+
+def _sum_qty(records):
+    return sum(int(row.get("qty") or 0) for row in records)
+
+
+def _month_sum(records, month):
+    return _sum_qty([row for row in records if _record_month(row) == month])
+
+
+def _record_month(row):
+    summary_month = row.get("summary_month")
+    if summary_month:
+        try:
+            month = int(summary_month)
+            if month in SUMMARY_MONTHS:
+                return month
+        except (TypeError, ValueError):
+            pass
+    return _export_month(_record_export_date(row))
+
+
+def _monthly_flow_values(records):
+    values = []
+    for month in SUMMARY_MONTHS:
+        issue = _sum_qty([
+            row for row in records
+            if row["rec_type"] == "issue" and _record_month(row) == month
+        ])
+        finished = _sum_qty([
+            row for row in records
+            if row["rec_type"] in ("finished", "semi_finished")
+            and _record_month(row) == month
+        ])
+        values.append({
+            "issue": issue,
+            "finished": finished,
+            "balance": issue - finished,
+        })
+    return values
+
+
+def _monthly_raw_values(records):
+    values = []
+    for month in SUMMARY_MONTHS:
+        inbound = _sum_qty([
+            row for row in records
+            if row["rec_type"] == "inbound_raw" and _record_month(row) == month
+        ])
+        outbound = _sum_qty([
+            row for row in records
+            if row["rec_type"] == "issue" and _record_month(row) == month
+        ])
+        values.append({
+            "inbound": inbound,
+            "outbound": outbound,
+            "balance": inbound - outbound,
+        })
+    return values
+
+
+def _sum_month_values(values, key):
+    return sum(int(row.get(key) or 0) for row in values)
+
+
+def _summary_material(row):
+    material = (row.get("material") or PCBA_MATERIAL).strip()
+    return NFC_MATERIAL if material == NFC_MATERIAL else material
+
+
+def _summary_materials(records):
+    preferred = [NFC_MATERIAL, PCBA_MATERIAL]
+    names = sorted({_summary_material(row) for row in records})
+    return sorted(
+        names,
+        key=lambda name: (
+            preferred.index(name) if name in preferred else len(preferred),
+            name,
+        ),
+    )
+
+
+def _monthly_location_summary(records, location_names):
+    locations = []
+    for location in location_names:
+        location_records = [
+            row for row in records if row.get("location") == location
+        ]
+        for material in _summary_materials(location_records):
+            material_records = [
+                row for row in location_records
+                if _summary_material(row) == material
+            ]
+            values = _monthly_flow_values(material_records)
+            locations.append({
+                "location": location,
+                "material": material,
+                "issue": _sum_month_values(values, "issue"),
+                "finished": _sum_month_values(values, "finished"),
+                "balance": _sum_month_values(values, "balance"),
+                "values": values,
+            })
+    subtotal_values = []
+    for index, _month in enumerate(SUMMARY_MONTHS):
+        issue = sum(row["values"][index]["issue"] for row in locations)
+        finished = sum(row["values"][index]["finished"] for row in locations)
+        subtotal_values.append({
+            "issue": issue,
+            "finished": finished,
+            "balance": issue - finished,
+        })
+    raw_values = _monthly_raw_values(records)
+    return {
+        "months": [
+            {"month": month, "label": SUMMARY_MONTH_LABELS[month]}
+            for month in SUMMARY_MONTHS
+        ],
+        "locations": locations,
+        "subtotal": {
+            "issue": _sum_month_values(subtotal_values, "issue"),
+            "finished": _sum_month_values(subtotal_values, "finished"),
+            "balance": _sum_month_values(subtotal_values, "balance"),
+            "values": subtotal_values,
+        },
+        "raw": {
+            "inbound": _sum_month_values(raw_values, "inbound"),
+            "outbound": _sum_month_values(raw_values, "outbound"),
+            "balance": _sum_month_values(raw_values, "balance"),
+            "values": raw_values,
+        },
+    }
+
+
+def _format_nfc_sticker_name(name):
+    name = name or ""
+    return name.replace("NFC贴纸", "NFC\n贴纸")
+
+
+def _apply_legacy_sheet_style(ws, max_row=None, max_col=None):
+    max_row = max_row or ws.max_row
+    max_col = max_col or ws.max_column
+    thin = Side(style="thin", color="000000")
+    border = Border(left=thin, right=thin, top=thin, bottom=thin)
+    alignment = Alignment(horizontal="center", vertical="center", wrap_text=True)
+    for row in ws.iter_rows(min_row=1, max_row=max_row, min_col=1, max_col=max_col):
+        for cell in row:
+            cell.alignment = alignment
+            cell.border = border
+    for col_no in range(1, max_col + 1):
+        letter = ws.cell(1, col_no).column_letter
+        ws.column_dimensions[letter].width = 13
+    ws.column_dimensions["A"].width = 14
+    ws.column_dimensions["B"].width = 16
+
+
+SUPPLIER_PCBA_SUMMARY_ROWS = (
+    ("邵阳华登", "邵阳华登领料总数", "PCB主板", "邵阳华登领料"),
+    ("河源华兴", "河源华兴领料总数", "PCB主板", "河源华兴领料"),
+    ("东莞加工厂利鸿", "加工厂利鸿领料总数", "PCB主板", "加工厂利鸿领料"),
+    ("东莞车间", "东莞车间领料", None, "东莞车间领料"),
+)
+
+
+def _supplier_pcba_month_sums(records):
+    return [_month_sum(records, month) for month in (6, *EXPORT_MONTHS)]
+
+
+def _supplier_pcba_activity_row(material_label, label, records):
+    month_sums = _supplier_pcba_month_sums(records)
+    month_values = [value or None for value in month_sums]
+    return [material_label, label, sum(month_sums), *month_values, None]
+
+
+def _supplier_pcba_detail_sheet(wb, title, records, doc_header, qty_header):
+    ws = wb.create_sheet(title[:31])
+    ws.append(["日期", doc_header, "物料名称", qty_header, "备注"])
+    for row in records:
+        ws.append([
+            _record_export_date(row),
+            row.get("doc_no"),
+            PCBA_MATERIAL,
+            row.get("qty"),
+            row.get("remark"),
+        ])
+    ws.append([None, None, "小计：", _sum_qty(records), None])
+    _apply_legacy_sheet_style(ws, ws.max_row, 5)
+    ws.column_dimensions["A"].width = 20
+    ws.column_dimensions["E"].width = 20
+
+
+def _pcba_inbound_detail_sheet(wb, title, records):
+    ws = wb.create_sheet(title[:31])
+    ws.append(["日期", "送货单号", "合同号", "货号", "品名/规格", "数量（pcs）", "备注"])
+    for row in records:
+        ws.append([
+            _record_export_date(row),
+            row.get("doc_no"),
+            None,
+            "77794",
+            row.get("material") or PCBA_MATERIAL,
+            row.get("qty"),
+            row.get("remark"),
+        ])
+    ws.append([None, None, None, None, "小计：", _sum_qty(records), None])
+    _apply_legacy_sheet_style(ws, ws.max_row, 7)
+    ws.column_dimensions["A"].width = 20
+    ws.column_dimensions["B"].width = 18
+    ws.column_dimensions["E"].width = 18
+    ws.column_dimensions["G"].width = 22
+
+
+def _outsource_pcba_export_workbook(records):
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "总表"
+    issue = [row for row in records if row["rec_type"] == "issue"]
+    finished = [row for row in records if row["rec_type"] == "finished"]
+    semi_finished = [row for row in records if row["rec_type"] == "semi_finished"]
+    headers = ["物料名称", None, "累计出入数", "截6月月结"]
+    headers += [f"{month}月" for month in EXPORT_MONTHS]
+    headers.append("备注")
+    ws.append(headers)
+    ws.append(["PCBA主板", "领料总数", _sum_qty(issue), *_supplier_pcba_month_sums(issue), None])
+    ws.append([
+        None, "半成品入仓总数", _sum_qty(semi_finished),
+        *_supplier_pcba_month_sums(semi_finished), None,
+    ])
+    if finished:
+        ws.append([
+            None, "成品入仓总数", _sum_qty(finished),
+            *_supplier_pcba_month_sums(finished), None,
+        ])
+    _apply_legacy_sheet_style(ws, ws.max_row, len(headers))
+    ws.column_dimensions["A"].width = 14
+    ws.column_dimensions["B"].width = 18
+
+    _supplier_pcba_detail_sheet(wb, "领料明细", issue, "领料编号", "领料数")
+    _pcba_inbound_detail_sheet(wb, "半成品入仓明细", semi_finished)
+    if finished:
+        _pcba_inbound_detail_sheet(wb, "成品入仓明细", finished)
+    return wb
+
+
+def _heyuan_pcba_export_workbook(records):
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "总表"
+    issue = [row for row in records if row["rec_type"] == "issue"]
+    finished = [row for row in records if row["rec_type"] == "finished"]
+    headers = ["物料名称", "领料总数", "截6月月结"]
+    headers += [f"{month}月" for month in EXPORT_MONTHS]
+    headers.append("备注")
+    ws.append(headers)
+    ws.append(["PCBA主板", _sum_qty(issue), *_supplier_pcba_month_sums(issue), None])
+    if finished:
+        ws.append(["成品入仓总数", _sum_qty(finished), *_supplier_pcba_month_sums(finished), None])
+    _apply_legacy_sheet_style(ws, ws.max_row, len(headers))
+    ws.column_dimensions["A"].width = 14
+    ws.column_dimensions["B"].width = 14
+
+    _supplier_pcba_detail_sheet(wb, "36#CD领料明细", [], "领料编号", "领料数")
+    _supplier_pcba_detail_sheet(wb, "PCB板领料明细", issue, "领料编号", "领料数")
+    _pcba_inbound_detail_sheet(wb, "成品入仓明细", finished)
+    return wb
+
+
+def _supplier_pcba_export_workbook(records):
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "总表"
+    inbound = [row for row in records if row["rec_type"] == "inbound_raw"]
+    issues = [row for row in records if row["rec_type"] == "issue"]
+    headers = ["物料名称", None, "累计出入总数", "6月月结"]
+    headers += [f"{month}月" for month in EXPORT_MONTHS]
+    headers.append("备注")
+    ws.append(headers)
+    ws.append(_supplier_pcba_activity_row("PCB主板", "入仓总数", inbound))
+    issue_month_sums = [0] * 7
+    for row_no, (location, label, material_label, _sheet_title) in enumerate(
+        SUPPLIER_PCBA_SUMMARY_ROWS, start=3
+    ):
+        location_rows = [row for row in issues if row.get("location_name") == location]
+        ws.append(_supplier_pcba_activity_row(material_label, label, location_rows))
+        issue_month_sums = [
+            current + value
+            for current, value in zip(issue_month_sums, _supplier_pcba_month_sums(location_rows))
+        ]
+    ws.append([None] * len(headers))
+    balance_rows = [
+        inbound_value - issue_value
+        for inbound_value, issue_value in zip(_supplier_pcba_month_sums(inbound), issue_month_sums)
+    ]
+    ws.append([None, "应存数", sum(balance_rows), *balance_rows, None])
+    _apply_legacy_sheet_style(ws, 8, len(headers))
+    ws["C8"].fill = PatternFill(fill_type="solid", fgColor="FFFFFF00")
+    ws.column_dimensions["A"].width = 14.625
+    ws.column_dimensions["B"].width = 17.25
+    ws.column_dimensions["C"].width = 15.5
+    ws.column_dimensions["D"].width = 14.75
+    ws.column_dimensions["K"].width = 9
+
+    _supplier_pcba_detail_sheet(wb, "入仓明细", inbound, "入仓单号", "入仓数")
+    for location, _label, _material_label, sheet_title in SUPPLIER_PCBA_SUMMARY_ROWS:
+        location_rows = [row for row in issues if row.get("location_name") == location]
+        _supplier_pcba_detail_sheet(
+            wb, sheet_title, location_rows, "领料单号", "领料数"
+        )
+    wb.create_sheet("Sheet2")
+    return wb
+
+
+def _supplier_nfc_sticker_names(records, sticker_types):
+    names = list(sticker_types)
+    for row in records:
+        name = row.get("sticker_type")
+        if name and name not in names:
+            names.append(name)
+    return names
+
+
+def _supplier_nfc_detail_sheet(wb, title, records, sticker_names, total_header):
+    ws = wb.create_sheet(title)
+    records = [
+        row for row in records
+        if _export_month(_record_export_date(row)) in (6, *EXPORT_MONTHS)
+    ]
+    ws.cell(1, 2).value = total_header
+    ws.cell(2, 1).value = "物料名称"
+    for offset, row in enumerate(records, start=3):
+        ws.cell(1, offset).value = _record_export_date(row)
+        ws.cell(2, offset).value = row.get("doc_no")
+    for row_no, sticker_type in enumerate(sticker_names, start=3):
+        ws.cell(row_no, 1).value = _format_nfc_sticker_name(sticker_type)
+        sticker_records = [
+            row for row in records if row.get("sticker_type") == sticker_type
+        ]
+        ws.cell(row_no, 2).value = _sum_qty(sticker_records) or 0
+        for col_no, record in enumerate(records, start=3):
+            if record.get("sticker_type") == sticker_type:
+                ws.cell(row_no, col_no).value = record.get("qty")
+    total_row = len(sticker_names) + 3
+    ws.cell(total_row, 1).value = "小计："
+    ws.cell(total_row, 2).value = _sum_qty(records) or 0
+    for col_no, row in enumerate(records, start=3):
+        ws.cell(total_row, col_no).value = row.get("qty")
+    _apply_legacy_sheet_style(ws, total_row, max(2, len(records) + 2))
+    return ws
+
+
+def _supplier_nfc_export_workbook(records, sticker_types):
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "总表"
+    inbound = [row for row in records if row["rec_type"] == "inbound_raw"]
+    outbound = [row for row in records if row["rec_type"] == "issue"]
+    sticker_names = _supplier_nfc_sticker_names(records, sticker_types)
+    ws.cell(1, 2).value = "累计入仓总数"
+    ws.cell(2, 1).value = "物料名称"
+    ws.cell(2, 3).value = "截止6月27号"
+    for i, month in enumerate(EXPORT_MONTHS, start=4):
+        ws.cell(1, i).value = f"{month}月入仓\n总数"
+    ws.cell(1, 11).value = "应存数"
+    ws.cell(1, 12).value = "累计出仓总数"
+    ws.cell(1, 13).value = "东莞"
+    ws.cell(2, 13).value = "截止6月27号"
+    ws.cell(1, 14).value = "邵阳领料"
+    for i, month in enumerate(EXPORT_MONTHS, start=15):
+        ws.cell(1, i).value = f"{month}月出仓\n总数"
+
+    for row_no, sticker_type in enumerate(sticker_names, start=3):
+        sticker_inbound = [row for row in inbound if row.get("sticker_type") == sticker_type]
+        sticker_outbound = [row for row in outbound if row.get("sticker_type") == sticker_type]
+        ws.cell(row_no, 1).value = _format_nfc_sticker_name(sticker_type)
+        ws.cell(row_no, 2).value = _sum_qty(sticker_inbound) or 0
+        ws.cell(row_no, 3).value = _month_sum(sticker_inbound, 6) or 0
+        for col_no, month in enumerate(EXPORT_MONTHS, start=4):
+            ws.cell(row_no, col_no).value = _month_sum(sticker_inbound, month) or None
+        ws.cell(row_no, 11).value = _sum_qty(sticker_inbound) - _sum_qty(sticker_outbound)
+        ws.cell(row_no, 12).value = _sum_qty(sticker_outbound) or 0
+        dongguan_opening = [
+            row for row in sticker_outbound
+            if row.get("location_name") == "东莞车间" and _export_month(row.get("rec_date")) == 6
+        ]
+        shaoyang_opening = [
+            row for row in sticker_outbound
+            if row.get("location_name") == "邵阳华登" and _export_month(row.get("rec_date")) == 6
+        ]
+        ws.cell(row_no, 13).value = _sum_qty(dongguan_opening) or 0
+        ws.cell(row_no, 14).value = _sum_qty(shaoyang_opening) or 0
+        for col_no, month in enumerate(EXPORT_MONTHS, start=15):
+            ws.cell(row_no, col_no).value = _month_sum(sticker_outbound, month) or None
+    _apply_legacy_sheet_style(ws, len(sticker_names) + 2, 20)
+    ws.column_dimensions["A"].width = 13
+    ws.column_dimensions["B"].width = 11
+    ws.column_dimensions["C"].width = 12
+
+    _supplier_nfc_detail_sheet(wb, "入库明细", inbound, sticker_names, "当月入仓总数")
+    _supplier_nfc_detail_sheet(wb, "出库明细", outbound, sticker_names, "当月出仓总数")
+    return wb
+
+
+def _monthly_totals_map(monthly_totals):
+    return {
+        row["sticker_type"]: {
+            "opening_stock": int(row.get("opening_stock") or 0),
+            "monthly_inbound": int(row.get("monthly_inbound") or 0),
+            "monthly_outbound": int(row.get("monthly_outbound") or 0),
+        }
+        for row in monthly_totals
+    }
+
+
+def _semi_finished_sticker_names(records, sticker_types, monthly_totals):
+    names = list(sticker_types)
+    for row in monthly_totals:
+        name = row.get("sticker_type")
+        if name and name not in names:
+            names.append(name)
+    for row in records:
+        name = row.get("sticker_type")
+        if name and name not in names:
+            names.append(name)
+    return names
+
+
+def _semi_month_total(total_row, records, key, rec_type):
+    value = int((total_row or {}).get(key) or 0)
+    if value:
+        return value
+    return _sum_qty([row for row in records if row["rec_type"] == rec_type])
+
+
+def _semi_finished_detail_sheet(
+    wb, title, records, sticker_names, totals_by_sticker, is_inbound
+):
+    ws = wb.create_sheet(title)
+    rec_type = "semi_inbound" if is_inbound else "semi_outbound"
+    total_key = "monthly_inbound" if is_inbound else "monthly_outbound"
+    total_header = "当月入仓总数" if is_inbound else "当月出仓总数"
+    sheet_records = [row for row in records if row["rec_type"] == rec_type]
+    start_col = 5 if is_inbound else 4
+    header_row = 3 if is_inbound else 5
+    data_row_start = header_row + 1
+
+    if is_inbound:
+        ws.cell(1, 4).value = "日期"
+        ws.cell(2, 4).value = "入库单号"
+        ws.cell(3, 1).value = "物料名称"
+        ws.cell(3, 2).value = total_header
+        ws.cell(3, 3).value = "6/24\n装配入库截数"
+        ws.cell(3, 4).value = "6/24\n鸿亚入库截数"
+    else:
+        ws.cell(5, 1).value = "物料名称"
+        ws.cell(5, 2).value = total_header
+        ws.cell(5, 3).value = "6/24盘点截数"
+
+    for offset, row in enumerate(sheet_records, start=start_col):
+        ws.cell(1, offset).value = _record_export_date(row)
+        ws.cell(2, offset).value = row.get("doc_no")
+
+    for row_no, sticker_type in enumerate(sticker_names, start=data_row_start):
+        sticker_records = [
+            row for row in sheet_records if row.get("sticker_type") == sticker_type
+        ]
+        total_row = totals_by_sticker.get(sticker_type, {})
+        ws.cell(row_no, 1).value = _format_nfc_sticker_name(sticker_type)
+        ws.cell(row_no, 2).value = _semi_month_total(
+            total_row, sticker_records, total_key, rec_type
+        ) or 0
+        ws.cell(row_no, 3).value = int(total_row.get("opening_stock") or 0) or None
+        for col_no, record in enumerate(sheet_records, start=start_col):
+            if record.get("sticker_type") == sticker_type:
+                ws.cell(row_no, col_no).value = record.get("qty")
+
+    total_row_no = data_row_start + len(sticker_names)
+    ws.cell(total_row_no, 1).value = "小计："
+    ws.cell(total_row_no, 2).value = sum(
+        ws.cell(row_no, 2).value or 0
+        for row_no in range(data_row_start, total_row_no)
+    )
+    ws.cell(total_row_no, 3).value = sum(
+        ws.cell(row_no, 3).value or 0
+        for row_no in range(data_row_start, total_row_no)
+    ) or None
+    for col_no, record in enumerate(sheet_records, start=start_col):
+        ws.cell(total_row_no, col_no).value = record.get("qty")
+
+    _apply_legacy_sheet_style(
+        ws, total_row_no, max(start_col - 1, len(sheet_records) + start_col - 1)
+    )
+    ws.column_dimensions["A"].width = 13
+    ws.column_dimensions["B"].width = 12
+    ws.column_dimensions["C"].width = 13
+    return ws
+
+
+def _semi_finished_export_workbook(records, sticker_types, monthly_totals):
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "总表"
+    sticker_names = _semi_finished_sticker_names(records, sticker_types, monthly_totals)
+    totals_by_sticker = _monthly_totals_map(monthly_totals)
+    inbound = [row for row in records if row["rec_type"] == "semi_inbound"]
+    outbound = [row for row in records if row["rec_type"] == "semi_outbound"]
+
+    ws.cell(1, 2).value = "累计入仓总数"
+    ws.cell(2, 1).value = "物料名称"
+    ws.cell(2, 3).value = "截止6月27号"
+    for col_no, month in enumerate(EXPORT_MONTHS, start=4):
+        ws.cell(1, col_no).value = f"{month}月入仓\n总数"
+    ws.cell(1, 11).value = "应存数"
+    ws.cell(1, 12).value = "累计出仓总数"
+    ws.cell(1, 13).value = "东莞"
+    ws.cell(2, 13).value = "截止6月27号"
+    ws.cell(1, 14).value = "邵阳生产"
+    for col_no, month in enumerate(EXPORT_MONTHS, start=15):
+        ws.cell(1, col_no).value = f"{month}月出仓\n总数"
+
+    for row_no, sticker_type in enumerate(sticker_names, start=3):
+        total_row = totals_by_sticker.get(sticker_type, {})
+        sticker_inbound = [row for row in inbound if row.get("sticker_type") == sticker_type]
+        sticker_outbound = [row for row in outbound if row.get("sticker_type") == sticker_type]
+        inbound_total = _semi_month_total(
+            total_row, sticker_inbound, "monthly_inbound", "semi_inbound"
+        )
+        outbound_total = _semi_month_total(
+            total_row, sticker_outbound, "monthly_outbound", "semi_outbound"
+        )
+        ws.cell(row_no, 1).value = _format_nfc_sticker_name(sticker_type)
+        ws.cell(row_no, 2).value = inbound_total or 0
+        ws.cell(row_no, 3).value = int(total_row.get("opening_stock") or 0) or None
+        ws.cell(row_no, 4).value = inbound_total or None
+        ws.cell(row_no, 11).value = inbound_total - outbound_total
+        ws.cell(row_no, 12).value = outbound_total or 0
+        ws.cell(row_no, 14).value = int(total_row.get("opening_stock") or 0) or None
+        ws.cell(row_no, 15).value = outbound_total or None
+
+    _apply_legacy_sheet_style(ws, len(sticker_names) + 2, 20)
+    ws.column_dimensions["A"].width = 13
+    ws.column_dimensions["B"].width = 11
+    ws.column_dimensions["C"].width = 12
+
+    _semi_finished_detail_sheet(
+        wb, "入库明细", records, sticker_names, totals_by_sticker, True
+    )
+    _semi_finished_detail_sheet(
+        wb, "邵阳领料", records, sticker_names, totals_by_sticker, False
+    )
+    wb.create_sheet("河源华兴36#CD领料")
+    wb.create_sheet("车间36#CD领料")
+    return wb
+
+
+@app.get("/api/records/export")
+def export_records(
+    user=Depends(current_user),
+    date_from: Optional[str] = None,
+    date_to: Optional[str] = None,
+    doc_no: Optional[str] = None,
+    material: Optional[str] = None,
+):
+    filters = _date_filter(date_from, date_to, doc_no)
+    material = _clean_optional(material)
+    conn = db.get_conn()
+    try:
+        sql = (
+            "SELECT r.id, r.rec_type, l.name AS location_name, r.rec_date, r.doc_no, "
+            "r.material, r.sticker_type, r.supplier, r.po_no, r.customer_name, "
+            "r.qty, r.remark, r.summary_month "
+            "FROM records r "
+            "LEFT JOIN locations l ON r.location_id = l.id "
+            "WHERE r.department=?"
+        )
+        params = [user["department"]]
+        sql, params = _append_date_filter(sql, params, filters)
+        if material:
+            sql += " AND r.material=?"
+            params.append(material)
+        sql += " ORDER BY r.id"
+        rows = conn.execute(sql, params).fetchall()
+        sticker_types = [
+            row["name"] for row in conn.execute(
+                "SELECT name FROM sticker_types ORDER BY sort, id"
+            ).fetchall()
+        ]
+        totals_sql = (
+            "SELECT material, sticker_type, opening_stock, "
+            "monthly_inbound, monthly_outbound "
+            "FROM semi_finished_monthly_totals WHERE department=?"
+        )
+        totals_params = [user["department"]]
+        if material:
+            totals_sql += " AND material=?"
+            totals_params.append(material)
+        monthly_totals = conn.execute(totals_sql, totals_params).fetchall()
+    finally:
+        conn.close()
+    records = [dict(r) for r in rows]
+    monthly_totals = [dict(r) for r in monthly_totals]
+    if user["department"] == SEMI_FINISHED_DEPARTMENT and material in (None, NFC_MATERIAL):
+        return _xlsx_response(
+            _semi_finished_export_workbook(records, sticker_types, monthly_totals),
+            "塑胶仓77772#CD半成品出入明细.xlsx",
+        )
+    if user["department"] == SUPPLIER_DEPARTMENT and material == PCBA_MATERIAL:
+        return _xlsx_response(
+            _supplier_pcba_export_workbook(records),
+            "来料仓77794PCB主板出入明细.xlsx",
+        )
+    if user["department"] == SUPPLIER_DEPARTMENT and material == NFC_MATERIAL:
+        return _xlsx_response(
+            _supplier_nfc_export_workbook(records, sticker_types),
+            "来料仓77772#NFC出入明细.xlsx",
+        )
+    if user["department"] == OUTSOURCE_DEPARTMENT and material == PCBA_MATERIAL:
+        return _xlsx_response(
+            _outsource_pcba_export_workbook(records),
+            "东莞加工厂利鸿77794PCB主板出入明细.xlsx",
+        )
+    if user["department"] == HEYUAN_DEPARTMENT and material == PCBA_MATERIAL:
+        return _xlsx_response(
+            _heyuan_pcba_export_workbook(records),
+            "河源华兴77794PCB主板出入明细.xlsx",
+        )
+    return _xlsx_response(
+        _records_export_workbook(records, user["department"]),
+        "records_export.xlsx",
+    )
 
 
 def _record_body_from_import_row(conn, row_no, row, department):
@@ -1860,6 +2733,45 @@ def import_records(file: UploadFile = File(...), user=Depends(current_user)):
     }
 
 
+@app.post("/api/shaoyang-cd/reconcile")
+def shaoyang_cd_reconcile(
+    month: int = Form(7),
+    issue_file: UploadFile = File(...),
+    finished_file: UploadFile = File(...),
+    _user=Depends(current_user),
+):
+    try:
+        return build_shaoyang_cd_reconcile(
+            issue_file.file.read(),
+            issue_file.filename or "",
+            finished_file.file.read(),
+            finished_file.filename or "",
+            month,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+
+@app.post("/api/shaoyang-cd/export-issue")
+def shaoyang_cd_export_issue(
+    month: int = Form(7),
+    issue_file: UploadFile = File(...),
+    finished_file: UploadFile = File(...),
+    _user=Depends(current_user),
+):
+    try:
+        wb = build_shaoyang_issue_export_workbook(
+            issue_file.file.read(),
+            issue_file.filename or "",
+            finished_file.file.read(),
+            finished_file.filename or "",
+            month,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return _xlsx_response(wb, "邵阳77772#CD领料明细-已填成品入仓.xlsx")
+
+
 def _get_record_or_404(conn, record_id, department):
     row = conn.execute(
         "SELECT * FROM records WHERE id=? AND department=?",
@@ -1886,9 +2798,11 @@ def update_record(record_id: int, body: RecordIn, user=Depends(current_user)):
         _check_owner(row, user)
         conn.execute(
             "UPDATE records SET rec_type=?, location_id=?, rec_date=?, doc_no=?, "
-            "material=?, sticker_type=?, qty=?, remark=?, supplier=?, po_no=?, customer_name=? WHERE id=?",
+            "material=?, sticker_type=?, qty=?, remark=?, supplier=?, po_no=?, "
+            "customer_name=?, summary_month=? WHERE id=?",
             (body.rec_type, body.location_id, body.rec_date, body.doc_no,
              body.material, sticker_type, body.qty, body.remark, supplier, po_no, customer_name,
+             body.summary_month,
              record_id),
         )
         conn.commit()
@@ -1913,7 +2827,9 @@ def delete_record(record_id: int, user=Depends(current_user)):
 def _all_records_for_summary(conn, department, filters=None):
     sql = (
         "SELECT r.rec_type AS rec_type, l.name AS location, r.qty AS qty, "
-        "r.material AS material, r.sticker_type AS sticker_type, r.department AS department "
+        "r.material AS material, r.sticker_type AS sticker_type, "
+        "r.rec_date AS rec_date, r.doc_no AS doc_no, r.remark AS remark, "
+        "r.summary_month AS summary_month, r.department AS department "
         "FROM records r LEFT JOIN locations l ON r.location_id = l.id "
         "WHERE r.department=?"
     )
@@ -1966,6 +2882,7 @@ def _with_common_summary_fields(summary, records, filters, reverse_departments=(
     result["sticker_types"] = compute_sticker_type_totals(
         records, reverse_departments
     )
+    result["monthly_locations"] = _monthly_location_summary(records, LOCATIONS)
     result["filters"] = filters
     return result
 
@@ -2101,7 +3018,8 @@ def export(
         summary_records = _all_records_for_summary(conn, user["department"], filters)
         sql = (
             "SELECT r.rec_type, l.name AS location_name, r.rec_date, r.doc_no, "
-            "r.material, r.sticker_type, r.supplier, r.po_no, r.customer_name, r.qty, r.remark FROM records r "
+            "r.material, r.sticker_type, r.supplier, r.po_no, r.customer_name, "
+            "r.qty, r.remark, r.summary_month FROM records r "
             "LEFT JOIN locations l ON r.location_id = l.id "
             "WHERE r.department=?"
         )

--- a/apps/PMC跟仓管/加工管理/pcba/shaoyang_reconcile.py
+++ b/apps/PMC跟仓管/加工管理/pcba/shaoyang_reconcile.py
@@ -1,0 +1,224 @@
+import io
+import re
+
+from openpyxl import load_workbook
+
+try:
+    import xlrd
+except ImportError:  # pragma: no cover - only reached when .xls support is absent.
+    xlrd = None
+
+
+def _cell_text(value):
+    if value is None:
+        return ""
+    return str(value).replace("\r", "").replace("\n", "").strip()
+
+
+def _compact_text(value):
+    return re.sub(r"\s+", "", _cell_text(value))
+
+
+def _number(value):
+    if value is None or _cell_text(value) == "":
+        return 0
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, (int, float)):
+        return int(round(value))
+    text = _cell_text(value).replace(",", "")
+    try:
+        return int(round(float(text)))
+    except ValueError:
+        return 0
+
+
+def _sticker_no(value):
+    match = re.search(r"(\d+)\s*#", _cell_text(value))
+    return int(match.group(1)) if match else None
+
+
+def _vinyl_no(value):
+    match = re.search(r"VINYL-S1-(\d+)", _cell_text(value), re.IGNORECASE)
+    return int(match.group(1)) if match else None
+
+
+def _read_sheets(content, filename):
+    suffix = (filename or "").lower().rsplit(".", 1)[-1]
+    if suffix == "xls":
+        if xlrd is None:
+            raise ValueError("当前环境缺少 xlrd，无法读取 .xls 文件")
+        book = xlrd.open_workbook(file_contents=content)
+        sheets = []
+        for sheet in book.sheets():
+            rows = [
+                [sheet.cell_value(row_no, col_no) for col_no in range(sheet.ncols)]
+                for row_no in range(sheet.nrows)
+            ]
+            sheets.append((sheet.name, rows))
+        return sheets
+
+    wb = load_workbook(io.BytesIO(content), data_only=True, read_only=True)
+    return [
+        (ws.title, [list(row) for row in ws.iter_rows(values_only=True)])
+        for ws in wb.worksheets
+    ]
+
+
+def _value_at(row, col_index):
+    return row[col_index] if col_index is not None and col_index < len(row) else None
+
+
+def _month_inbound_col(rows, month):
+    wanted = f"{month}月"
+    for row in rows[:8]:
+        for index, value in enumerate(row):
+            text = _compact_text(value)
+            if wanted in text and "入仓" in text and "成品" in text:
+                return index
+    for row in rows[:8]:
+        for index, value in enumerate(row):
+            text = _compact_text(value)
+            if wanted in text and "入仓" in text:
+                return index
+    return None
+
+
+def _issue_month_inbound(content, filename, month):
+    for _sheet_name, rows in _read_sheets(content, filename):
+        month_col = _month_inbound_col(rows, month)
+        if month_col is None:
+            continue
+        items = {}
+        for row in rows:
+            no = _sticker_no(row[0] if row else None)
+            if no is None:
+                continue
+            items[no] = {
+                "sticker_name": _compact_text(row[0]),
+                "issue_month_inbound": _number(_value_at(row, month_col)),
+            }
+        if items:
+            return items
+    raise ValueError(f"领料表总表里找不到 {month} 月成品入仓总数")
+
+
+def _header_index(headers, *candidates):
+    compact_headers = [_compact_text(header).lower() for header in headers]
+    for candidate in candidates:
+        text = candidate.lower()
+        for index, header in enumerate(compact_headers):
+            if text in header:
+                return index
+    return None
+
+
+def _finished_totals(content, filename):
+    for _sheet_name, rows in _read_sheets(content, filename):
+        for header_no, row in enumerate(rows[:12]):
+            item_col = _header_index(row, "itemno")
+            subtotal_col = _header_index(row, "小计")
+            if item_col is None or subtotal_col is None:
+                continue
+            name_col = _header_index(row, "minisname", "name")
+            result = {}
+            for values in rows[header_no + 1:]:
+                item_no = _cell_text(_value_at(values, item_col))
+                no = _vinyl_no(item_no)
+                if no is None:
+                    continue
+                result[no] = {
+                    "item_no": item_no,
+                    "minis_name": _cell_text(_value_at(values, name_col)),
+                    "finished_total": _number(_value_at(values, subtotal_col)),
+                }
+            if result:
+                return result
+    raise ValueError("成品入仓表总表里找不到 Item No. 和小计")
+
+
+def _validate_month(month):
+    month = int(month)
+    if month < 1 or month > 12:
+        raise ValueError("月份必须在 1 到 12 之间")
+    return month
+
+
+def _load_editable_xlsx(content, filename):
+    suffix = (filename or "").lower().rsplit(".", 1)[-1]
+    if suffix != "xlsx":
+        raise ValueError("导出领料表只支持 .xlsx 领料文件")
+    try:
+        return load_workbook(io.BytesIO(content))
+    except Exception as exc:
+        raise ValueError("领料表无法读取") from exc
+
+
+def _find_month_inbound_worksheet(wb, month):
+    for ws in wb.worksheets:
+        rows = [list(row) for row in ws.iter_rows(values_only=True)]
+        month_col = _month_inbound_col(rows, month)
+        if month_col is not None:
+            return ws, month_col + 1
+    raise ValueError(f"领料表总表里找不到 {month} 月成品入仓总数")
+
+
+def _is_subtotal_row(ws, row_no):
+    for col_no in range(1, min(ws.max_column, 6) + 1):
+        if "小计" in _compact_text(ws.cell(row_no, col_no).value):
+            return True
+    return False
+
+
+def build_shaoyang_issue_export_workbook(
+    issue_content, issue_filename, finished_content, finished_filename, month
+):
+    month = _validate_month(month)
+    wb = _load_editable_xlsx(issue_content, issue_filename)
+    ws, month_col = _find_month_inbound_worksheet(wb, month)
+    finished_rows = _finished_totals(finished_content, finished_filename)
+
+    written_total = 0
+    for row_no in range(1, ws.max_row + 1):
+        no = _sticker_no(ws.cell(row_no, 1).value)
+        if no is None:
+            continue
+        qty = int((finished_rows.get(no) or {}).get("finished_total") or 0)
+        ws.cell(row_no, month_col).value = qty
+        written_total += qty
+
+    for row_no in range(1, ws.max_row + 1):
+        if _is_subtotal_row(ws, row_no):
+            ws.cell(row_no, month_col).value = written_total
+            break
+
+    return wb
+
+
+def build_shaoyang_cd_reconcile(issue_content, issue_filename, finished_content, finished_filename, month):
+    month = _validate_month(month)
+
+    issue_rows = _issue_month_inbound(issue_content, issue_filename, month)
+    finished_rows = _finished_totals(finished_content, finished_filename)
+    rows = []
+    for no in sorted(set(issue_rows) | set(finished_rows)):
+        issue = issue_rows.get(no, {})
+        finished = finished_rows.get(no, {})
+        issue_qty = int(issue.get("issue_month_inbound") or 0)
+        finished_qty = int(finished.get("finished_total") or 0)
+        rows.append({
+            "sticker_no": no,
+            "sticker_name": issue.get("sticker_name") or f"{no}#NFC贴纸",
+            "item_no": finished.get("item_no") or f"VINYL-S1-{no:03d}",
+            "minis_name": finished.get("minis_name") or "",
+            "issue_month_inbound": issue_qty,
+            "finished_total": finished_qty,
+            "difference": finished_qty - issue_qty,
+        })
+
+    totals = {
+        "issue_month_inbound": sum(row["issue_month_inbound"] for row in rows),
+        "finished_total": sum(row["finished_total"] for row in rows),
+    }
+    totals["difference"] = totals["finished_total"] - totals["issue_month_inbound"]
+    return {"month": month, "rows": rows, "totals": totals}

--- a/apps/PMC跟仓管/加工管理/pcba/static/app.html
+++ b/apps/PMC跟仓管/加工管理/pcba/static/app.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>唱片机管理系统</title>
-<link rel="stylesheet" href="/static/style.css?v=17">
+<link rel="stylesheet" href="/static/style.css?v=19">
 </head>
 <body class="app-page">
 <header class="app-header">
@@ -21,6 +21,7 @@
 <nav class="app-nav">
   <button class="tab-btn" data-tab="entry" onclick="showTab('entry')">录入</button>
   <button class="tab-btn" data-tab="summary" onclick="showTab('summary')">汇总</button>
+  <button class="tab-btn" data-tab="shaoyangReconcile" onclick="showTab('shaoyangReconcile')">邵阳核对</button>
   <button class="tab-btn" id="matTabBtn" data-tab="materials" onclick="showTab('materials')" style="display:none">物料管理</button>
   <button class="tab-btn" id="supTabBtn" data-tab="suppliers" onclick="showTab('suppliers')" style="display:none">供应商管理</button>
   <button class="tab-btn" id="usersTabBtn" data-tab="users" onclick="showTab('users')" style="display:none">用户管理</button>
@@ -51,6 +52,7 @@
       <div class="section-actions">
         <button class="ghost-btn" onclick="downloadRecordTemplate()">下载模板</button>
         <button class="primary-btn slim" onclick="chooseImportFile('recordImportFile')">导入Excel</button>
+        <button class="ghost-btn" onclick="exportRecords()">导出Excel</button>
         <input id="recordImportFile" type="file" accept=".xlsx" onchange="importRecords(this)" hidden>
         <span id="editBanner" class="status-pill subtle"></span>
       </div>
@@ -121,6 +123,55 @@
           <tbody id="stickerSummaryRows"></tbody>
         </table>
       </div>
+    </div>
+  </section>
+
+  <section id="shaoyangReconcile" class="tab panel" style="display:none">
+    <div class="section-head">
+      <div>
+        <h2>邵阳成品核对</h2>
+        <p>上传邵阳77772#CD领料明细和77772、77794成品入仓明细，按 1# 对应 VINYL-S1-001 核对数量</p>
+      </div>
+    </div>
+    <div class="form-grid compact-form reconcile-form">
+      <select id="shaoyangReconcileMonth" title="核对月份">
+        <option value="7">7月</option>
+        <option value="8">8月</option>
+        <option value="9">9月</option>
+        <option value="10">10月</option>
+        <option value="11">11月</option>
+        <option value="12">12月</option>
+      </select>
+      <div class="file-upload-card">
+        <button type="button" class="file-upload-trigger" onclick="chooseImportFile('shaoyangIssueFile')">领料表</button>
+        <span id="shaoyangIssueFileName" class="file-upload-name">未选择文件</span>
+        <input id="shaoyangIssueFile" type="file" accept=".xlsx" title="邵阳77772#CD领料明细" onchange="updateFileName('shaoyangIssueFile', 'shaoyangIssueFileName')" hidden>
+      </div>
+      <div class="file-upload-card">
+        <button type="button" class="file-upload-trigger" onclick="chooseImportFile('shaoyangFinishedFile')">成品表</button>
+        <span id="shaoyangFinishedFileName" class="file-upload-name">未选择文件</span>
+        <input id="shaoyangFinishedFile" type="file" accept=".xls,.xlsx" title="邵阳77772、77794成品入仓明细" onchange="updateFileName('shaoyangFinishedFile', 'shaoyangFinishedFileName')" hidden>
+      </div>
+      <button class="primary-btn" onclick="reconcileShaoyangCd()">开始核对</button>
+      <button class="ghost-btn" onclick="exportShaoyangIssueWorkbook()">导出领料表</button>
+    </div>
+    <p id="shaoyangReconcileErr" class="err"></p>
+    <div id="shaoyangReconcileCards" class="metric-grid"></div>
+    <div class="table-wrap">
+      <table id="shaoyangReconcileTable">
+        <thead>
+          <tr>
+            <th>贴纸序号</th>
+            <th>物料名称</th>
+            <th>Item No.</th>
+            <th>Minis Name</th>
+            <th>成品入仓数</th>
+            <th>第二表小计</th>
+            <th>差异</th>
+          </tr>
+        </thead>
+        <tbody><tr><td colspan="7">请先上传两个表格并开始核对</td></tr></tbody>
+      </table>
     </div>
   </section>
 
@@ -241,6 +292,6 @@
   </section>
 </main>
 
-<script src="/static/app.js?v=18"></script>
+  <script src="/static/app.js?v=27"></script>
 </body>
 </html>

--- a/apps/PMC跟仓管/加工管理/pcba/static/app.html
+++ b/apps/PMC跟仓管/加工管理/pcba/static/app.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>唱片机管理系统</title>
-<link rel="stylesheet" href="/static/style.css?v=16">
+<link rel="stylesheet" href="/static/style.css?v=17">
 </head>
 <body class="app-page">
 <header class="app-header">
@@ -57,11 +57,12 @@
     </div>
 
     <div id="entryTypeTabs" class="entry-type-tabs"></div>
+    <div id="entryMaterialTabs" class="entry-type-tabs material-tabs"></div>
 
     <div class="form-grid">
       <select id="recType" style="display:none"></select>
       <select id="locationId"></select>
-      <select id="material" title="物料名称" onchange="onMaterialChange()"></select>
+      <select id="material" title="物料名称" style="display:none" onchange="onMaterialChange()"></select>
       <select id="supplier" title="供应商" style="display:none"></select>
       <input id="recDate" type="date" title="日期">
       <input id="docNo" placeholder="单据编号">
@@ -240,6 +241,6 @@
   </section>
 </main>
 
-<script src="/static/app.js?v=17"></script>
+<script src="/static/app.js?v=18"></script>
 </body>
 </html>

--- a/apps/PMC跟仓管/加工管理/pcba/static/app.js
+++ b/apps/PMC跟仓管/加工管理/pcba/static/app.js
@@ -58,6 +58,16 @@ function fmt(n) {
   return Number(n || 0).toLocaleString('zh-CN');
 }
 
+function fmtNonZero(n) {
+  const value = Number(n || 0);
+  return value ? fmt(value) : '';
+}
+
+function hasMonthlyQuantity(total, values, key) {
+  if (Number(total || 0) !== 0) return true;
+  return (values || []).some(value => Number(((value || {})[key]) || 0) !== 0);
+}
+
 function isXingxin() {
   return ME && ME.department === XINGXIN_DEPARTMENT;
 }
@@ -222,6 +232,13 @@ function filterQuery() {
 
 function withFilters(path) {
   const query = filterQuery();
+  return path + (query ? '?' + query : '');
+}
+
+function withEntryExportFilters(path) {
+  const params = new URLSearchParams(filterQuery());
+  if (ACTIVE_ENTRY_MATERIAL) params.set('material', ACTIVE_ENTRY_MATERIAL);
+  const query = params.toString();
   return path + (query ? '?' + query : '');
 }
 
@@ -784,6 +801,10 @@ async function loadSummary() {
       `<tbody><tr><td>${fmt(s.raw.issue)}</td><td>${fmt(s.raw.finished_inbound)}</td><td>${fmt(s.raw.semi_finished_inbound)}</td><td>${fmt(s.raw.balance)}</td></tr></tbody>`;
     return;
   }
+  if (s.monthly_locations) {
+    el('sumTable').innerHTML = renderMonthlyLocationSummary(s.monthly_locations);
+    return;
+  }
 
   let html = '<thead><tr><th>范围</th><th>领料数</th><th>成品完成数</th><th>应存数</th></tr></thead><tbody>';
   for (const row of s.locations) {
@@ -794,6 +815,39 @@ async function loadSummary() {
   html += `<tr><td>${fmt(s.raw.inbound)}</td><td>${fmt(s.raw.outbound)}</td><td>${fmt(s.raw.balance)}</td><td></td></tr>`;
   html += '</tbody>';
   el('sumTable').innerHTML = html;
+}
+
+function renderMonthlyLocationSummary(summary) {
+  const months = summary.months || [
+    {label: '6月月结'}, {label: '7月'}, {label: '8月'}, {label: '9月'},
+    {label: '10月'}, {label: '11月'}, {label: '12月'},
+  ];
+  const monthHeads = months.map(month => `<th>${esc(month.label)}</th>`).join('');
+  const monthCells = (values, key) => months.map((_, index) =>
+    `<td>${fmtNonZero((values[index] || {})[key])}</td>`
+  ).join('');
+  const dataRow = (scope, material, item, total, values, key, className = '') => {
+    if (!hasMonthlyQuantity(total, values, key)) return '';
+    return `<tr class="${className}"><td>${esc(scope)}</td><td>${esc(material || '')}</td><td>${esc(item)}</td><td>${fmtNonZero(total)}</td>${monthCells(values || [], key)}<td></td></tr>`;
+  };
+
+  let html = `<thead><tr><th>范围</th><th>物料名称</th><th>项目</th><th>累计总数</th>${monthHeads}<th>备注</th></tr></thead><tbody>`;
+  for (const row of summary.locations || []) {
+    html += dataRow(row.location, row.material, '领料数', row.issue, row.values, 'issue');
+    html += dataRow(row.location, row.material, '成品完成数', row.finished, row.values, 'finished');
+    html += dataRow(row.location, row.material, '应存数', row.balance, row.values, 'balance');
+  }
+  const subtotal = summary.subtotal || {};
+  html += dataRow('小计', '全部物料', '领料数', subtotal.issue, subtotal.values, 'issue', 'subtotal');
+  html += dataRow('小计', '全部物料', '成品完成数', subtotal.finished, subtotal.values, 'finished', 'subtotal');
+  html += dataRow('小计', '全部物料', '应存数', subtotal.balance, subtotal.values, 'balance', 'subtotal');
+  const raw = summary.raw || {};
+  html += '<tr class="summary-spacer"><td colspan="12"></td></tr>';
+  html += dataRow('来料仓', '全部物料', '入仓总数', raw.inbound, raw.values, 'inbound');
+  html += dataRow('来料仓', '全部物料', '出库总数', raw.outbound, raw.values, 'outbound');
+  html += dataRow('货仓', '全部物料', '应存', raw.balance, raw.values, 'balance');
+  html += '</tbody>';
+  return html;
 }
 
 function renderSummaryCards(s) {
@@ -859,8 +913,103 @@ function chooseImportFile(id) {
   input.click();
 }
 
+function updateFileName(inputId, labelId) {
+  const input = el(inputId);
+  const label = el(labelId);
+  const file = input.files && input.files[0];
+  if (label) label.textContent = file ? file.name : '未选择文件';
+}
+
 function downloadRecordTemplate() {
   location.href = appPath('/api/records/import-template');
+}
+
+function exportRecords() {
+  location.href = appPath(withEntryExportFilters('/api/records/export'));
+}
+
+function shaoyangReconcileFormData() {
+  const issueFile = el('shaoyangIssueFile').files && el('shaoyangIssueFile').files[0];
+  const finishedFile = el('shaoyangFinishedFile').files && el('shaoyangFinishedFile').files[0];
+  if (!issueFile || !finishedFile) {
+    setMessage('shaoyangReconcileErr', '请先选择两个表格文件', false);
+    return null;
+  }
+  const form = new FormData();
+  form.append('month', el('shaoyangReconcileMonth').value || '7');
+  form.append('issue_file', issueFile);
+  form.append('finished_file', finishedFile);
+  return form;
+}
+
+async function reconcileShaoyangCd() {
+  const form = shaoyangReconcileFormData();
+  if (!form) return;
+  const r = await api('/api/shaoyang-cd/reconcile', {
+    method: 'POST',
+    body: form,
+  });
+  if (!r.ok) {
+    const e = await r.json();
+    setMessage('shaoyangReconcileErr', e.detail || '核对失败', false);
+    return;
+  }
+  const data = await r.json();
+  setMessage('shaoyangReconcileErr', `已完成 ${data.month} 月核对`, true);
+  renderShaoyangReconcile(data);
+}
+
+async function exportShaoyangIssueWorkbook() {
+  const form = shaoyangReconcileFormData();
+  if (!form) return;
+  const r = await api('/api/shaoyang-cd/export-issue', {
+    method: 'POST',
+    body: form,
+  });
+  if (!r.ok) {
+    const e = await r.json().catch(() => ({}));
+    setMessage('shaoyangReconcileErr', e.detail || '导出领料表失败', false);
+    return;
+  }
+  const blob = await r.blob();
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = '邵阳77772#CD领料明细-已填成品入仓.xlsx';
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+  setMessage('shaoyangReconcileErr', '已生成导出领料表', true);
+}
+
+function renderShaoyangReconcile(data) {
+  const totals = data.totals || {};
+  const cards = [
+    [`${data.month}月成品入仓数`, totals.issue_month_inbound || 0],
+    ['第二表小计', totals.finished_total || 0],
+    ['差异', totals.difference || 0],
+    ['核对行数', (data.rows || []).length],
+  ];
+  el('shaoyangReconcileCards').innerHTML = cards.map(([label, value]) =>
+    `<div class="metric-card"><span>${esc(label)}</span><strong>${fmt(value)}</strong></div>`
+  ).join('');
+
+  const rows = data.rows || [];
+  const body = el('shaoyangReconcileTable').querySelector('tbody');
+  body.innerHTML = rows.map(row => {
+    const diff = Number(row.difference || 0);
+    const cls = diff === 0 ? 'reconcile-ok' : 'reconcile-diff';
+    return `<tr class="${cls}">
+      <td>${fmt(row.sticker_no)}</td>
+      <td>${esc(row.sticker_name)}</td>
+      <td>${esc(row.item_no)}</td>
+      <td>${esc(row.minis_name)}</td>
+      <td>${fmt(row.issue_month_inbound)}</td>
+      <td>${fmt(row.finished_total)}</td>
+      <td>${fmt(diff)}</td>
+    </tr>`;
+  }).join('') || '<tr><td colspan="7">没有读取到可核对的数据</td></tr>';
 }
 
 async function importFile(input, endpoint, errId, afterImport) {
@@ -1027,7 +1176,7 @@ async function changeMyPassword() {
 }
 
 function showTab(name) {
-  for (const id of ['entry', 'summary', 'materials', 'suppliers', 'users', 'password']) {
+  for (const id of ['entry', 'summary', 'shaoyangReconcile', 'materials', 'suppliers', 'users', 'password']) {
     el(id).style.display = id === name ? '' : 'none';
   }
   document.querySelectorAll('.tab-btn').forEach(btn =>

--- a/apps/PMC跟仓管/加工管理/pcba/static/app.js
+++ b/apps/PMC跟仓管/加工管理/pcba/static/app.js
@@ -31,6 +31,7 @@ let ME = null;
 let RECORDS = [];
 let ENTRY_TYPE_OPTIONS = [];
 let ACTIVE_ENTRY_TYPE = '';
+let ACTIVE_ENTRY_MATERIAL = '';
 let DEPARTMENTS = [];
 let SUPPLIERS = [];
 let MATERIALS = [];
@@ -167,6 +168,38 @@ function setEntryType(type) {
   renderRecordsTable();
 }
 
+function entryMaterialOptions() {
+  const preferred = [NFC_MATERIAL, PCBA_MATERIAL];
+  const byName = new Map(MATERIALS.map(m => [m.name, m]));
+  const ordered = preferred
+    .filter(name => byName.has(name))
+    .map(name => byName.get(name));
+  MATERIALS.forEach(m => {
+    if (!preferred.includes(m.name)) ordered.push(m);
+  });
+  return ordered;
+}
+
+function renderEntryMaterialTabs() {
+  const tabs = el('entryMaterialTabs');
+  if (!tabs) return;
+  const materials = entryMaterialOptions();
+  tabs.innerHTML = materials.map(mat => {
+    const active = mat.name === ACTIVE_ENTRY_MATERIAL ? ' active' : '';
+    return `<button type="button" class="entry-type-tab${active}" onclick="setEntryMaterial('${esc(mat.name)}')">${esc(mat.name)}</button>`;
+  }).join('');
+}
+
+function setEntryMaterial(material) {
+  if (!entryMaterialOptions().some(mat => mat.name === material)) return;
+  if (editingId && ACTIVE_ENTRY_MATERIAL !== material) cancelEdit();
+  ACTIVE_ENTRY_MATERIAL = material;
+  el('material').value = material;
+  onMaterialChange();
+  renderEntryMaterialTabs();
+  renderRecordsTable();
+}
+
 async function api(path, opts) {
   const r = await fetch(appPath(path), opts);
   if (r.status === 401) {
@@ -279,6 +312,11 @@ async function loadMaterials() {
   el('material').innerHTML = mats
     .map(m => `<option value="${esc(m.name)}">${esc(m.name)}</option>`)
     .join('');
+  if (!mats.some(m => m.name === ACTIVE_ENTRY_MATERIAL)) {
+    ACTIVE_ENTRY_MATERIAL = mats[0] ? mats[0].name : '';
+  }
+  el('material').value = ACTIVE_ENTRY_MATERIAL;
+  renderEntryMaterialTabs();
 
   const form = el('materialForm');
   if (form) form.style.display = '';
@@ -624,6 +662,10 @@ function startEdit(id) {
     ACTIVE_ENTRY_TYPE = rec.rec_type;
     renderEntryTypeTabs();
   }
+  if (entryMaterialOptions().some(mat => mat.name === rec.material)) {
+    ACTIVE_ENTRY_MATERIAL = rec.material;
+    renderEntryMaterialTabs();
+  }
   el('recType').value = rec.rec_type;
   onTypeChange();
   if (rec.location_id) el('locationId').value = rec.location_id;
@@ -674,7 +716,10 @@ function renderRecordsTable() {
   renderRecordHeader();
   const tb = document.querySelector('#recTable tbody');
   const emptyColspan = 10 + (isXingxin() ? 1 : 0) + (supportsPoCustomer() ? 2 : 0);
-  const visibleRecords = RECORDS.filter(x => !ACTIVE_ENTRY_TYPE || x.rec_type === ACTIVE_ENTRY_TYPE);
+  const visibleRecords = RECORDS.filter(x =>
+    (!ACTIVE_ENTRY_TYPE || x.rec_type === ACTIVE_ENTRY_TYPE) &&
+    (!ACTIVE_ENTRY_MATERIAL || x.material === ACTIVE_ENTRY_MATERIAL)
+  );
   tb.innerHTML = visibleRecords.map(x => {
     const canEdit = ME.role === 'admin' || x.created_by === ME.id;
     const ops = canEdit

--- a/apps/PMC跟仓管/加工管理/pcba/static/app.js
+++ b/apps/PMC跟仓管/加工管理/pcba/static/app.js
@@ -164,8 +164,11 @@ function renderEntryTypeTabs() {
   if (!tabs) return;
   tabs.innerHTML = ENTRY_TYPE_OPTIONS.map(opt => {
     const active = opt.value === ACTIVE_ENTRY_TYPE ? ' active' : '';
-    return `<button type="button" class="entry-type-tab${active}" onclick="setEntryType('${esc(opt.value)}')">${esc(opt.label)}</button>`;
+    return `<button type="button" class="entry-type-tab${active}" data-entry-type="${esc(opt.value)}">${esc(opt.label)}</button>`;
   }).join('');
+  tabs.querySelectorAll('[data-entry-type]').forEach(btn => {
+    btn.addEventListener('click', () => setEntryType(btn.dataset.entryType || ''));
+  });
 }
 
 function setEntryType(type) {
@@ -196,8 +199,11 @@ function renderEntryMaterialTabs() {
   const materials = entryMaterialOptions();
   tabs.innerHTML = materials.map(mat => {
     const active = mat.name === ACTIVE_ENTRY_MATERIAL ? ' active' : '';
-    return `<button type="button" class="entry-type-tab${active}" onclick="setEntryMaterial('${esc(mat.name)}')">${esc(mat.name)}</button>`;
+    return `<button type="button" class="entry-type-tab${active}" data-entry-material="${esc(mat.name)}">${esc(mat.name)}</button>`;
   }).join('');
+  tabs.querySelectorAll('[data-entry-material]').forEach(btn => {
+    btn.addEventListener('click', () => setEntryMaterial(btn.dataset.entryMaterial || ''));
+  });
 }
 
 function setEntryMaterial(material) {

--- a/apps/PMC跟仓管/加工管理/pcba/static/style.css
+++ b/apps/PMC跟仓管/加工管理/pcba/static/style.css
@@ -531,6 +531,14 @@ tr.subtotal {
   background: #fefce8;
 }
 
+tr.reconcile-ok {
+  background: rgba(5, 150, 105, 0.07);
+}
+
+tr.reconcile-diff {
+  background: rgba(220, 38, 38, 0.07);
+}
+
 .app-page {
   min-height: 100vh;
 }
@@ -642,6 +650,46 @@ tr.subtotal {
 .form-grid.compact-form {
   grid-template-columns: repeat(5, minmax(150px, 1fr));
   max-width: 900px;
+}
+
+.reconcile-form {
+  max-width: 980px;
+}
+
+.file-upload-card {
+  height: 42px;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px;
+  border: 1px solid #cfd8e5;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.file-upload-trigger {
+  height: 32px;
+  flex: 0 0 auto;
+  padding: 0 13px;
+  border-radius: 7px;
+  color: #fff;
+  font-weight: 800;
+  background: linear-gradient(135deg, var(--primary), var(--cyan));
+  box-shadow: 0 8px 18px rgba(37, 99, 235, 0.18);
+}
+
+.file-upload-trigger:hover {
+  filter: brightness(0.98);
+}
+
+.file-upload-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--muted);
+  font-size: 13px;
 }
 
 .btn-sm {

--- a/apps/PMC跟仓管/加工管理/pcba/static/style.css
+++ b/apps/PMC跟仓管/加工管理/pcba/static/style.css
@@ -604,6 +604,11 @@ tr.subtotal {
   background: rgba(241, 245, 249, 0.78);
 }
 
+.entry-type-tabs.material-tabs {
+  margin-top: -6px;
+  background: rgba(255, 255, 255, 0.72);
+}
+
 .entry-type-tab {
   min-height: 38px;
   padding: 0 18px;

--- a/apps/PMC跟仓管/加工管理/requirements.txt
+++ b/apps/PMC跟仓管/加工管理/requirements.txt
@@ -2,5 +2,6 @@ fastapi==0.111.0
 uvicorn[standard]==0.30.1
 itsdangerous==2.2.0
 openpyxl==3.1.5
+xlrd==2.0.2
 pytest==8.2.2
 httpx==0.27.0

--- a/apps/PMC跟仓管/加工管理/tests/test_api_summary.py
+++ b/apps/PMC跟仓管/加工管理/tests/test_api_summary.py
@@ -120,6 +120,63 @@ def test_summary_is_scoped_to_current_department(client):
     assert s["subtotal"]["issue"] == 0
 
 
+def test_summary_includes_monthly_location_totals(client):
+    admin_login(client, "兴信B来料仓")
+    dg = loc_id(client, "东莞车间")
+    client.post("/api/records", json={
+        "rec_type": "inbound_raw", "rec_date": "2026-06-27", "qty": 40})
+    client.post("/api/records", json={
+        "rec_type": "inbound_raw", "rec_date": "2026-07-05", "qty": 60})
+    client.post("/api/records", json={
+        "rec_type": "issue", "location_id": dg, "rec_date": "2026-06-27", "qty": 10})
+    client.post("/api/records", json={
+        "rec_type": "issue", "location_id": dg, "rec_date": "2026-07-06", "qty": 20})
+
+    s = client.get("/api/summary").json()
+    monthly = s["monthly_locations"]
+    by_location = {row["location"]: row for row in monthly["locations"]}
+
+    assert [row["label"] for row in monthly["months"]] == [
+        "6月月结", "7月", "8月", "9月", "10月", "11月", "12月"]
+    assert by_location["东莞车间"]["issue"] == 30
+    assert by_location["东莞车间"]["values"][0] == {
+        "issue": 10, "finished": 0, "balance": 10}
+    assert by_location["东莞车间"]["values"][1] == {
+        "issue": 20, "finished": 0, "balance": 20}
+    assert monthly["subtotal"]["values"][0]["issue"] == 10
+    assert monthly["subtotal"]["values"][1]["issue"] == 20
+    assert monthly["raw"]["values"][0] == {
+        "inbound": 40, "outbound": 10, "balance": 30}
+    assert monthly["raw"]["values"][1] == {
+        "inbound": 60, "outbound": 20, "balance": 40}
+
+
+def test_monthly_location_summary_groups_by_material(client):
+    admin_login(client, "兴信B来料仓")
+    dg = loc_id(client, "东莞车间")
+    client.post("/api/records", json={
+        "rec_type": "issue", "location_id": dg, "rec_date": "2026-07-06",
+        "material": "77794-PCBA板", "qty": 20})
+    client.post("/api/records/batch", json={
+        "rec_type": "issue", "location_id": dg, "rec_date": "2026-07-06",
+        "material": "NFC贴纸",
+        "items": [
+            {"sticker_type": "1#NFC贴纸", "qty": 10},
+            {"sticker_type": "2#NFC贴纸", "qty": 15},
+        ],
+    })
+
+    s = client.get("/api/summary").json()
+    rows = {
+        (row["location"], row["material"]): row
+        for row in s["monthly_locations"]["locations"]
+    }
+
+    assert rows[("东莞车间", "77794-PCBA板")]["issue"] == 20
+    assert rows[("东莞车间", "NFC贴纸")]["issue"] == 25
+    assert rows[("东莞车间", "NFC贴纸")]["values"][1]["issue"] == 25
+
+
 def test_assembly_summary_subtracts_semi_finished(client):
     admin_login(client, "装配")
     dg = loc_id(client, "东莞加工厂利鸿")

--- a/apps/PMC跟仓管/加工管理/tests/test_export.py
+++ b/apps/PMC跟仓管/加工管理/tests/test_export.py
@@ -17,6 +17,10 @@ def loc_id(client, name):
     return next(l["id"] for l in locs if l["name"] == name)
 
 
+def summary_row(rows, scope, item):
+    return next(row for row in rows if row and row[0] == scope and row[1] == item)
+
+
 def test_export_returns_xlsx_with_summary(client):
     admin_login(client, "装配")
     sy = loc_id(client, "邵阳华登")
@@ -56,10 +60,42 @@ def test_export_is_scoped_to_current_department(client):
     r = client.get("/api/export")
     wb = openpyxl.load_workbook(io.BytesIO(r.content), data_only=True)
     rows = list(wb["总表"].iter_rows(values_only=True))
-    header_index = next(i for i, row in enumerate(rows) if row and row[0] == "来料仓入仓总数")
-    raw_row = rows[header_index + 1]
-    assert raw_row[0] == 5
-    assert raw_row[1] == 0
+    inbound_row = summary_row(rows, "来料仓", "入仓总数")
+    outbound_row = summary_row(rows, "来料仓", "出库总数")
+    assert inbound_row[2] == 5
+    assert inbound_row[3] == 5
+    assert outbound_row[2] == 0
+
+
+def test_xingxin_export_summary_is_split_by_month(client):
+    admin_login(client, "兴信B来料仓")
+    dg = loc_id(client, "东莞车间")
+    client.post("/api/records", json={
+        "rec_type": "inbound_raw", "rec_date": "2026-06-27", "qty": 40})
+    client.post("/api/records", json={
+        "rec_type": "inbound_raw", "rec_date": "2026-07-05", "qty": 60})
+    client.post("/api/records", json={
+        "rec_type": "issue", "location_id": dg, "rec_date": "2026-06-27", "qty": 10})
+    client.post("/api/records", json={
+        "rec_type": "issue", "location_id": dg, "rec_date": "2026-07-06", "qty": 20})
+
+    r = client.get("/api/export")
+    wb = openpyxl.load_workbook(io.BytesIO(r.content), data_only=True)
+    ws = wb["总表"]
+    rows = list(ws.iter_rows(values_only=True))
+    keyed = {(row[0], row[1]): row for row in rows if row and row[1]}
+
+    assert [ws.cell(row=2, column=col).value for col in range(1, 12)] == [
+        "范围", "项目", "累计总数", "6月月结", "7月", "8月",
+        "9月", "10月", "11月", "12月", "备注",
+    ]
+    assert keyed[("东莞车间", "领料数")][2:5] == (30, 10, 20)
+    assert keyed[("东莞车间", "成品完成数")][2:5] == (0, 0, 0)
+    assert keyed[("东莞车间", "应存数")][2:5] == (30, 10, 20)
+    assert keyed[("小计", "领料数")][2:5] == (30, 10, 20)
+    assert keyed[("来料仓", "入仓总数")][2:5] == (100, 40, 60)
+    assert keyed[("来料仓", "出库总数")][2:5] == (30, 10, 20)
+    assert keyed[("货仓", "应存")][2:5] == (70, 30, 40)
 
 
 def test_export_can_filter_by_date_range(client):
@@ -72,10 +108,10 @@ def test_export_can_filter_by_date_range(client):
     r = client.get("/api/export?date_from=2026-07-02&date_to=2026-07-31")
     wb = openpyxl.load_workbook(io.BytesIO(r.content), data_only=True)
     rows = list(wb["总表"].iter_rows(values_only=True))
-    header_index = next(i for i, row in enumerate(rows) if row and row[0] == "来料仓入仓总数")
-    raw_row = rows[header_index + 1]
+    raw_row = summary_row(rows, "来料仓", "入仓总数")
 
-    assert raw_row[0] == 20
+    assert raw_row[2] == 20
+    assert raw_row[4] == 20
 
 
 def test_export_can_filter_by_doc_no(client):
@@ -88,10 +124,10 @@ def test_export_can_filter_by_doc_no(client):
     r = client.get("/api/export?doc_no=KEEP")
     wb = openpyxl.load_workbook(io.BytesIO(r.content), data_only=True)
     rows = list(wb["总表"].iter_rows(values_only=True))
-    header_index = next(i for i, row in enumerate(rows) if row and row[0] == "来料仓入仓总数")
-    raw_row = rows[header_index + 1]
+    raw_row = summary_row(rows, "来料仓", "入仓总数")
 
-    assert raw_row[0] == 12
+    assert raw_row[2] == 12
+    assert raw_row[3] == 12
 
 
 def test_xingxin_export_detail_includes_supplier_column(client):
@@ -124,6 +160,26 @@ def test_export_includes_sticker_type_column_when_present(client):
     assert headers == ["日期", "单据编号", "物料名称", "贴纸类型", "供应商", "入仓数", "备注"]
     assert ws.cell(row=2, column=4).value == "1#NFC贴纸"
     assert ws.cell(row=2, column=6).value == 12
+
+
+def test_export_fills_legacy_opening_date_when_record_date_is_blank(client):
+    admin_login(client, "兴信B来料仓")
+    dg = loc_id(client, "东莞车间")
+    client.post("/api/records", json={
+        "rec_type": "issue",
+        "location_id": dg,
+        "material": "NFC贴纸",
+        "sticker_type": "1#NFC贴纸",
+        "doc_no": "1#NFC贴纸-东莞期初出仓",
+        "qty": 60,
+        "remark": "总表东莞期初出仓导入",
+    })
+
+    r = client.get("/api/export")
+    wb = openpyxl.load_workbook(io.BytesIO(r.content), data_only=True)
+    ws = wb["东莞车间领料"]
+
+    assert ws.cell(row=2, column=1).value == "2026-06-27"
 
 
 def test_non_xingxin_export_detail_omits_supplier_column(client):

--- a/apps/PMC跟仓管/加工管理/tests/test_import_export.py
+++ b/apps/PMC跟仓管/加工管理/tests/test_import_export.py
@@ -13,6 +13,11 @@ def login(client, username="admin", password="admin123", department=DEFAULT_DEPA
     )
 
 
+def loc_id(client, name):
+    locations = client.get("/api/locations").json()
+    return next(item["id"] for item in locations if item["name"] == name)
+
+
 def workbook_bytes(headers, rows):
     wb = openpyxl.Workbook()
     ws = wb.active
@@ -146,13 +151,15 @@ def legacy_supplier_pcba_workbook_bytes():
 
     issue_ws = wb.create_sheet("河源华兴领料")
     issue_ws.append(["日期", "领料单号", "物料名称", "领料数", "备注"])
+    issue_ws.append(["2026-06-30", 2518000, "77794-PCBA板", 18, None])
     issue_ws.append(["2026-07-02", 2518791, "77794-PCBA板", 30, None])
     issue_ws.append(["2026-07-03", "退不良品", "77794-PCBA板", -5, None])
-    issue_ws.append([None, None, "7月小计：", 25, None])
+    issue_ws.append([None, None, "7月小计：", 43, None])
 
     total_ws = wb.create_sheet("总表")
-    total_ws.append(["物料名称", None, "累计出入总数"])
-    total_ws.append(["PCB主板", "入仓总数", 180])
+    total_ws.append(["物料名称", None, "累计出入总数", "6月月结", "7月"])
+    total_ws.append(["PCB主板", "入仓总数", 175, 100, 75])
+    total_ws.append(["PCB主板", "河源华兴领料总数", 43, None, 43])
 
     buf = io.BytesIO()
     wb.save(buf)
@@ -236,6 +243,270 @@ def test_record_import_template_exports_expected_headers(client):
         "类型", "物料名称", "贴纸类型", "加工点", "供应商",
         "日期", "单据编号", "数量", "备注", "PO", "客名",
     ]
+
+
+def test_non_supplier_record_export_matches_import_template_headers(client):
+    login(client, "装配", "123456", "装配")
+    dongguan = loc_id(client, "东莞加工厂利鸿")
+    client.post("/api/records", json={
+        "rec_type": "issue",
+        "location_id": dongguan,
+        "material": "77794-PCBA板",
+        "rec_date": "2026-07-08",
+        "doc_no": "EXP-001",
+        "qty": 18,
+        "remark": "导出测试",
+    })
+
+    r = client.get("/api/records/export")
+    wb = openpyxl.load_workbook(io.BytesIO(r.content), data_only=True)
+    ws = wb.active
+    headers = [cell.value for cell in ws[1]]
+    first_row = [cell.value for cell in ws[2]]
+
+    assert r.status_code == 200
+    assert headers == [
+        "类型", "物料名称", "贴纸类型", "加工点", "供应商",
+        "日期", "单据编号", "数量", "备注", "PO", "客名",
+    ]
+    assert first_row == [
+        "领料", "77794-PCBA板", None, "东莞加工厂利鸿", None,
+        "2026-07-08", "EXP-001", 18, "导出测试", None, None,
+    ]
+
+
+def test_xingxin_pcba_export_uses_legacy_warehouse_workbook(client):
+    login(client, "兴信B来料仓", "123456", DEFAULT_DEPARTMENT)
+    heyuan = loc_id(client, "河源华兴")
+    client.post("/api/records", json={
+        "rec_type": "inbound_raw",
+        "material": "77794-PCBA板",
+        "rec_date": "2026-07-01",
+        "doc_no": "RK-PCBA-1",
+        "qty": 40,
+        "remark": "入仓测试",
+    })
+    client.post("/api/records", json={
+        "rec_type": "issue",
+        "location_id": heyuan,
+        "material": "77794-PCBA板",
+        "rec_date": "2026-07-02",
+        "doc_no": "LL-PCBA-1",
+        "qty": 25,
+        "remark": "领料测试",
+    })
+
+    r = client.get("/api/records/export?material=77794-PCBA板")
+    wb = openpyxl.load_workbook(io.BytesIO(r.content), data_only=True)
+
+    assert r.status_code == 200
+    assert wb.sheetnames[:7] == [
+        "总表", "入仓明细", "邵阳华登领料", "河源华兴领料",
+        "加工厂利鸿领料", "东莞车间领料", "Sheet2",
+    ]
+    assert [cell.value for cell in wb["入仓明细"][1]] == [
+        "日期", "入仓单号", "物料名称", "入仓数", "备注"]
+    assert [cell.value for cell in wb["河源华兴领料"][1]] == [
+        "日期", "领料单号", "物料名称", "领料数", "备注"]
+    assert wb["入仓明细"].cell(2, 2).value == "RK-PCBA-1"
+    assert wb["入仓明细"].cell(2, 4).value == 40
+    assert wb["河源华兴领料"].cell(2, 2).value == "LL-PCBA-1"
+    assert wb["河源华兴领料"].cell(2, 4).value == 25
+    total = wb["总表"]
+    assert [total.cell(1, col).value for col in range(1, 12)] == [
+        "物料名称", None, "累计出入总数", "6月月结", "7月", "8月",
+        "9月", "10月", "11月", "12月", "备注",
+    ]
+    assert [total.cell(row, 2).value for row in range(2, 9)] == [
+        "入仓总数", "邵阳华登领料总数", "河源华兴领料总数",
+        "加工厂利鸿领料总数", "东莞车间领料", None, "应存数",
+    ]
+    assert total.cell(2, 1).value == "PCB主板"
+    assert total.cell(2, 3).value == 40
+    assert total.cell(2, 5).value == 40
+    assert total.cell(4, 3).value == 25
+    assert total.cell(4, 5).value == 25
+    assert total.cell(8, 3).value == 15
+    assert total.cell(8, 4).value == 0
+    assert total.cell(8, 5).value == 15
+
+
+def test_xingxin_nfc_export_uses_legacy_matrix_workbook(client):
+    login(client, "兴信B来料仓", "123456", DEFAULT_DEPARTMENT)
+    dongguan = loc_id(client, "东莞车间")
+    client.post("/api/records/batch", json={
+        "rec_type": "inbound_raw",
+        "material": "NFC贴纸",
+        "rec_date": "2026-07-01",
+        "doc_no": "RK-NFC-1",
+        "items": [{"sticker_type": "1#NFC贴纸", "qty": 50}],
+    })
+    client.post("/api/records/batch", json={
+        "rec_type": "issue",
+        "location_id": dongguan,
+        "material": "NFC贴纸",
+        "rec_date": "2026-07-02",
+        "doc_no": "CK-NFC-1",
+        "items": [{"sticker_type": "1#NFC贴纸", "qty": 20}],
+    })
+
+    r = client.get("/api/records/export?material=NFC贴纸")
+    wb = openpyxl.load_workbook(io.BytesIO(r.content), data_only=True)
+
+    assert r.status_code == 200
+    assert wb.sheetnames[:3] == ["总表", "入库明细", "出库明细"]
+    assert wb["总表"].cell(1, 2).value == "累计入仓总数"
+    assert wb["总表"].cell(2, 1).value == "物料名称"
+    assert wb["总表"].cell(3, 1).value == "1#NFC\n贴纸"
+    assert wb["总表"].cell(3, 2).value == 50
+    assert wb["总表"].cell(3, 11).value == 30
+    assert wb["总表"].cell(3, 12).value == 20
+    assert wb["入库明细"].cell(1, 2).value == "当月入仓总数"
+    assert wb["入库明细"].cell(2, 1).value == "物料名称"
+    assert wb["入库明细"].cell(2, 3).value == "RK-NFC-1"
+    assert wb["入库明细"].cell(3, 2).value == 50
+    assert wb["入库明细"].cell(3, 3).value == 50
+    assert wb["出库明细"].cell(1, 2).value == "当月出仓总数"
+    assert wb["出库明细"].cell(2, 3).value == "CK-NFC-1"
+    assert wb["出库明细"].cell(3, 2).value == 20
+    assert wb["出库明细"].cell(3, 3).value == 20
+
+
+def test_xingxin_nfc_record_export_fills_legacy_opening_date(client):
+    login(client, "兴信B来料仓", "123456", DEFAULT_DEPARTMENT)
+    dongguan = loc_id(client, "东莞车间")
+    client.post("/api/records", json={
+        "rec_type": "issue",
+        "location_id": dongguan,
+        "material": "NFC贴纸",
+        "sticker_type": "1#NFC贴纸",
+        "doc_no": "1#NFC贴纸-东莞期初出仓",
+        "qty": 60,
+        "remark": "总表东莞期初出仓导入",
+    })
+
+    r = client.get("/api/records/export?material=NFC贴纸")
+    wb = openpyxl.load_workbook(io.BytesIO(r.content), data_only=True)
+
+    assert r.status_code == 200
+    assert wb["出库明细"].cell(1, 3).value == "2026-06-27"
+
+
+def test_semi_finished_export_uses_legacy_matrix_workbook(client):
+    login(client, "半成品", "123456", "半成品")
+    upload = upload_bytes(client, "/api/records/import", legacy_semi_finished_workbook_bytes())
+    assert upload.status_code == 200
+
+    r = client.get("/api/records/export?material=NFC贴纸")
+    wb = openpyxl.load_workbook(io.BytesIO(r.content), data_only=True)
+
+    assert r.status_code == 200
+    assert wb.sheetnames[:5] == [
+        "总表", "入库明细", "邵阳领料", "河源华兴36#CD领料", "车间36#CD领料"]
+    assert wb["总表"].cell(1, 2).value == "累计入仓总数"
+    assert wb["总表"].cell(1, 11).value == "应存数"
+    assert wb["总表"].cell(3, 1).value == "1#NFC\n贴纸"
+    assert wb["总表"].cell(3, 2).value == 100
+    assert wb["总表"].cell(3, 11).value == 60
+    assert wb["总表"].cell(3, 12).value == 40
+
+    inbound = wb["入库明细"]
+    assert inbound.cell(1, 4).value == "日期"
+    assert inbound.cell(2, 4).value == "入库单号"
+    assert inbound.cell(3, 1).value == "物料名称"
+    assert inbound.cell(3, 2).value == "当月入仓总数"
+    assert inbound.cell(3, 3).value == "6/24\n装配入库截数"
+    assert inbound.cell(4, 1).value == "1#NFC\n贴纸"
+    assert inbound.cell(4, 2).value == 100
+    assert inbound.cell(4, 3).value == 25
+    assert inbound.cell(1, 5).value == "2026-07-01"
+    assert inbound.cell(2, 5).value == "RK-001"
+    assert inbound.cell(4, 5).value == 30
+
+    outbound = wb["邵阳领料"]
+    assert outbound.cell(5, 1).value == "物料名称"
+    assert outbound.cell(5, 2).value == "当月出仓总数"
+    assert outbound.cell(6, 1).value == "1#NFC\n贴纸"
+    assert outbound.cell(6, 2).value == 40
+    assert outbound.cell(6, 3).value == 25
+    assert outbound.cell(1, 4).value == "2026-07-03"
+    assert outbound.cell(2, 4).value == "LL-001"
+    assert outbound.cell(6, 4).value == 35
+
+
+def test_outsource_record_export_uses_legacy_pcba_workbook(client):
+    login(client, "外发", "123456", "外发")
+    client.post("/api/records", json={
+        "rec_type": "issue",
+        "material": "77794-PCBA板",
+        "rec_date": "2026-07-01",
+        "doc_no": "LL-LH-001",
+        "qty": 100,
+    })
+    client.post("/api/records", json={
+        "rec_type": "semi_finished",
+        "material": "77794-PCBA板",
+        "rec_date": "2026-07-02",
+        "doc_no": "BS-LH-001",
+        "qty": 35,
+        "remark": "LH202607 77794 光身唱机",
+    })
+
+    r = client.get("/api/records/export?material=77794-PCBA板")
+    wb = openpyxl.load_workbook(io.BytesIO(r.content), data_only=True)
+
+    assert r.status_code == 200
+    assert wb.sheetnames[:3] == ["总表", "领料明细", "半成品入仓明细"]
+    assert [cell.value for cell in wb["领料明细"][1][:5]] == [
+        "日期", "领料编号", "物料名称", "领料数", "备注"]
+    assert [cell.value for cell in wb["半成品入仓明细"][1][:7]] == [
+        "日期", "送货单号", "合同号", "货号", "品名/规格", "数量（pcs）", "备注"]
+    assert wb["领料明细"].cell(2, 2).value == "LL-LH-001"
+    assert wb["领料明细"].cell(2, 4).value == 100
+    assert wb["半成品入仓明细"].cell(2, 2).value == "BS-LH-001"
+    assert wb["半成品入仓明细"].cell(2, 6).value == 35
+    assert wb["总表"].cell(2, 2).value == "领料总数"
+    assert wb["总表"].cell(2, 3).value == 100
+    assert wb["总表"].cell(3, 2).value == "半成品入仓总数"
+    assert wb["总表"].cell(3, 3).value == 35
+
+
+def test_heyuan_record_export_uses_legacy_pcba_workbook(client):
+    login(client, "河源华兴", "123456", "河源华兴")
+    heyuan = loc_id(client, "河源华兴")
+    client.post("/api/records", json={
+        "rec_type": "issue",
+        "location_id": heyuan,
+        "material": "77794-PCBA板",
+        "rec_date": "2026-07-03",
+        "doc_no": "LL-HY-001",
+        "qty": 88,
+    })
+    client.post("/api/records", json={
+        "rec_type": "finished",
+        "location_id": heyuan,
+        "material": "77794-PCBA板",
+        "rec_date": "2026-07-04",
+        "doc_no": "BS-HY-001",
+        "qty": 66,
+        "remark": "HY202607 77794 光身唱机",
+    })
+
+    r = client.get("/api/records/export?material=77794-PCBA板")
+    wb = openpyxl.load_workbook(io.BytesIO(r.content), data_only=True)
+
+    assert r.status_code == 200
+    assert wb.sheetnames[:4] == ["总表", "36#CD领料明细", "PCB板领料明细", "成品入仓明细"]
+    assert [cell.value for cell in wb["PCB板领料明细"][1][:5]] == [
+        "日期", "领料编号", "物料名称", "领料数", "备注"]
+    assert [cell.value for cell in wb["成品入仓明细"][1][:7]] == [
+        "日期", "送货单号", "合同号", "货号", "品名/规格", "数量（pcs）", "备注"]
+    assert wb["PCB板领料明细"].cell(2, 2).value == "LL-HY-001"
+    assert wb["PCB板领料明细"].cell(2, 4).value == 88
+    assert wb["成品入仓明细"].cell(2, 2).value == "BS-HY-001"
+    assert wb["成品入仓明细"].cell(2, 6).value == 66
+    assert wb["总表"].cell(2, 1).value == "PCBA主板"
+    assert wb["总表"].cell(2, 2).value == 88
 
 
 def test_operator_can_import_record_rows_from_xlsx(client):
@@ -365,7 +636,7 @@ def test_supplier_pcba_legacy_workbook_imports_inbound_and_issue_rows(client):
     records = client.get("/api/records").json()
 
     assert r.status_code == 200
-    assert r.json()["created"] == 6
+    assert r.json()["created"] == 7
     assert [row["qty"] for row in records if row["doc_no"] == "2534693"] == [40, 40]
     by_type_doc = {(row["rec_type"], row["doc_no"]): row for row in records}
     assert by_type_doc[("inbound_raw", "截止到6月17号")]["qty"] == 100
@@ -374,16 +645,22 @@ def test_supplier_pcba_legacy_workbook_imports_inbound_and_issue_rows(client):
     assert by_type_doc[("issue", "退不良品")]["qty"] == -5
 
     summary = client.get("/api/summary").json()
-    assert summary["raw"] == {"inbound": 175, "outbound": 25, "balance": 150}
+    assert summary["raw"] == {"inbound": 175, "outbound": 43, "balance": 132}
     assert summary["materials"] == [
-        {"material": "77794-PCBA板", "inbound": 175, "outbound": 25, "balance": 150}
+        {"material": "77794-PCBA板", "inbound": 175, "outbound": 43, "balance": 132}
     ]
+    monthly_rows = {
+        (row["location"], row["material"]): row
+        for row in summary["monthly_locations"]["locations"]
+    }
+    assert monthly_rows[("河源华兴", "77794-PCBA板")]["values"][0]["issue"] == 0
+    assert monthly_rows[("河源华兴", "77794-PCBA板")]["values"][1]["issue"] == 43
 
     second = upload_bytes(client, "/api/records/import", legacy_supplier_pcba_workbook_bytes())
     assert second.status_code == 200
     assert second.json()["created"] == 0
-    assert second.json()["skipped"] == 6
-    assert len(client.get("/api/records").json()) == 6
+    assert second.json()["skipped"] == 7
+    assert len(client.get("/api/records").json()) == 7
 
 
 def test_supplier_nfc_legacy_workbook_imports_opening_and_detail_rows(client):
@@ -398,6 +675,9 @@ def test_supplier_nfc_legacy_workbook_imports_opening_and_detail_rows(client):
     assert rows[("inbound_raw", "1#NFC贴纸-期初入仓")]["qty"] == 100
     assert rows[("issue", "1#NFC贴纸-东莞期初出仓")]["qty"] == 60
     assert rows[("issue", "1#NFC贴纸-邵阳期初领料")]["qty"] == 15
+    assert rows[("inbound_raw", "1#NFC贴纸-期初入仓")]["rec_date"] == "2026-06-27"
+    assert rows[("issue", "1#NFC贴纸-东莞期初出仓")]["rec_date"] == "2026-06-27"
+    assert rows[("issue", "1#NFC贴纸-邵阳期初领料")]["rec_date"] == "2026-06-27"
     assert rows[("issue", "CK-1")]["location_name"] == "东莞车间"
     assert all(row["sticker_type"] == "1#NFC贴纸" for row in records)
 

--- a/apps/PMC跟仓管/加工管理/tests/test_shaoyang_reconcile.py
+++ b/apps/PMC跟仓管/加工管理/tests/test_shaoyang_reconcile.py
@@ -1,0 +1,117 @@
+import io
+
+import openpyxl
+
+
+def admin_login(client, department="邵阳"):
+    client.post(
+        "/api/login",
+        json={"username": "admin", "password": "admin123", "department": department},
+    )
+
+
+def _workbook_bytes(wb):
+    buf = io.BytesIO()
+    wb.save(buf)
+    return buf.getvalue()
+
+
+def _shaoyang_issue_workbook():
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "总表"
+    ws.cell(1, 13).value = "累计入仓数"
+    ws.cell(1, 15).value = "7月成品\n入仓总数"
+    ws.cell(2, 1).value = "物料名称"
+    ws.cell(3, 1).value = "1#NFC\n贴纸"
+    ws.cell(3, 13).value = 12
+    ws.cell(3, 15).value = 12
+    ws.cell(4, 1).value = "2#NFC\n贴纸"
+    ws.cell(4, 13).value = 5
+    ws.cell(4, 15).value = 5
+    ws.cell(5, 1).value = "小计："
+    ws.cell(5, 15).value = 17
+    return _workbook_bytes(wb)
+
+
+def _shaoyang_finished_workbook():
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "总表"
+    ws.append(["Sku No.", "Item No.", "Minis Name", "Catalogue", "小计"])
+    ws.append([77772, "VINYL-S1-001", "Song A", "C1", 12])
+    ws.append([77772, "VINYL-S1-002", "Song B", "C1", 7])
+    return _workbook_bytes(wb)
+
+
+def test_shaoyang_reconcile_maps_sticker_number_to_vinyl_item(client):
+    admin_login(client)
+
+    r = client.post(
+        "/api/shaoyang-cd/reconcile",
+        data={"month": "7"},
+        files={
+            "issue_file": (
+                "issue.xlsx",
+                _shaoyang_issue_workbook(),
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            ),
+            "finished_file": (
+                "finished.xlsx",
+                _shaoyang_finished_workbook(),
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            ),
+        },
+    )
+
+    assert r.status_code == 200
+    data = r.json()
+    rows = {row["sticker_no"]: row for row in data["rows"]}
+    assert data["month"] == 7
+    assert data["totals"] == {
+        "issue_month_inbound": 17,
+        "finished_total": 19,
+        "difference": 2,
+    }
+    assert rows[1]["sticker_name"] == "1#NFC贴纸"
+    assert rows[1]["item_no"] == "VINYL-S1-001"
+    assert rows[1]["minis_name"] == "Song A"
+    assert rows[1]["issue_month_inbound"] == 12
+    assert rows[1]["finished_total"] == 12
+    assert rows[1]["difference"] == 0
+    assert rows[2]["sticker_name"] == "2#NFC贴纸"
+    assert rows[2]["item_no"] == "VINYL-S1-002"
+    assert rows[2]["issue_month_inbound"] == 5
+    assert rows[2]["finished_total"] == 7
+    assert rows[2]["difference"] == 2
+
+
+def test_shaoyang_export_issue_workbook_fills_month_inbound_from_finished_subtotal(client):
+    admin_login(client)
+
+    r = client.post(
+        "/api/shaoyang-cd/export-issue",
+        data={"month": "7"},
+        files={
+            "issue_file": (
+                "issue.xlsx",
+                _shaoyang_issue_workbook(),
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            ),
+            "finished_file": (
+                "finished.xlsx",
+                _shaoyang_finished_workbook(),
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            ),
+        },
+    )
+
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith(
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    )
+    wb = openpyxl.load_workbook(io.BytesIO(r.content), data_only=True)
+    ws = wb["总表"]
+    assert ws.cell(3, 15).value == 12
+    assert ws.cell(4, 15).value == 7
+    assert ws.cell(5, 15).value == 19

--- a/apps/PMC跟仓管/加工管理/tests/test_static_entry_subpages.py
+++ b/apps/PMC跟仓管/加工管理/tests/test_static_entry_subpages.py
@@ -59,6 +59,16 @@ def test_entry_records_are_filtered_by_active_type():
     assert "x.material === ACTIVE_ENTRY_MATERIAL" in js
 
 
+def test_entry_tabs_bind_clicks_without_inline_material_arguments():
+    js = (ROOT / "pcba/static/app.js").read_text(encoding="utf-8")
+
+    assert 'data-entry-type="${esc(opt.value)}"' in js
+    assert "addEventListener('click', () => setEntryType" in js
+    assert 'data-entry-material="${esc(mat.name)}"' in js
+    assert "addEventListener('click', () => setEntryMaterial" in js
+    assert "onclick=\"setEntryMaterial('${esc(mat.name)}')\"" not in js
+
+
 def test_summary_page_prefers_monthly_location_totals():
     js = (ROOT / "pcba/static/app.js").read_text(encoding="utf-8")
 

--- a/apps/PMC跟仓管/加工管理/tests/test_static_entry_subpages.py
+++ b/apps/PMC跟仓管/加工管理/tests/test_static_entry_subpages.py
@@ -8,13 +8,18 @@ def test_entry_page_exposes_type_subpage_container():
     html = (ROOT / "pcba/static/app.html").read_text(encoding="utf-8")
 
     assert 'id="entryTypeTabs"' in html
+    assert 'id="entryMaterialTabs"' in html
     assert 'id="recType" style="display:none"' in html
+    assert 'id="material" title="物料名称" style="display:none"' in html
 
 
 def test_entry_records_are_filtered_by_active_type():
     js = (ROOT / "pcba/static/app.js").read_text(encoding="utf-8")
 
     assert "let ACTIVE_ENTRY_TYPE" in js
+    assert "let ACTIVE_ENTRY_MATERIAL" in js
     assert "function setEntryType(type)" in js
+    assert "function setEntryMaterial(material)" in js
     assert "function renderRecordsTable()" in js
     assert "x.rec_type === ACTIVE_ENTRY_TYPE" in js
+    assert "x.material === ACTIVE_ENTRY_MATERIAL" in js

--- a/apps/PMC跟仓管/加工管理/tests/test_static_entry_subpages.py
+++ b/apps/PMC跟仓管/加工管理/tests/test_static_entry_subpages.py
@@ -4,6 +4,36 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 
 
+def test_shaoyang_reconcile_has_separate_page_controls():
+    html = (ROOT / "pcba/static/app.html").read_text(encoding="utf-8")
+    js = (ROOT / "pcba/static/app.js").read_text(encoding="utf-8")
+
+    assert 'data-tab="shaoyangReconcile"' in html
+    assert 'id="shaoyangReconcile"' in html
+    assert 'id="shaoyangIssueFile"' in html
+    assert 'id="shaoyangFinishedFile"' in html
+    assert 'onclick="exportShaoyangIssueWorkbook()"' in html
+    assert "function reconcileShaoyangCd()" in js
+    assert "function exportShaoyangIssueWorkbook()" in js
+    assert "/api/shaoyang-cd/reconcile" in js
+    assert "/api/shaoyang-cd/export-issue" in js
+    assert "'shaoyangReconcile'" in js
+
+
+def test_shaoyang_reconcile_uses_modern_file_buttons():
+    html = (ROOT / "pcba/static/app.html").read_text(encoding="utf-8")
+    js = (ROOT / "pcba/static/app.js").read_text(encoding="utf-8")
+    css = (ROOT / "pcba/static/style.css").read_text(encoding="utf-8")
+
+    assert 'class="file-upload-card"' in html
+    assert 'id="shaoyangIssueFileName"' in html
+    assert 'id="shaoyangFinishedFileName"' in html
+    assert 'onclick="chooseImportFile(\'shaoyangIssueFile\')"' in html
+    assert 'onchange="updateFileName(\'shaoyangIssueFile\', \'shaoyangIssueFileName\')"' in html
+    assert "function updateFileName(inputId, labelId)" in js
+    assert ".file-upload-trigger" in css
+
+
 def test_entry_page_exposes_type_subpage_container():
     html = (ROOT / "pcba/static/app.html").read_text(encoding="utf-8")
 
@@ -11,6 +41,7 @@ def test_entry_page_exposes_type_subpage_container():
     assert 'id="entryMaterialTabs"' in html
     assert 'id="recType" style="display:none"' in html
     assert 'id="material" title="物料名称" style="display:none"' in html
+    assert 'onclick="exportRecords()"' in html
 
 
 def test_entry_records_are_filtered_by_active_type():
@@ -20,6 +51,43 @@ def test_entry_records_are_filtered_by_active_type():
     assert "let ACTIVE_ENTRY_MATERIAL" in js
     assert "function setEntryType(type)" in js
     assert "function setEntryMaterial(material)" in js
+    assert "function withEntryExportFilters(path)" in js
+    assert "params.set('material', ACTIVE_ENTRY_MATERIAL)" in js
+    assert "function exportRecords()" in js
     assert "function renderRecordsTable()" in js
     assert "x.rec_type === ACTIVE_ENTRY_TYPE" in js
     assert "x.material === ACTIVE_ENTRY_MATERIAL" in js
+
+
+def test_summary_page_prefers_monthly_location_totals():
+    js = (ROOT / "pcba/static/app.js").read_text(encoding="utf-8")
+
+    assert "function renderMonthlyLocationSummary(summary)" in js
+    assert "s.monthly_locations" in js
+
+
+def test_monthly_summary_hides_zero_quantities():
+    js = (ROOT / "pcba/static/app.js").read_text(encoding="utf-8")
+
+    assert "function fmtNonZero(n)" in js
+    assert "return value ? fmt(value) : '';" in js
+    assert "fmtNonZero((values[index] || {})[key])" in js
+    assert "fmtNonZero(total)" in js
+
+
+def test_monthly_summary_skips_rows_without_quantities():
+    js = (ROOT / "pcba/static/app.js").read_text(encoding="utf-8")
+
+    assert "function hasMonthlyQuantity(total, values, key)" in js
+    assert "return (values || []).some(value => Number(((value || {})[key]) || 0) !== 0);" in js
+    assert "if (!hasMonthlyQuantity(total, values, key)) return '';" in js
+
+
+def test_monthly_summary_shows_material_name():
+    js = (ROOT / "pcba/static/app.js").read_text(encoding="utf-8")
+
+    assert "<th>物料名称</th>" in js
+    assert "dataRow(row.location, row.material" in js
+    assert "<td>${esc(material || '')}</td>" in js
+    assert "6月月结" in js
+    assert "累计总数" in js


### PR DESCRIPTION
## 变更内容
- 将加工管理完善为唱片机管理系统的分部门业务流程
- 登录和页面支持部门选择、权限、公开汇总、修改密码和现代化 UI
- 补齐来料仓、半成品、外发、河源、邵阳等导入导出旧表格式
- 新增邵阳成品核对页面，并支持导出自动回填成品入仓数的领料表
- 支持贴纸类型多选录入、NFC 贴纸 1#-45# 物料名称、PCBA/NFC 分开导出

## 验证
- python -m pytest tests -q：142 passed
- node --check pcba/static/app.js
- git diff --check