### PR TITLE
Feat cpg clear and bulk delete records

### DIFF
--- a/apps/PMC跟仓管/加工管理/pcba/main.py
+++ b/apps/PMC跟仓管/加工管理/pcba/main.py
@@ -1993,6 +1993,15 @@ class RecordBatchIn(BaseModel):
     items: List[StickerRecordItemIn]
 
 
+class RecordBulkDeleteIn(BaseModel):
+    ids: List[int]
+
+
+class RecordClearIn(BaseModel):
+    department: str
+    material: str
+
+
 def _record_extras(body, department):
     supplier = (body.supplier or "").strip() or None
     if department != SUPPLIER_DEPARTMENT:
@@ -3231,6 +3240,52 @@ def _check_owner(row, user):
         raise HTTPException(status_code=403, detail="只能修改自己录入的记录")
 
 
+def _normalized_record_ids(ids):
+    result = []
+    seen = set()
+    for value in ids or []:
+        try:
+            record_id = int(value)
+        except (TypeError, ValueError):
+            raise HTTPException(status_code=400, detail="记录 ID 无效")
+        if record_id <= 0:
+            raise HTTPException(status_code=400, detail="记录 ID 无效")
+        if record_id not in seen:
+            seen.add(record_id)
+            result.append(record_id)
+    if not result:
+        raise HTTPException(status_code=400, detail="请选择要删除的记录")
+    return result
+
+
+def _delete_record_ids_with_links(conn, record_ids):
+    if not record_ids:
+        return 0
+    deleted = 0
+    chunk_size = 500
+    for start in range(0, len(record_ids), chunk_size):
+        chunk = record_ids[start:start + chunk_size]
+        placeholders = ",".join("?" for _ in chunk)
+        linked_count = conn.execute(
+            f"SELECT COUNT(*) AS c FROM records WHERE source_record_id IN ({placeholders})",
+            chunk,
+        ).fetchone()["c"]
+        conn.execute(
+            f"DELETE FROM records WHERE source_record_id IN ({placeholders})",
+            chunk,
+        )
+        deleted += int(linked_count or 0)
+    for start in range(0, len(record_ids), chunk_size):
+        chunk = record_ids[start:start + chunk_size]
+        placeholders = ",".join("?" for _ in chunk)
+        cur = conn.execute(
+            f"DELETE FROM records WHERE id IN ({placeholders})",
+            chunk,
+        )
+        deleted += int(cur.rowcount or 0)
+    return deleted
+
+
 @app.put("/api/records/{record_id}")
 def update_record(record_id: int, body: RecordIn, user=Depends(current_user)):
     conn = db.get_conn()
@@ -3264,12 +3319,55 @@ def delete_record(record_id: int, user=Depends(current_user)):
         row = _get_record_or_404(conn, record_id, user["department"])
         _reject_auto_record_direct_edit(row)
         _check_owner(row, user)
-        conn.execute("DELETE FROM records WHERE source_record_id=?", (record_id,))
-        conn.execute("DELETE FROM records WHERE id=?", (record_id,))
+        deleted = _delete_record_ids_with_links(conn, [record_id])
         conn.commit()
     finally:
         conn.close()
-    return {"ok": True}
+    return {"ok": True, "deleted": deleted}
+
+
+@app.post("/api/records/bulk-delete")
+def bulk_delete_records(body: RecordBulkDeleteIn, user=Depends(current_user)):
+    record_ids = _normalized_record_ids(body.ids)
+    placeholders = ",".join("?" for _ in record_ids)
+    conn = db.get_conn()
+    try:
+        rows = conn.execute(
+            f"SELECT * FROM records WHERE department=? AND id IN ({placeholders})",
+            [user["department"], *record_ids],
+        ).fetchall()
+        rows_by_id = {row["id"]: row for row in rows}
+        if len(rows_by_id) != len(record_ids):
+            raise HTTPException(status_code=404, detail="部分记录不存在")
+        for record_id in record_ids:
+            row = rows_by_id[record_id]
+            _reject_auto_record_direct_edit(row)
+            _check_owner(row, user)
+        deleted = _delete_record_ids_with_links(conn, record_ids)
+        conn.commit()
+    finally:
+        conn.close()
+    return {"ok": True, "deleted": deleted}
+
+
+@app.post("/api/records/clear")
+def clear_records(body: RecordClearIn, _admin=Depends(require_admin)):
+    department = _validate_department(body.department)
+    material = (body.material or "").strip()
+    if not material:
+        raise HTTPException(status_code=400, detail="请选择物料")
+    conn = db.get_conn()
+    try:
+        rows = conn.execute(
+            "SELECT id FROM records WHERE department=? AND material=?",
+            (department, material),
+        ).fetchall()
+        record_ids = [row["id"] for row in rows]
+        deleted = _delete_record_ids_with_links(conn, record_ids)
+        conn.commit()
+    finally:
+        conn.close()
+    return {"ok": True, "matched": len(record_ids), "deleted": deleted}
 
 
 def _all_records_for_summary(conn, department, filters=None):

--- a/apps/PMC跟仓管/加工管理/pcba/static/app.html
+++ b/apps/PMC跟仓管/加工管理/pcba/static/app.html
@@ -61,6 +61,16 @@
     <div id="entryTypeTabs" class="entry-type-tabs"></div>
     <div id="entryMaterialTabs" class="entry-type-tabs material-tabs"></div>
 
+    <div id="clearDataPanel" class="danger-panel clear-data-panel" style="display:none">
+      <div>
+        <div class="mini-title">清空数据</div>
+        <p>按部门和物料清空流水，源记录的自动联动记录会一并删除。</p>
+      </div>
+      <select id="clearDepartment" title="清空部门"></select>
+      <select id="clearMaterial" title="清空物料"></select>
+      <button class="btn-danger" onclick="clearRecordsByDepartmentMaterial()">清空数据</button>
+    </div>
+
     <div class="form-grid">
       <select id="recType" style="display:none"></select>
       <select id="locationId"></select>
@@ -80,6 +90,10 @@
       <div id="stickerTypeGrid" class="sticker-grid"></div>
     </div>
     <p id="entryErr" class="err"></p>
+    <div id="recordBulkBar" class="record-bulk-bar">
+      <span id="recordSelectedText">已选择 0 条</span>
+      <button id="bulkDeleteBtn" class="btn-danger btn-sm" onclick="deleteSelectedRecords()" disabled>删除所选</button>
+    </div>
     <div class="table-wrap">
       <table id="recTable"><thead></thead><tbody></tbody></table>
     </div>

--- a/apps/PMC跟仓管/加工管理/pcba/static/app.js
+++ b/apps/PMC跟仓管/加工管理/pcba/static/app.js
@@ -38,6 +38,7 @@ let DEPARTMENTS = [];
 let SUPPLIERS = [];
 let MATERIALS = [];
 let STICKER_TYPES = [];
+let SELECTED_RECORD_IDS = new Set();
 let editingId = null;
 let editingMaterialId = null;
 let editingSupplierId = null;
@@ -305,6 +306,7 @@ async function loadDepartments() {
       .map(name => `<option value="${esc(name)}">${esc(name)}</option>`)
       .join('');
   }
+  configureClearDataPanel();
 }
 
 function configureEntryForDepartment() {
@@ -353,6 +355,7 @@ async function loadMaterials() {
   }
   el('material').value = ACTIVE_ENTRY_MATERIAL;
   renderEntryMaterialTabs();
+  configureClearDataPanel();
 
   const form = el('materialForm');
   if (form) form.style.display = '';
@@ -745,24 +748,70 @@ function cancelEdit() {
 async function loadRecords() {
   const r = await api(withFilters('/api/records'));
   RECORDS = await r.json();
+  SELECTED_RECORD_IDS.clear();
+  renderRecordsTable();
+}
+
+function visibleEntryRecords() {
+  return RECORDS.filter(x =>
+    (!ACTIVE_ENTRY_TYPE || x.rec_type === ACTIVE_ENTRY_TYPE) &&
+    (!ACTIVE_ENTRY_MATERIAL || x.material === ACTIVE_ENTRY_MATERIAL)
+  );
+}
+
+function canDeleteRecord(rec) {
+  return !!rec && !rec.source_record_id && (ME.role === 'admin' || rec.created_by === ME.id);
+}
+
+function updateRecordSelectionUi(visibleRecords = null) {
+  const records = visibleRecords || visibleEntryRecords();
+  const deletable = records.filter(canDeleteRecord);
+  const deletableIds = new Set(deletable.map(x => x.id));
+  SELECTED_RECORD_IDS = new Set([...SELECTED_RECORD_IDS].filter(id => deletableIds.has(id)));
+  const selectedCount = SELECTED_RECORD_IDS.size;
+  const text = el('recordSelectedText');
+  if (text) text.textContent = `已选择 ${selectedCount} 条`;
+  const bulkBtn = el('bulkDeleteBtn');
+  if (bulkBtn) bulkBtn.disabled = selectedCount === 0;
+  const all = document.getElementById('recordSelectAll');
+  if (all) {
+    all.disabled = deletable.length === 0;
+    all.checked = deletable.length > 0 && selectedCount === deletable.length;
+    all.indeterminate = selectedCount > 0 && selectedCount < deletable.length;
+  }
+}
+
+function onRecordSelectChange(id, checked) {
+  if (checked) SELECTED_RECORD_IDS.add(id);
+  else SELECTED_RECORD_IDS.delete(id);
+  updateRecordSelectionUi();
+}
+
+function toggleRecordSelectionAll(checked) {
+  visibleEntryRecords().forEach(x => {
+    if (!canDeleteRecord(x)) return;
+    if (checked) SELECTED_RECORD_IDS.add(x.id);
+    else SELECTED_RECORD_IDS.delete(x.id);
+  });
   renderRecordsTable();
 }
 
 function renderRecordsTable() {
   renderRecordHeader();
   const tb = document.querySelector('#recTable tbody');
-  const emptyColspan = 10 + (isXingxin() ? 1 : 0) + (supportsPoCustomer() ? 2 : 0);
-  const visibleRecords = RECORDS.filter(x =>
-    (!ACTIVE_ENTRY_TYPE || x.rec_type === ACTIVE_ENTRY_TYPE) &&
-    (!ACTIVE_ENTRY_MATERIAL || x.material === ACTIVE_ENTRY_MATERIAL)
-  );
+  const emptyColspan = 11 + (isXingxin() ? 1 : 0) + (supportsPoCustomer() ? 2 : 0);
+  const visibleRecords = visibleEntryRecords();
+  updateRecordSelectionUi(visibleRecords);
   tb.innerHTML = visibleRecords.map(x => {
     const canEdit = ME.role === 'admin' || x.created_by === ME.id;
+    const canDelete = canDeleteRecord(x);
+    const checkTitle = x.source_record_id ? '自动生成记录不能直接删除' : '选择删除';
     const ops = canEdit
       ? `<button class="btn-edit btn-sm" onclick="startEdit(${x.id})">修改</button>` +
         `<button class="btn-danger btn-sm" onclick="delRecord(${x.id})">删除</button>`
       : '';
     return `<tr>
+      <td class="select-col"><input type="checkbox" class="record-check" title="${checkTitle}" onchange="onRecordSelectChange(${x.id}, this.checked)" ${SELECTED_RECORD_IDS.has(x.id) ? 'checked' : ''} ${canDelete ? '' : 'disabled'}></td>
       <td>${esc(typeLabel(x.rec_type))}</td>
       <td>${esc(x.material)}</td>
       <td>${esc(x.sticker_type)}</td>
@@ -777,12 +826,14 @@ function renderRecordsTable() {
       <td>${ops}</td>
     </tr>`;
   }).join('') || `<tr><td colspan="${emptyColspan}">当前页面暂无记录</td></tr>`;
+  updateRecordSelectionUi(visibleRecords);
 }
 
 function renderRecordHeader() {
   const supplierHead = isXingxin() ? '<th>供应商</th>' : '';
   const poCustomerHead = supportsPoCustomer() ? '<th>PO</th><th>客名</th>' : '';
   document.querySelector('#recTable thead').innerHTML = `<tr>
+    <th class="select-col"><input id="recordSelectAll" type="checkbox" title="全选可删除记录" onchange="toggleRecordSelectionAll(this.checked)"></th>
     <th>类型</th><th>物料名称</th><th>贴纸类型</th><th>加工点</th>${supplierHead}<th>日期</th><th>单据编号</th>${poCustomerHead}
     <th>数量</th><th>备注</th><th>录入人</th><th>操作</th>
   </tr>`;
@@ -798,6 +849,79 @@ async function delRecord(id) {
   } else {
     const e = await r.json();
     alert(e.detail || '删除失败');
+  }
+}
+
+async function deleteSelectedRecords() {
+  const ids = [...SELECTED_RECORD_IDS];
+  if (!ids.length) return;
+  if (!confirm(`确定删除选中的 ${ids.length} 条记录？源记录的自动联动记录会一并删除。`)) return;
+  const r = await api('/api/records/bulk-delete', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({ids}),
+  });
+  if (r.ok) {
+    const data = await r.json();
+    SELECTED_RECORD_IDS.clear();
+    if (ids.includes(editingId)) cancelEdit();
+    await loadRecords();
+    if (el('summary').style.display !== 'none') await loadSummary();
+    setMessage('entryErr', `已删除 ${data.deleted || ids.length} 条记录`, true);
+  } else {
+    const e = await r.json();
+    alert(e.detail || '批量删除失败');
+  }
+}
+
+function configureClearDataPanel() {
+  const panel = document.getElementById('clearDataPanel');
+  if (!panel) return;
+  if (!ME || ME.role !== 'admin') {
+    panel.style.display = 'none';
+    return;
+  }
+  panel.style.display = '';
+  const dept = el('clearDepartment');
+  const material = el('clearMaterial');
+  if (DEPARTMENTS.length) {
+    const current = dept.value || ME.department;
+    dept.innerHTML = DEPARTMENTS.map(name =>
+      `<option value="${esc(name)}" ${name === current ? 'selected' : ''}>${esc(name)}</option>`
+    ).join('');
+  }
+  if (MATERIALS.length) {
+    const currentMaterial = material.value || ACTIVE_ENTRY_MATERIAL;
+    material.innerHTML = MATERIALS.map(m =>
+      `<option value="${esc(m.name)}" ${m.name === currentMaterial ? 'selected' : ''}>${esc(m.name)}</option>`
+    ).join('');
+  }
+}
+
+async function clearRecordsByDepartmentMaterial() {
+  const department = el('clearDepartment').value;
+  const material = el('clearMaterial').value;
+  if (!department || !material) {
+    setMessage('entryErr', '请选择要清空的部门和物料', false);
+    return;
+  }
+  const ok = confirm(`确定清空「${department} / ${material}」的所有流水数据？此操作不可撤销。`);
+  if (!ok) return;
+  const r = await api('/api/records/clear', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({department, material}),
+  });
+  if (r.ok) {
+    const data = await r.json();
+    SELECTED_RECORD_IDS.clear();
+    cancelEdit();
+    await loadRecords();
+    if (el('summary').style.display !== 'none') await loadSummary();
+    setMessage('entryErr', `已清空 ${department} / ${material}，删除 ${data.deleted || 0} 条记录`, true);
+  } else {
+    const e = await r.json();
+    setMessage('entryErr', e.detail || '清空失败', false);
   }
 }
 

--- a/apps/PMC跟仓管/加工管理/pcba/static/style.css
+++ b/apps/PMC跟仓管/加工管理/pcba/static/style.css
@@ -652,6 +652,40 @@ tr.reconcile-diff {
   max-width: 900px;
 }
 
+.danger-panel {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) minmax(150px, 220px) minmax(150px, 220px) auto;
+  gap: 10px;
+  align-items: center;
+  padding: 12px;
+  margin-bottom: 12px;
+  border: 1px solid #fecaca;
+  border-radius: 8px;
+  background: #fff7f7;
+}
+
+.danger-panel p {
+  margin: 4px 0 0;
+  color: #991b1b;
+  font-size: 13px;
+}
+
+.record-bulk-bar {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 10px;
+  min-height: 34px;
+  margin: 4px 0 10px;
+  color: #475467;
+  font-size: 13px;
+}
+
+.select-col {
+  width: 42px;
+  text-align: center;
+}
+
 .reconcile-form {
   max-width: 980px;
 }

--- a/apps/PMC跟仓管/加工管理/tests/test_api_records.py
+++ b/apps/PMC跟仓管/加工管理/tests/test_api_records.py
@@ -190,6 +190,94 @@ def test_admin_can_delete_any(client):
     assert r.status_code == 200
 
 
+def test_bulk_delete_removes_selected_records_and_linked_records(client):
+    admin_login(client, "兴信B来料仓")
+    dongguan = loc_id(client, "东莞车间")
+    source = client.post("/api/records", json={
+        "rec_type": "issue", "location_id": dongguan,
+        "material": "NFC贴纸", "sticker_type": "1#NFC贴纸",
+        "doc_no": "BULK-LINK-001", "qty": 12}).json()["id"]
+    inbound = client.post("/api/records", json={
+        "rec_type": "inbound_raw", "material": "77794-PCBA板",
+        "doc_no": "BULK-IN-001", "qty": 20}).json()["id"]
+
+    r = client.post("/api/records/bulk-delete", json={"ids": [source, inbound]})
+
+    assert r.status_code == 200
+    assert r.json()["deleted"] == 3
+    assert client.get("/api/records?doc_no=BULK-LINK-001").json() == []
+    assert client.get("/api/records?doc_no=BULK-IN-001").json() == []
+    client.post("/api/logout")
+    admin_login(client, "东莞车间")
+    assert client.get("/api/records?doc_no=BULK-LINK-001").json() == []
+
+
+def test_bulk_delete_rejects_auto_linked_record(client):
+    admin_login(client, "兴信B来料仓")
+    dongguan = loc_id(client, "东莞车间")
+    client.post("/api/records", json={
+        "rec_type": "issue", "location_id": dongguan,
+        "material": "NFC贴纸", "sticker_type": "1#NFC贴纸",
+        "doc_no": "BULK-AUTO-001", "qty": 12})
+    client.post("/api/logout")
+    admin_login(client, "东莞车间")
+    linked_id = client.get("/api/records?doc_no=BULK-AUTO-001").json()[0]["id"]
+
+    r = client.post("/api/records/bulk-delete", json={"ids": [linked_id]})
+
+    assert r.status_code == 400
+
+
+def test_operator_bulk_delete_rejects_other_users_records(client):
+    admin_login(client)
+    lid = loc_id(client, "东莞车间")
+    rid_admin = client.post("/api/records", json={
+        "rec_type": "issue", "location_id": lid, "qty": 100}).json()["id"]
+    client.post("/api/logout")
+    make_operator(client)
+
+    r = client.post("/api/records/bulk-delete", json={"ids": [rid_admin]})
+
+    assert r.status_code == 403
+
+
+def test_admin_can_clear_records_by_department_and_material(client):
+    admin_login(client, "兴信B来料仓")
+    dongguan = loc_id(client, "东莞车间")
+    source_id = client.post("/api/records", json={
+        "rec_type": "issue", "location_id": dongguan,
+        "material": "77794-PCBA板", "doc_no": "CLEAR-PCBA-001", "qty": 18}).json()["id"]
+    keep_id = client.post("/api/records", json={
+        "rec_type": "inbound_raw", "material": "NFC贴纸",
+        "doc_no": "CLEAR-NFC-KEEP", "qty": 30}).json()["id"]
+
+    r = client.post("/api/records/clear", json={
+        "department": "兴信B来料仓",
+        "material": "77794-PCBA板",
+    })
+
+    assert r.status_code == 200
+    assert r.json()["matched"] == 1
+    assert r.json()["deleted"] == 2
+    rows = client.get("/api/records").json()
+    assert all(row["id"] != source_id for row in rows)
+    assert any(row["id"] == keep_id for row in rows)
+    client.post("/api/logout")
+    admin_login(client, "东莞车间")
+    assert client.get("/api/records?doc_no=CLEAR-PCBA-001").json() == []
+
+
+def test_clear_records_requires_admin(client):
+    make_operator(client)
+
+    r = client.post("/api/records/clear", json={
+        "department": "兴信B来料仓",
+        "material": "NFC贴纸",
+    })
+
+    assert r.status_code == 403
+
+
 def test_records_are_isolated_by_department(client):
     admin_login(client, "东莞车间")
     lid = loc_id(client, "东莞车间")

--- a/apps/PMC跟仓管/加工管理/tests/test_static_entry_subpages.py
+++ b/apps/PMC跟仓管/加工管理/tests/test_static_entry_subpages.py
@@ -44,6 +44,22 @@ def test_entry_page_exposes_type_subpage_container():
     assert 'onclick="exportRecords()"' in html
 
 
+def test_entry_page_exposes_clear_and_bulk_delete_controls():
+    html = (ROOT / "pcba/static/app.html").read_text(encoding="utf-8")
+    js = (ROOT / "pcba/static/app.js").read_text(encoding="utf-8")
+
+    assert 'id="clearDataPanel"' in html
+    assert 'id="clearDepartment"' in html
+    assert 'id="clearMaterial"' in html
+    assert 'onclick="clearRecordsByDepartmentMaterial()"' in html
+    assert 'id="recordBulkBar"' in html
+    assert 'id="recordSelectAll"' in js
+    assert "function deleteSelectedRecords()" in js
+    assert "function clearRecordsByDepartmentMaterial()" in js
+    assert "/api/records/bulk-delete" in js
+    assert "/api/records/clear" in js
+
+
 def test_entry_records_are_filtered_by_active_type():
     js = (ROOT / "pcba/static/app.js").read_text(encoding="utf-8")
 


### PR DESCRIPTION
Summary:
- add admin-only clear records by department and material
- add selectable record rows with bulk delete for deletable entry records
- keep linked-record cleanup and ownership checks consistent with single delete

Tests:
- node --check pcba/static/app.js
- git diff --check
- python -m pytest -q