### PR TITLE
Fix cpg same-date sticker ordering

### DIFF
--- a/apps/PMC跟仓管/加工管理/pcba/main.py
+++ b/apps/PMC跟仓管/加工管理/pcba/main.py
@@ -2241,7 +2241,12 @@ def list_records(
             sql += " AND r.rec_type = ?"
             params.append(rec_type)
         sql, params = _append_date_filter(sql, params, filters)
-        sql += " ORDER BY r.rec_date IS NULL, r.rec_date DESC, r.id DESC"
+        sql += (
+            " ORDER BY r.rec_date IS NULL, r.rec_date DESC, "
+            "CASE WHEN r.sticker_type GLOB '[0-9]*#*' THEN 0 ELSE 1 END, "
+            "CASE WHEN r.sticker_type GLOB '[0-9]*#*' THEN CAST(r.sticker_type AS INTEGER) END, "
+            "r.id DESC"
+        )
         rows = conn.execute(sql, params).fetchall()
     finally:
         conn.close()

--- a/apps/PMC跟仓管/加工管理/tests/test_api_records.py
+++ b/apps/PMC跟仓管/加工管理/tests/test_api_records.py
@@ -82,6 +82,25 @@ def test_records_are_ordered_by_newest_date_first(client):
     ]
 
 
+def test_same_date_nfc_records_are_ordered_by_sticker_number(client):
+    admin_login(client)
+    for sticker_type in ["45#NFC贴纸", "1#NFC贴纸", "10#NFC贴纸"]:
+        client.post("/api/records", json={
+            "rec_type": "inbound_raw",
+            "rec_date": "2036-06-27",
+            "material": "NFC贴纸",
+            "sticker_type": sticker_type,
+            "doc_no": f"{sticker_type}-SORT-SAME-DATE",
+            "qty": 10,
+        })
+
+    rows = client.get("/api/records?doc_no=SORT-SAME-DATE").json()
+
+    assert [r["sticker_type"] for r in rows] == [
+        "1#NFC贴纸", "10#NFC贴纸", "45#NFC贴纸"
+    ]
+
+
 def test_records_can_filter_by_doc_no_fuzzy(client):
     admin_login(client)
     client.post("/api/records", json={


### PR DESCRIPTION
Summary:
- keep record list sorted by newest date first
- sort same-date numbered sticker records by sticker number naturally
- add regression coverage for 1#/10#/45# NFC rows

Tests:
- python -m pytest tests/test_api_records.py::test_same_date_nfc_records_are_ordered_by_sticker_number -q
- python -m pytest tests/test_api_records.py -q
- node --check pcba/static/app.js
- git diff --check
- python -m pytest -q