### PR TITLE
Fix internal quote Libao category split

### DIFF
--- a/apps/业务部/内部报价系统/backend/services/exportXlsx.js
+++ b/apps/业务部/内部报价系统/backend/services/exportXlsx.js
@@ -10,7 +10,7 @@ const HKD4 = '"HK$"#,##0.0000';
 const PCT = '0.00%';
 const FONT = 'Microsoft YaHei';  // 全表统一字体
 // 辅助/包装材料 类别 — 减税明细各外购项按此类别统计（须与前端 workbench.js MAT_CATEGORIES 一致）
-const MAT_CATEGORIES = ['吸塑', '胶袋', '彩盒/内咭', '电池', '利宝', '电镀', '其他外购'];
+const MAT_CATEGORIES = ['吸塑', '胶袋', '彩盒/内咭', '电池', '产品利宝', '彩盒利宝', '电镀', '其他外购'];
 
 // 工具
 const num = (v) => Number(v) || 0;
@@ -1774,6 +1774,7 @@ function renderTaxSummary(ws, row, sales, extra = {}) {
   const _isGlueBag = s => /胶袋|胶代|poly\s?bag|pe\s?bag|opp\s?bag/i.test(String(s || ''));
   const _isBat     = s => /电池|battery/i.test(String(s || ''));
   const _isLib     = s => /利宝|贴纸|libao|sticker/i.test(String(s || ''));
+  const _isColorBoxLib = r => /彩盒|彩卡|内咭|内卡|背卡|包装|package|box/i.test(String((r.name || '') + ' ' + (r.spec || '')));
   const _isPlate   = s => /电镀|plating/i.test(String(s || ''));
   const _isCarton  = s => /纸箱|carton/i.test(String(s || ''));
   const _row = (fn, r) => fn(r.name) || fn(r.spec);
@@ -1783,10 +1784,11 @@ function renderTaxSummary(ws, row, sales, extra = {}) {
   // 辅助/包装 行的类别：显式 category 优先，否则关键字兜底（纸箱 → null 单独计），与前端 _catOf 一致
   const _catOf = (r, tbl) => {
     if (r.category && MAT_CATEGORIES.includes(r.category)) return r.category;
+    if (r.category === '利宝') return '产品利宝';
     if (_row(_isBlister, r)) return '吸塑';
     if (_row(_isGlueBag, r)) return '胶袋';
     if (_row(_isBat, r))     return '电池';
-    if (_row(_isLib, r))     return '利宝';
+    if (_row(_isLib, r))     return _isColorBoxLib(r) ? '彩盒利宝' : '产品利宝';
     if (_row(_isPlate, r))   return '电镀';
     if (_row(_isCarton, r))  return null;  // 纸箱另算
     return tbl === 'aux' ? '其他外购' : '彩盒/内咭';
@@ -1802,7 +1804,7 @@ function renderTaxSummary(ws, row, sales, extra = {}) {
   const blisterCells = [...byCat('吸塑'), ..._pick('electronic', _isBlister), ..._pick('hardware', _isBlister)];
   const glueBagCells  = byCat('胶袋');
   const batteryCells  = byCat('电池');
-  const libaoCells    = byCat('利宝');
+  const libaoCells    = [...byCat('产品利宝'), ...byCat('彩盒利宝')];
   const platingCells  = byCat('电镀');
   const colorBoxCells = byCat('彩盒/内咭');
   const otherBuyCells = byCat('其他外购');

--- a/apps/业务部/内部报价系统/frontend/workbench.js
+++ b/apps/业务部/内部报价系统/frontend/workbench.js
@@ -176,7 +176,7 @@ function renderTable(container, columns, rows, opts = {}) {
 }
 
 // 辅助/包装材料 类别 — 减税明细各外购项按此类别统计
-const MAT_CATEGORIES = ['吸塑', '胶袋', '彩盒/内咭', '电池', '利宝', '电镀', '其他外购'];
+const MAT_CATEGORIES = ['吸塑', '胶袋', '彩盒/内咭', '电池', '产品利宝', '彩盒利宝', '电镀', '其他外购'];
 
 // 车缝：人工若已作为明细行(名称含"人工")计入，则不再额外加 labor_amount，避免双算
 function sewLaborToAdd(g) {
@@ -1046,6 +1046,7 @@ function renderSummaryPane(host, sections, quote, me) {
   // 分类关键字（用于无显式类别时兜底）
   const _isBat = (s) => /电池|battery/i.test(String(s || ''));
   const _isLib = (s) => /利宝|贴纸|libao|sticker/i.test(String(s || ''));
+  const _isColorBoxLib = (r) => /彩盒|彩卡|内咭|内卡|背卡|包装|package|box/i.test(String((r.name || '') + ' ' + (r.spec || '')));
   const _isPlate = (s) => /电镀|plating/i.test(String(s || ''));
   const _isCarton = (s) => /纸箱|carton/i.test(String(s || ''));
   // 马达：电子/五金里含 "马达" / "motor" 的行（电子/五金表不设类别下拉，仍按关键字）
@@ -1063,11 +1064,12 @@ function renderSummaryPane(host, sections, quote, me) {
   // tbl='aux'|'pk'：返回行所属类别（合法 MAT_CATEGORIES 之一），纸箱返回 null（单独计），否则按表默认兜底
   const _catOf = (r, tbl) => {
     if (r.category && MAT_CATEGORIES.includes(r.category)) return r.category;
+    if (r.category === '利宝') return '产品利宝';
     const a = r.name, b = r.spec;
     if (isBlister(a) || isBlister(b)) return '吸塑';
     if (isGlueBag(a) || isGlueBag(b)) return '胶袋';
     if (_isBat(a) || _isBat(b)) return '电池';
-    if (_isLib(a) || _isLib(b)) return '利宝';
+    if (_isLib(a) || _isLib(b)) return _isColorBoxLib(r) ? '彩盒利宝' : '产品利宝';
     if (_isPlate(a) || _isPlate(b)) return '电镀';
     if (_isCarton(a) || _isCarton(b)) return null;  // 纸箱另算
     return tbl === 'aux' ? '其他外购' : '彩盒/内咭';
@@ -1079,7 +1081,7 @@ function renderSummaryPane(host, sections, quote, me) {
   const blisterRmb = _catSum('吸塑') + _sumByMatch(elecSrc, isBlister) + _sumByMatch(eng.hardware, isBlister);
   const glueBagRmb = _catSum('胶袋');
   const batteryRmb = _catSum('电池');
-  const libaoRmb = _catSum('利宝');
+  const libaoRmb = _catSum('产品利宝') + _catSum('彩盒利宝');
   const platingRmb = _catSum('电镀');
   const colorBoxRmb = _catSum('彩盒/内咭');
   const otherBuyRmb = _catSum('其他外购');
@@ -1757,6 +1759,11 @@ function renderEngineering(host, payload, canEdit, onChange, fxRmbHkd, fxRmbUsd)
   payload.hardware = payload.hardware || [];
   payload.aux_materials = payload.aux_materials || [];
   payload.packaging_materials = payload.packaging_materials || [];
+  const migrateLibaoCategory = rows => (rows || []).forEach(r => {
+    if (r && r.category === '利宝') r.category = '产品利宝';
+  });
+  migrateLibaoCategory(payload.aux_materials);
+  migrateLibaoCategory(payload.packaging_materials);
   payload.packaging_loss_pct = payload.packaging_loss_pct ?? 1;
   payload.electronics_loss_pct = payload.electronics_loss_pct ?? 1;
   payload.hardware_loss_pct = payload.hardware_loss_pct ?? 1;


### PR DESCRIPTION
## Summary
- Split material category options from the old single 利宝 into 产品利宝 and 彩盒利宝.
- Migrate existing row category value 利宝 to 产品利宝 when rendering material tables.
- Keep downstream 包装/外购 and export tax summary as one 利宝 column, summing 产品利宝 + 彩盒利宝.

## Checks
- node --check apps/业务部/内部报价系统/frontend/workbench.js
- node --check apps/业务部/内部报价系统/backend/services/exportXlsx.js
- git diff --check