### PR TITLE
Fix cpg record date ordering

### DIFF
--- a/apps/PMC跟仓管/加工管理/pcba/main.py
+++ b/apps/PMC跟仓管/加工管理/pcba/main.py
@@ -2241,7 +2241,7 @@ def list_records(
             sql += " AND r.rec_type = ?"
             params.append(rec_type)
         sql, params = _append_date_filter(sql, params, filters)
-        sql += " ORDER BY r.id DESC"
+        sql += " ORDER BY r.rec_date IS NULL, r.rec_date DESC, r.id DESC"
         rows = conn.execute(sql, params).fetchall()
     finally:
         conn.close()

--- a/apps/PMC跟仓管/加工管理/tests/test_api_records.py
+++ b/apps/PMC跟仓管/加工管理/tests/test_api_records.py
@@ -60,6 +60,28 @@ def test_records_can_filter_by_date_range(client):
     assert [r["qty"] for r in rows] == [10]
 
 
+def test_records_are_ordered_by_newest_date_first(client):
+    admin_login(client)
+    client.post("/api/records", json={
+        "rec_type": "inbound_raw", "rec_date": "2026-07-01",
+        "doc_no": "SORT-OLD", "qty": 10})
+    client.post("/api/records", json={
+        "rec_type": "inbound_raw", "rec_date": "2026-07-05",
+        "doc_no": "SORT-NEW-1", "qty": 20})
+    client.post("/api/records", json={
+        "rec_type": "inbound_raw", "rec_date": "2026-07-03",
+        "doc_no": "SORT-MID", "qty": 30})
+    client.post("/api/records", json={
+        "rec_type": "inbound_raw", "rec_date": "2026-07-05",
+        "doc_no": "SORT-NEW-2", "qty": 40})
+
+    rows = client.get("/api/records?doc_no=SORT-").json()
+
+    assert [r["doc_no"] for r in rows] == [
+        "SORT-NEW-2", "SORT-NEW-1", "SORT-MID", "SORT-OLD"
+    ]
+
+
 def test_records_can_filter_by_doc_no_fuzzy(client):
     admin_login(client)
     client.post("/api/records", json={


### PR DESCRIPTION
Summary:
- sort record list by record date descending
- keep newest-created records first when dates match
- add regression coverage for date ordering

Tests:
- python -m pytest tests/test_api_records.py::test_records_are_ordered_by_newest_date_first -q
- python -m pytest tests/test_api_records.py -q
- node --check pcba/static/app.js
- git diff --check
- python -m pytest -q