### PR TITLE
绑定出库目标部门并自动同步入库

### DIFF
--- a/apps/PMC跟仓管/加工管理/pcba/main.py
+++ b/apps/PMC跟仓管/加工管理/pcba/main.py
@@ -744,6 +744,11 @@ def _parse_legacy_semi_finished_workbook(conn, wb, department):
         if not header_row:
             continue
 
+        location_id = None
+        if rec_type == "semi_outbound":
+            location_id = _location_id_from_name(
+                conn, _legacy_location_from_sheet(ws.title), 1
+            )
         detail_columns = _legacy_detail_columns(ws)
         monthly_col = _legacy_monthly_column(ws, header_row, monthly_header)
         opening_stock_columns = _legacy_opening_stock_columns(ws, header_row)
@@ -812,6 +817,7 @@ def _parse_legacy_semi_finished_workbook(conn, wb, department):
                     doc_no=doc_no,
                     material=NFC_MATERIAL,
                     sticker_type=sticker_type,
+                    location_id=location_id,
                     qty=qty,
                     remark=f"{ws.title}导入",
                 )
@@ -928,7 +934,7 @@ def _add_record_body(bodies, body, department, validate_positive=True):
     bodies.append(body)
 
 
-def _parse_legacy_outsource_workbook(wb, department):
+def _parse_legacy_outsource_workbook(conn, wb, department):
     if not _is_outsource_department(department):
         raise HTTPException(status_code=400, detail="东莞加工厂台账只能在对应加工厂部门导入")
 
@@ -953,6 +959,7 @@ def _parse_legacy_outsource_workbook(wb, department):
                 doc_no = _cell_text(date_value)
             body = RecordIn(
                 rec_type="issue",
+                location_id=_location_id_from_name(conn, department, 1),
                 rec_date=_outsource_date_value(date_value),
                 doc_no=doc_no,
                 material=_normalize_pcba_material(material),
@@ -1027,6 +1034,7 @@ def _parse_legacy_outsource_nfc_workbook(conn, wb, department):
         "领料明细": "issue",
         "入仓明细": "finished",
     }
+    issue_location_id = _location_id_from_name(conn, department, 1)
     for sheet_name, rec_type in sheet_types.items():
         if sheet_name not in wb.sheetnames:
             continue
@@ -1046,6 +1054,7 @@ def _parse_legacy_outsource_nfc_workbook(conn, wb, department):
                     continue
                 body = RecordIn(
                     rec_type=rec_type,
+                    location_id=issue_location_id if rec_type == "issue" else None,
                     rec_date=rec_date,
                     doc_no=doc_no,
                     material=NFC_MATERIAL,
@@ -1951,13 +1960,18 @@ def _validate_record(body: RecordIn, department: Optional[str] = None):
         raise HTTPException(status_code=400, detail="半成品仓出入库仅限碟片半成品部门")
     if body.qty is None or body.qty < 0:
         raise HTTPException(status_code=400, detail="数量必须为非负整数")
+    if body.rec_type in ("issue", "semi_outbound") and not body.location_id:
+        raise HTTPException(status_code=400, detail="出库必须选择目标部门")
     if (
-        body.rec_type in ("issue", "finished", "semi_finished")
+        body.rec_type in ("finished", "semi_finished")
         and not _is_outsource_department(department)
         and not body.location_id
     ):
         raise HTTPException(status_code=400, detail="领料/入库必须选择加工点")
-    if body.rec_type in ("inbound_raw", "semi_inbound") or _is_outsource_department(department):
+    if body.rec_type in ("inbound_raw", "semi_inbound") or (
+        _is_outsource_department(department)
+        and body.rec_type in ("finished", "semi_finished")
+    ):
         body.location_id = None
 
 
@@ -2043,37 +2057,57 @@ def _auto_flow_record_body(
     return body
 
 
+def _auto_receive_record_type(target_department):
+    if target_department == SUPPLIER_DEPARTMENT:
+        return "inbound_raw"
+    if target_department == SEMI_FINISHED_DEPARTMENT:
+        return "semi_inbound"
+    return "issue"
+
+
+def _auto_receive_location_id(conn, target_department, rec_type):
+    if rec_type != "issue":
+        return None
+    return _location_id_from_name(conn, target_department, 1)
+
+
+def _append_department_transfer_target(
+    conn,
+    targets,
+    source_body,
+    source_department,
+    source_location,
+):
+    if source_body.rec_type not in ("issue", "semi_outbound"):
+        return
+    if source_location not in DEPARTMENTS or source_location == source_department:
+        return
+    rec_type = _auto_receive_record_type(source_location)
+    targets.append((
+        source_location,
+        _auto_flow_record_body(
+            source_body,
+            source_department,
+            source_location,
+            rec_type,
+            _auto_receive_location_id(conn, source_location, rec_type),
+        ),
+        "department_transfer",
+    ))
+
+
 def _auto_flow_targets(conn, source_body, source_department):
-    if (
-        source_body.material != NFC_MATERIAL
-        or not source_body.sticker_type
-        or source_body.qty is None
-        or source_body.qty <= 0
-    ):
+    if source_body.qty is None or source_body.qty <= 0:
         return []
 
-    sticker_type = _normalize_sticker_type(
-        conn, source_body.material, source_body.sticker_type
-    )
+    if source_body.material == NFC_MATERIAL and source_body.sticker_type:
+        _normalize_sticker_type(conn, source_body.material, source_body.sticker_type)
     source_location = _location_name_from_id(conn, source_body.location_id)
     targets = []
 
-    if (
-        source_department == SUPPLIER_DEPARTMENT
-        and source_body.rec_type == "issue"
-        and source_location == ASSEMBLY_DEPARTMENT
-    ):
-        targets.append((
-            ASSEMBLY_DEPARTMENT,
-            _auto_flow_record_body(
-                source_body,
-                source_department,
-                ASSEMBLY_DEPARTMENT,
-                "issue",
-                _location_id_from_name(conn, ASSEMBLY_DEPARTMENT, 1),
-            ),
-            "supplier_to_assembly",
-        ))
+    _append_department_transfer_target(
+        conn, targets, source_body, source_department, source_location
+    )
 
     if source_department == ASSEMBLY_DEPARTMENT and source_body.rec_type == "semi_finished":
         targets.append((
@@ -2086,38 +2120,6 @@ def _auto_flow_targets(conn, source_body, source_department):
             ),
             "assembly_to_semi_finished",
         ))
-
-    if source_department == SEMI_FINISHED_DEPARTMENT and source_body.rec_type == "semi_outbound":
-        if source_location == HONGYA_DEPARTMENT:
-            targets.append((
-                HONGYA_DEPARTMENT,
-                _auto_flow_record_body(
-                    source_body,
-                    source_department,
-                    HONGYA_DEPARTMENT,
-                    "issue",
-                ),
-                "semi_finished_to_hongya",
-            ))
-        elif sticker_type == "36#NFC贴纸":
-            destination_departments = {
-                ASSEMBLY_DEPARTMENT: ASSEMBLY_DEPARTMENT,
-                "邵阳华登": SHAOYANG_DEPARTMENT,
-                HEYUAN_DEPARTMENT: HEYUAN_DEPARTMENT,
-            }
-            target_department = destination_departments.get(source_location)
-            if target_department:
-                targets.append((
-                    target_department,
-                    _auto_flow_record_body(
-                        source_body,
-                        source_department,
-                        target_department,
-                        "issue",
-                        _location_id_from_name(conn, source_location, 1),
-                    ),
-                    "semi_finished_36_to_processing",
-                ))
 
     if (
         source_department == HONGYA_DEPARTMENT
@@ -3123,7 +3125,7 @@ def import_records(file: UploadFile = File(...), user=Depends(current_user)):
             monthly_totals = []
         elif legacy_outsource_import:
             _require_filename_contains(file, user["department"])
-            bodies = _parse_legacy_outsource_workbook(wb, user["department"])
+            bodies = _parse_legacy_outsource_workbook(conn, wb, user["department"])
             monthly_totals = []
         elif legacy_outsource_nfc_import:
             _require_filename_contains(file, user["department"])

--- a/apps/PMC跟仓管/加工管理/tests/test_api_public_summary.py
+++ b/apps/PMC跟仓管/加工管理/tests/test_api_public_summary.py
@@ -115,8 +115,9 @@ def test_public_summary_can_filter_by_material_and_department(client):
 
 def test_public_summary_uses_outsource_balance_direction(client):
     admin_login(client, "东莞加工厂利鸿")
+    semi = loc_id(client, "碟片半成品")
     client.post("/api/records", json={
-        "rec_type": "issue", "rec_date": "2026-07-01",
+        "rec_type": "issue", "location_id": semi, "rec_date": "2026-07-01",
         "material": "PCBA板", "qty": 100})
     client.post("/api/records", json={
         "rec_type": "semi_finished", "rec_date": "2026-07-02",

--- a/apps/PMC跟仓管/加工管理/tests/test_api_records.py
+++ b/apps/PMC跟仓管/加工管理/tests/test_api_records.py
@@ -419,18 +419,23 @@ def test_outsource_can_create_finished_and_semi_finished_without_location(client
     assert by_type["semi_finished"]["location_id"] is None
 
 
-def test_outsource_can_create_issue_finished_and_semi_finished_without_location(client):
+def test_outsource_can_create_issue_with_target_department(client):
     admin_login(client, "东莞加工厂利鸿")
+    semi = loc_id(client, "碟片半成品")
     issue = client.post("/api/records", json={
-        "rec_type": "issue", "material": "PCBA板", "qty": 20})
+        "rec_type": "issue", "location_id": semi,
+        "material": "PCBA板", "qty": 20})
     assert issue.status_code == 200
+    row = client.get("/api/records").json()[0]
+    assert row["location_id"] == semi
 
 
-def test_hongya_outsource_can_create_all_outsource_types_without_location(client):
+def test_hongya_outsource_can_create_all_outsource_types(client):
     admin_login(client, "东莞加工厂鸿亚")
+    semi = loc_id(client, "碟片半成品")
 
     issue = client.post("/api/records", json={
-        "rec_type": "issue", "material": "NFC贴纸",
+        "rec_type": "issue", "location_id": semi, "material": "NFC贴纸",
         "sticker_type": "1#NFC贴纸", "qty": 120})
     finished = client.post("/api/records", json={
         "rec_type": "finished", "material": "NFC贴纸",
@@ -443,7 +448,7 @@ def test_hongya_outsource_can_create_all_outsource_types_without_location(client
     assert semi_finished.status_code == 200
     rows = client.get("/api/records").json()
     by_type = {row["rec_type"]: row for row in rows}
-    assert by_type["issue"]["location_id"] is None
+    assert by_type["issue"]["location_id"] == semi
     assert by_type["finished"]["location_id"] is None
     assert by_type["semi_finished"]["location_id"] is None
 
@@ -458,11 +463,13 @@ def test_outsource_rejects_other_warehouse_record_types(client):
 
 def test_semi_finished_department_can_create_inbound_and_outbound(client):
     admin_login(client, "碟片半成品")
+    hongya = loc_id(client, "东莞加工厂鸿亚")
     inbound = client.post("/api/records", json={
         "rec_type": "semi_inbound", "material": "PCBA板", "qty": 80})
     assert inbound.status_code == 200
     outbound = client.post("/api/records", json={
-        "rec_type": "semi_outbound", "material": "PCBA板", "qty": 30})
+        "rec_type": "semi_outbound", "location_id": hongya,
+        "material": "PCBA板", "qty": 30})
     assert outbound.status_code == 200
 
     rows = client.get("/api/records").json()
@@ -470,7 +477,15 @@ def test_semi_finished_department_can_create_inbound_and_outbound(client):
     assert by_type["semi_inbound"]["qty"] == 80
     assert by_type["semi_outbound"]["qty"] == 30
     assert by_type["semi_inbound"]["location_id"] is None
-    assert by_type["semi_outbound"]["location_id"] is None
+    assert by_type["semi_outbound"]["location_id"] == hongya
+
+
+def test_semi_finished_outbound_requires_target_department(client):
+    admin_login(client, "碟片半成品")
+    r = client.post("/api/records", json={
+        "rec_type": "semi_outbound", "material": "PCBA板", "qty": 30})
+
+    assert r.status_code == 400
 
 
 def test_non_semi_finished_department_rejects_warehouse_types(client):
@@ -536,6 +551,32 @@ def test_xingxin_nfc_issue_auto_syncs_dongguan_issue_record(client):
     assert client.get("/api/records?doc_no=FLOW-XD-001").json() == []
 
 
+def test_xingxin_pcba_issue_auto_syncs_dongguan_issue_record(client):
+    admin_login(client, "兴信B来料仓")
+    dongguan = loc_id(client, "东莞车间")
+    created = client.post("/api/records", json={
+        "rec_type": "issue",
+        "location_id": dongguan,
+        "material": "77794-PCBA板",
+        "rec_date": "2026-07-10",
+        "doc_no": "FLOW-PCBA-XD-001",
+        "qty": 88,
+    })
+    assert created.status_code == 200
+    source_id = created.json()["id"]
+
+    client.post("/api/logout")
+    admin_login(client, "东莞车间")
+    rows = client.get("/api/records?doc_no=FLOW-PCBA-XD-001").json()
+    assert len(rows) == 1
+    assert rows[0]["rec_type"] == "issue"
+    assert rows[0]["location_name"] == "东莞车间"
+    assert rows[0]["material"] == "77794-PCBA板"
+    assert rows[0]["sticker_type"] is None
+    assert rows[0]["qty"] == 88
+    assert rows[0]["source_record_id"] == source_id
+
+
 def test_auto_linked_records_cannot_be_edited_or_deleted_directly(client):
     admin_login(client, "兴信B来料仓")
     dongguan = loc_id(client, "东莞车间")
@@ -591,7 +632,47 @@ def test_semifinished_outbound_to_hongya_auto_creates_hongya_issue(client):
     assert rows[0]["material"] == "NFC贴纸"
     assert rows[0]["sticker_type"] == "1#NFC贴纸"
     assert rows[0]["qty"] == 70
-    assert rows[0]["location_id"] is None
+    assert rows[0]["location_id"] == hongya
+
+
+def test_outsource_issue_requires_target_department(client):
+    admin_login(client, "东莞加工厂鸿亚")
+
+    r = client.post("/api/records", json={
+        "rec_type": "issue",
+        "material": "NFC贴纸",
+        "sticker_type": "1#NFC贴纸",
+        "doc_no": "FLOW-HY-NO-TARGET-001",
+        "qty": 22,
+    })
+
+    assert r.status_code == 400
+
+
+def test_outsource_issue_auto_syncs_target_department_inbound(client):
+    admin_login(client, "东莞加工厂鸿亚")
+    semi = loc_id(client, "碟片半成品")
+
+    created = client.post("/api/records", json={
+        "rec_type": "issue",
+        "location_id": semi,
+        "material": "NFC贴纸",
+        "sticker_type": "1#NFC贴纸",
+        "doc_no": "FLOW-HY-TO-SEMI-001",
+        "qty": 22,
+    })
+    assert created.status_code == 200
+    source_id = created.json()["id"]
+
+    client.post("/api/logout")
+    admin_login(client, "碟片半成品")
+    rows = client.get("/api/records?doc_no=FLOW-HY-TO-SEMI-001").json()
+    assert len(rows) == 1
+    assert rows[0]["rec_type"] == "semi_inbound"
+    assert rows[0]["material"] == "NFC贴纸"
+    assert rows[0]["sticker_type"] == "1#NFC贴纸"
+    assert rows[0]["qty"] == 22
+    assert rows[0]["source_record_id"] == source_id
 
 
 def test_hongya_return_auto_creates_semifinished_inbound(client):
@@ -616,7 +697,7 @@ def test_hongya_return_auto_creates_semifinished_inbound(client):
     assert rows[0]["qty"] == 55
 
 
-def test_semifinished_36_nfc_to_heyuan_auto_creates_heyuan_issue(client):
+def test_semifinished_nfc_to_heyuan_auto_creates_heyuan_issue(client):
     admin_login(client, "碟片半成品")
     heyuan = loc_id(client, "河源华兴")
 
@@ -648,7 +729,11 @@ def test_semifinished_36_nfc_to_heyuan_auto_creates_heyuan_issue(client):
     assert rows_36[0]["location_name"] == "河源华兴"
     assert rows_36[0]["sticker_type"] == "36#NFC贴纸"
     assert rows_36[0]["qty"] == 36
-    assert rows_other == []
+    assert len(rows_other) == 1
+    assert rows_other[0]["rec_type"] == "issue"
+    assert rows_other[0]["location_name"] == "河源华兴"
+    assert rows_other[0]["sticker_type"] == "35#NFC贴纸"
+    assert rows_other[0]["qty"] == 35
 
 
 def test_semifinished_36_nfc_to_shaoyang_huadeng_auto_creates_shaoyang_issue(client):

--- a/apps/PMC跟仓管/加工管理/tests/test_api_summary.py
+++ b/apps/PMC跟仓管/加工管理/tests/test_api_summary.py
@@ -197,10 +197,12 @@ def test_assembly_summary_subtracts_semi_finished(client):
 
 def test_semi_finished_department_summary_uses_warehouse_balance(client):
     admin_login(client, "碟片半成品")
+    hongya = loc_id(client, "东莞加工厂鸿亚")
     client.post("/api/records", json={
         "rec_type": "semi_inbound", "material": "PCBA板", "qty": 80})
     client.post("/api/records", json={
-        "rec_type": "semi_outbound", "material": "PCBA板", "qty": 30})
+        "rec_type": "semi_outbound", "location_id": hongya,
+        "material": "PCBA板", "qty": 30})
 
     s = client.get("/api/summary").json()
     assert s["raw"]["inbound"] == 80

--- a/apps/PMC跟仓管/加工管理/tests/test_export.py
+++ b/apps/PMC跟仓管/加工管理/tests/test_export.py
@@ -213,10 +213,12 @@ def test_export_includes_semi_finished_detail_sheet(client):
 
 def test_semi_finished_department_export_has_inbound_and_outbound_sheets(client):
     admin_login(client, "碟片半成品")
+    hongya = loc_id(client, "东莞加工厂鸿亚")
     client.post("/api/records", json={
         "rec_type": "semi_inbound", "material": "PCBA板", "qty": 80})
     client.post("/api/records", json={
-        "rec_type": "semi_outbound", "material": "PCBA板", "qty": 30})
+        "rec_type": "semi_outbound", "location_id": hongya,
+        "material": "PCBA板", "qty": 30})
 
     r = client.get("/api/export")
     wb = openpyxl.load_workbook(io.BytesIO(r.content), data_only=True)

--- a/apps/PMC跟仓管/加工管理/tests/test_import_export.py
+++ b/apps/PMC跟仓管/加工管理/tests/test_import_export.py
@@ -551,8 +551,10 @@ def test_semi_finished_export_uses_legacy_matrix_workbook(client):
 
 def test_outsource_record_export_uses_legacy_pcba_workbook(client):
     login(client, "东莞加工厂利鸿", "123456", "东莞加工厂利鸿")
+    semi = loc_id(client, "碟片半成品")
     client.post("/api/records", json={
         "rec_type": "issue",
+        "location_id": semi,
         "material": "77794-PCBA板",
         "rec_date": "2026-07-01",
         "doc_no": "LL-LH-001",
@@ -835,7 +837,7 @@ def test_hongya_nfc_legacy_workbook_imports_issue_and_finished_rows(client):
     assert rows[("finished", "2026-07-02")]["qty"] == 20
     assert rows[("issue", "2026-07-01")]["material"] == "NFC贴纸"
     assert rows[("issue", "2026-07-01")]["sticker_type"] == "1#NFC贴纸"
-    assert rows[("issue", "2026-07-01")]["location_name"] is None
+    assert rows[("issue", "2026-07-01")]["location_name"] == "东莞加工厂鸿亚"
     assert rows[("finished", "2026-07-02")]["location_name"] is None
 
     summary = client.get("/api/summary").json()


### PR DESCRIPTION
## 变更内容
- 出库/领料记录必须选择目标部门，半成品出库同样强制选择目标部门
- 按目标部门自动生成对方部门记录：来料仓入库、碟片半成品入库、其他部门领料
- 加工厂出库保留目标部门，旧格式 Excel 导入补齐历史领料落点
- 补充跨部门自动同步、半成品出库、加工厂出库和旧表导入回归测试

## 验证
- python -m pytest -q
- node --check pcba/static/app.js
- git diff --check origin/main..HEAD