### PR TITLE
Feat cpg admin department switcher

### DIFF
--- a/apps/PMC跟仓管/加工管理/pcba/main.py
+++ b/apps/PMC跟仓管/加工管理/pcba/main.py
@@ -116,6 +116,10 @@ class LoginIn(BaseModel):
     department: str
 
 
+class DepartmentSwitchIn(BaseModel):
+    department: str
+
+
 def _validate_department(department: Optional[str], required=True):
     if not department:
         if required:
@@ -204,6 +208,19 @@ def logout(request: Request):
 @app.get("/api/me")
 def me(user=Depends(current_user)):
     return user
+
+
+@app.post("/api/me/department")
+def switch_current_department(
+    body: DepartmentSwitchIn,
+    request: Request,
+    user=Depends(require_admin),
+):
+    department = _validate_department(body.department)
+    request.session["department"] = department
+    result = dict(user)
+    result["department"] = department
+    return result
 
 
 # ---------- 用户管理（仅 admin） ----------

--- a/apps/PMC跟仓管/加工管理/pcba/static/app.html
+++ b/apps/PMC跟仓管/加工管理/pcba/static/app.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>唱片机管理系统</title>
-<link rel="stylesheet" href="/static/style.css?v=19">
+<link rel="stylesheet" href="/static/style.css?v=20">
 </head>
 <body class="app-page">
 <header class="app-header">
@@ -13,6 +13,10 @@
     <div>
       <h1>唱片机管理系统</h1>
       <p id="who"></p>
+      <div id="adminDepartmentSwitcher" class="admin-switcher" style="display:none">
+        <span>当前部门</span>
+        <select id="currentDepartmentSelect" onchange="switchCurrentDepartment()"></select>
+      </div>
     </div>
   </div>
   <button id="logoutBtn" class="ghost-btn inverted" onclick="logout()">退出</button>
@@ -306,6 +310,6 @@
   </section>
 </main>
 
-  <script src="/static/app.js?v=27"></script>
+  <script src="/static/app.js?v=28"></script>
 </body>
 </html>

--- a/apps/PMC跟仓管/加工管理/pcba/static/app.js
+++ b/apps/PMC跟仓管/加工管理/pcba/static/app.js
@@ -273,17 +273,76 @@ function updateFilterText() {
   el('currentFilterText').textContent = parts.length ? parts.join('，') : '当前显示全部日期';
 }
 
+function renderCurrentUser() {
+  el('who').textContent = `${ME.username}（${ME.role === 'admin' ? '管理员' : '录入员'}） - ${ME.department}`;
+  el('deptTitle').textContent = `${ME.department}工作台`;
+}
+
+function configureAdminDepartmentSwitcher() {
+  const panel = document.getElementById('adminDepartmentSwitcher');
+  if (!panel) return;
+  if (!ME || ME.role !== 'admin') {
+    panel.style.display = 'none';
+    return;
+  }
+  panel.style.display = '';
+  const select = el('currentDepartmentSelect');
+  select.innerHTML = DEPARTMENTS.map(name =>
+    `<option value="${esc(name)}" ${name === ME.department ? 'selected' : ''}>${esc(name)}</option>`
+  ).join('');
+}
+
+async function reloadWorkspaceAfterDepartmentSwitch() {
+  SELECTED_RECORD_IDS.clear();
+  cancelEdit();
+  ACTIVE_ENTRY_TYPE = '';
+  ACTIVE_ENTRY_MATERIAL = '';
+  await loadLocations();
+  await loadMaterials();
+  await loadStickerTypes();
+  await loadSuppliers();
+  configureEntryForDepartment();
+  onTypeChange();
+  await loadRecords();
+  if (el('summary').style.display !== 'none') await loadSummary();
+  if (el('users').style.display !== 'none') await loadUsers();
+}
+
+async function switchCurrentDepartment() {
+  const select = el('currentDepartmentSelect');
+  const department = select.value;
+  if (!department || department === ME.department) return;
+  const previousDepartment = ME.department;
+  const r = await api('/api/me/department', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({department}),
+  });
+  if (r.ok) {
+    ME = await r.json();
+    renderCurrentUser();
+    configureAdminDepartmentSwitcher();
+    await reloadWorkspaceAfterDepartmentSwitch();
+    setMessage('entryErr', `已切换到 ${ME.department}`, true);
+  } else {
+    select.value = previousDepartment;
+    const e = await r.json();
+    alert(e.detail || '切换部门失败');
+  }
+}
+
 async function init() {
   const r = await api('/api/me');
   ME = await r.json();
-  el('who').textContent = `${ME.username}（${ME.role === 'admin' ? '管理员' : '录入员'}） - ${ME.department}`;
-  el('deptTitle').textContent = `${ME.department}工作台`;
+  renderCurrentUser();
 
   el('matTabBtn').style.display = '';
   el('supTabBtn').style.display = '';
   if (ME.role === 'admin') {
     el('usersTabBtn').style.display = '';
     await loadDepartments();
+  } else {
+    configureAdminDepartmentSwitcher();
   }
 
   await loadLocations();
@@ -306,6 +365,7 @@ async function loadDepartments() {
       .map(name => `<option value="${esc(name)}">${esc(name)}</option>`)
       .join('');
   }
+  configureAdminDepartmentSwitcher();
   configureClearDataPanel();
 }
 

--- a/apps/PMC跟仓管/加工管理/pcba/static/style.css
+++ b/apps/PMC跟仓管/加工管理/pcba/static/style.css
@@ -170,6 +170,28 @@ label {
   margin-top: 4px;
 }
 
+.admin-switcher {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+  color: #e0ecff;
+  font-size: 13px;
+}
+
+.admin-switcher select {
+  width: 180px;
+  height: 34px;
+  border-color: rgba(255, 255, 255, 0.32);
+  color: #fff;
+  background: rgba(255, 255, 255, 0.14);
+}
+
+.admin-switcher select option {
+  color: var(--text);
+  background: #fff;
+}
+
 .section-head {
   display: flex;
   align-items: flex-start;

--- a/apps/PMC跟仓管/加工管理/tests/test_api_users.py
+++ b/apps/PMC跟仓管/加工管理/tests/test_api_users.py
@@ -77,6 +77,49 @@ def test_admin_can_login_to_any_department(client):
     assert r.json()["department"] == "新邵"
 
 
+def test_admin_can_switch_department_without_relogin(client):
+    login(client, "admin", "admin123")
+    departments = client.get("/api/departments").json()
+    target_department = departments[1]
+
+    client.post("/api/records", json={
+        "rec_type": "inbound_raw", "doc_no": "SWITCH-DEFAULT", "qty": 5})
+
+    r = client.post("/api/me/department", json={"department": target_department})
+
+    assert r.status_code == 200
+    assert r.json()["department"] == target_department
+    assert client.get("/api/me").json()["department"] == target_department
+
+    client.post("/api/records", json={
+        "rec_type": "inbound_raw", "doc_no": "SWITCH-TARGET", "qty": 7})
+    rows = client.get("/api/records").json()
+    assert any(row["doc_no"] == "SWITCH-TARGET" for row in rows)
+    assert all(row["doc_no"] != "SWITCH-DEFAULT" for row in rows)
+
+    r = client.post("/api/me/department", json={"department": DEFAULT_DEPARTMENT})
+
+    assert r.status_code == 200
+    rows = client.get("/api/records").json()
+    assert any(row["doc_no"] == "SWITCH-DEFAULT" for row in rows)
+    assert all(row["doc_no"] != "SWITCH-TARGET" for row in rows)
+
+
+def test_operator_cannot_switch_department(client):
+    login(client, "admin", "admin123")
+    client.post("/api/users", json={
+        "username": "op_switch_department", "password": "pw123456",
+        "role": "operator", "department": DEFAULT_DEPARTMENT})
+    target_department = client.get("/api/departments").json()[1]
+    client.post("/api/logout")
+    login(client, "op_switch_department", "pw123456")
+
+    r = client.post("/api/me/department", json={"department": target_department})
+
+    assert r.status_code == 403
+    assert client.get("/api/me").json()["department"] == DEFAULT_DEPARTMENT
+
+
 def test_operator_requires_department_when_created(client):
     login(client, "admin", "admin123")
     r = client.post("/api/users", json={

--- a/apps/PMC跟仓管/加工管理/tests/test_static_entry_subpages.py
+++ b/apps/PMC跟仓管/加工管理/tests/test_static_entry_subpages.py
@@ -60,6 +60,18 @@ def test_entry_page_exposes_clear_and_bulk_delete_controls():
     assert "/api/records/clear" in js
 
 
+def test_admin_department_switcher_controls_exist():
+    html = (ROOT / "pcba/static/app.html").read_text(encoding="utf-8")
+    js = (ROOT / "pcba/static/app.js").read_text(encoding="utf-8")
+
+    assert 'id="adminDepartmentSwitcher"' in html
+    assert 'id="currentDepartmentSelect"' in html
+    assert 'onchange="switchCurrentDepartment()"' in html
+    assert "function configureAdminDepartmentSwitcher()" in js
+    assert "async function switchCurrentDepartment()" in js
+    assert "/api/me/department" in js
+
+
 def test_entry_records_are_filtered_by_active_type():
     js = (ROOT / "pcba/static/app.js").read_text(encoding="utf-8")
 


### PR DESCRIPTION
Summary:
- add admin-only current department switch endpoint
- add top-bar department selector for admin users
- reload workspace data after switching departments without requiring logout/login

Tests:
- node --check pcba/static/app.js
- git diff --check
- python -m pytest -q