### PR TITLE
feat(QA): 按货号追踪产品测试生命周期

### DIFF
--- a/apps/QA部/QA测试报告周结系统/client/src/App.jsx
+++ b/apps/QA部/QA测试报告周结系统/client/src/App.jsx
@@ -3,21 +3,26 @@ import Upload from './pages/Upload.jsx';
 import ReportList from './pages/ReportList.jsx';
 import ReportDetail from './pages/ReportDetail.jsx';
 import Weekly from './pages/Weekly.jsx';
+import Products from './pages/Products.jsx';
+import ProductDetail from './pages/ProductDetail.jsx';
 
 export default function App() {
   return (
     <div className="app">
       <header className="topbar">
-        <h1>QA 测试报告周结系统</h1>
+        <h1>QA 产品测试生命周期</h1>
         <nav>
-          <NavLink to="/" end>上传</NavLink>
+          <NavLink to="/" end>产品追踪</NavLink>
+          <NavLink to="/upload">上传报告</NavLink>
           <NavLink to="/reports">历史报告</NavLink>
           <NavLink to="/weekly">周报</NavLink>
         </nav>
       </header>
       <main>
         <Routes>
-          <Route path="/" element={<Upload />} />
+          <Route path="/" element={<Products />} />
+          <Route path="/products/:productNo" element={<ProductDetail />} />
+          <Route path="/upload" element={<Upload />} />
           <Route path="/reports" element={<ReportList />} />
           <Route path="/reports/:id" element={<ReportDetail />} />
           <Route path="/weekly" element={<Weekly />} />

--- a/apps/QA部/QA测试报告周结系统/client/src/ReportView.jsx
+++ b/apps/QA部/QA测试报告周结系统/client/src/ReportView.jsx
@@ -9,9 +9,12 @@ export default function ReportView({ report, showSummary = true, headingLevel = 
       {showSummary && (
         <div className="summary">
           <span>客户：<b>{report.customerName}</b></span>
+          {report.productNo && <span>货号：<b>{report.productNo}</b></span>}
+          {report.stage && <span>阶段：<b>{report.stage}</b></span>}
           <span>归属周：<b>{report.weekKey}</b></span>
           <span>有效行数：{report.totalRows}</span>
           <span>不合格行数：<b style={{ color: '#dc2626' }}>{report.failCount}</b></span>
+          <span>明确 PASS：<b style={{ color: '#16a34a' }}>{report.passCount || 0}</b></span>
           {report.totalImages > 0 && <span>附图：<b>{report.totalImages}</b> 张</span>}
           <span>上传时间：{new Date(report.uploadedAt).toLocaleString('zh-CN')}</span>
         </div>

--- a/apps/QA部/QA测试报告周结系统/client/src/api.js
+++ b/apps/QA部/QA测试报告周结系统/client/src/api.js
@@ -10,10 +10,11 @@ async function handle(res) {
   return data;
 }
 
-export async function uploadFile(file, customerId) {
+export async function uploadFile(file, customerId, stage = '') {
   const fd = new FormData();
   fd.append('file', file);
   if (customerId) fd.append('customerId', customerId);
+  if (stage) fd.append('stage', stage);
   return handle(await fetch(`${BASE}/upload`, { method: 'POST', body: fd }));
 }
 
@@ -57,6 +58,18 @@ export async function createCustomer(name) {
 
 export async function deleteCustomer(id) {
   return handle(await fetch(`${BASE}/customers/${id}`, { method: 'DELETE' }));
+}
+
+export async function listProducts(customerId = '', query = '') {
+  const params = new URLSearchParams();
+  if (customerId) params.set('customerId', customerId);
+  if (query) params.set('q', query);
+  const qs = params.toString() ? `?${params.toString()}` : '';
+  return handle(await fetch(`${BASE}/products${qs}`));
+}
+
+export async function getProduct(productNo) {
+  return handle(await fetch(`${BASE}/products/${encodeURIComponent(productNo)}`));
 }
 
 export function exportWeeklyUrl(weekKey, customerId) {

--- a/apps/QA部/QA测试报告周结系统/client/src/pages/ProductDetail.jsx
+++ b/apps/QA部/QA测试报告周结系统/client/src/pages/ProductDetail.jsx
@@ -1,0 +1,136 @@
+import { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { getProduct } from '../api.js';
+
+const STATUS_LABELS = { open: '未解决', recurring: '复发', resolved: '已解决' };
+
+export default function ProductDetail() {
+  const { productNo } = useParams();
+  const [data, setData] = useState(null);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    getProduct(productNo).then(setData).catch(e => setError(e.message));
+  }, [productNo]);
+
+  if (error) return <div className="page"><div className="error">{error}</div><Link to="/">返回产品列表</Link></div>;
+  if (!data) return <div className="page">加载产品档案中…</div>;
+
+  const { product, stages } = data;
+  return (
+    <div className="page lifecycle-page">
+      <Link className="back-link" to="/">← 返回产品列表</Link>
+      <div className="product-detail-head">
+        <div>
+          <div className="eyebrow">{product.customerName}</div>
+          <h2>{product.productNo} · {product.productName || '未填写产品名称'}</h2>
+          <p className="hint">共 {product.reportCount} 份测试报告，当前阶段 {product.currentStage || '未识别'}</p>
+        </div>
+        <div className={`product-health ${product.openCount ? 'has-open' : 'clear'}`}>
+          <strong>{product.openCount}</strong>
+          <span>项未解决</span>
+        </div>
+      </div>
+
+      <div className="stage-panel">
+        <h3>开发阶段</h3>
+        <div className="stage-rail">
+          {stages.map(stage => (
+            <div key={stage} className={`stage-node ${product.completedStages.includes(stage) ? 'done' : ''} ${product.currentStage === stage ? 'current' : ''}`}>
+              <i />
+              <span>{stage}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <section className="issue-section">
+        <div className="section-heading">
+          <div><h3>需要重点处理</h3><p>没有明确 PASS 的问题会一直保留在这里。</p></div>
+          <span className="count-pill danger">{product.openIssues.length}</span>
+        </div>
+        {product.openIssues.length === 0 ? (
+          <div className="all-clear">✓ 当前没有未解决问题</div>
+        ) : (
+          <div className="issue-grid">
+            {product.openIssues.map(issue => <IssueCard key={issue.issueKey} issue={issue} />)}
+          </div>
+        )}
+      </section>
+
+      <section className="timeline-section">
+        <div className="section-heading"><div><h3>测试报告时间线</h3><p>按 FS → EP → EP1 → PE2 → FEP → PP → PS 排列。</p></div></div>
+        <div className="report-timeline">
+          {product.reports.map(report => (
+            <div className="timeline-report" key={report.id}>
+              <div className="timeline-marker">{report.stage}</div>
+              <div className="timeline-content">
+                <Link to={`/reports/${report.id}`}><b>{report.originalName}</b></Link>
+                <div className="timeline-meta">
+                  <span>{formatDate(report.reportDate || report.uploadedAt)}</span>
+                  <span className="danger-text">FAIL {report.failCount}</span>
+                  <span className="success-text">PASS {report.passCount}</span>
+                  {report.totalImages > 0 && <span>图片 {report.totalImages}</span>}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="resolved-section">
+        <div className="section-heading">
+          <div><h3>已解决问题</h3><p>只有后续报告明确 PASS 才会进入这里，历史仍可追溯。</p></div>
+          <span className="count-pill success">{product.resolvedIssues.length}</span>
+        </div>
+        {product.resolvedIssues.length === 0 ? <p className="hint">暂无已解决问题</p> : (
+          <div className="table-wrap">
+            <table>
+              <thead><tr><th>测试项目</th><th>首次发现</th><th>解决阶段</th><th>最后问题描述</th></tr></thead>
+              <tbody>
+                {product.resolvedIssues.map(issue => (
+                  <tr key={issue.issueKey}>
+                    <td><b>{issue.testItem}</b></td>
+                    <td>{issue.firstSeenStage} · {formatDate(issue.firstSeenAt)}</td>
+                    <td><span className="status-badge resolved">{issue.resolvedStage} PASS</span></td>
+                    <td>{issue.latestDescription}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function IssueCard({ issue }) {
+  return (
+    <article className={`issue-card ${issue.status}`}>
+      <div className="issue-card-head">
+        <div><span className={`status-badge ${issue.status}`}>{STATUS_LABELS[issue.status]}</span><h4>{issue.testItem}</h4></div>
+        {issue.recurrenceCount > 0 && <b className="recurrence-count">复发 {issue.recurrenceCount} 次</b>}
+      </div>
+      <p className="issue-description">{issue.latestDescription || '报告中未填写问题描述'}</p>
+      <div className="issue-meta">
+        <span>首次：{issue.firstSeenStage} · {formatDate(issue.firstSeenAt)}</span>
+        <span>最近：{issue.lastSeenStage} · {formatDate(issue.lastSeenAt)}</span>
+      </div>
+      <div className="issue-history">
+        {issue.history.map((event, index) => (
+          <div className={`issue-event ${event.type}`} key={`${event.reportId}-${index}`}>
+            <span>{event.stage}</span>
+            <Link to={`/reports/${event.reportId}`}>{event.type === 'pass' ? '明确 PASS' : event.description || 'FAIL'}</Link>
+          </div>
+        ))}
+      </div>
+    </article>
+  );
+}
+
+function formatDate(value) {
+  if (!value) return '—';
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleDateString('zh-CN');
+}

--- a/apps/QA部/QA测试报告周结系统/client/src/pages/Products.jsx
+++ b/apps/QA部/QA测试报告周结系统/client/src/pages/Products.jsx
@@ -1,0 +1,126 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { listCustomers, listProducts } from '../api.js';
+
+const STAGES = ['FS', 'EP', 'EP1', 'PE2', 'FEP', 'PP', 'PS'];
+
+export default function Products() {
+  const [products, setProducts] = useState([]);
+  const [customers, setCustomers] = useState([]);
+  const [customerId, setCustomerId] = useState('');
+  const [query, setQuery] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => { listCustomers().then(r => setCustomers(r.list || [])); }, []);
+  useEffect(() => {
+    setLoading(true);
+    setError('');
+    const timer = setTimeout(() => {
+      listProducts(customerId, query)
+        .then(r => setProducts(r.list || []))
+        .catch(e => setError(e.message))
+        .finally(() => setLoading(false));
+    }, 180);
+    return () => clearTimeout(timer);
+  }, [customerId, query]);
+
+  const stats = useMemo(() => ({
+    products: products.length,
+    open: products.reduce((sum, product) => sum + product.openCount, 0),
+    recurring: products.reduce((sum, product) => sum + product.recurringCount, 0),
+    completed: products.filter(product => product.status === 'completed').length
+  }), [products]);
+
+  return (
+    <div className="page lifecycle-page">
+      <div className="page-heading">
+        <div>
+          <h2>产品测试生命周期</h2>
+          <p className="hint">按测试报告货号归档，从 FS 到 PS 跟踪所有测试与问题闭环。</p>
+        </div>
+        <Link className="btn-link" to="/upload">+ 上传测试报告</Link>
+      </div>
+
+      <div className="stat-grid">
+        <StatCard label="产品数量" value={stats.products} tone="blue" />
+        <StatCard label="未解决问题" value={stats.open} tone={stats.open ? 'red' : 'green'} />
+        <StatCard label="复发问题" value={stats.recurring} tone={stats.recurring ? 'purple' : 'green'} />
+        <StatCard label="已完成产品" value={stats.completed} tone="green" />
+      </div>
+
+      <div className="filter-bar">
+        <input
+          type="search"
+          placeholder="搜索货号、产品名或客户"
+          value={query}
+          onChange={event => setQuery(event.target.value)}
+        />
+        <select value={customerId} onChange={event => setCustomerId(event.target.value)}>
+          <option value="">全部客户</option>
+          {customers.map(customer => <option key={customer.id} value={customer.id}>{customer.name}</option>)}
+        </select>
+      </div>
+
+      {error && <div className="error">{error}</div>}
+      {loading && <p className="hint">加载产品档案中…</p>}
+      {!loading && products.length === 0 && (
+        <div className="empty-state">
+          <h3>暂无产品档案</h3>
+          <p>上传第一份测试报告后，系统会根据报告中的货号自动建立产品档案。</p>
+          <Link className="btn-link" to="/upload">上传报告</Link>
+        </div>
+      )}
+      {!loading && products.length > 0 && (
+        <div className="product-list">
+          {products.map(product => (
+            <Link className="product-card" key={product.productNo} to={`/products/${encodeURIComponent(product.productNo)}`}>
+              <div className="product-card-main">
+                <div className="product-title-row">
+                  <span className="product-no">{product.productNo}</span>
+                  <StatusBadge status={product.status} openCount={product.openCount} recurringCount={product.recurringCount} />
+                </div>
+                <h3>{product.productName || '未填写产品名称'}</h3>
+                <div className="product-meta">
+                  <span>客户：{product.customerName}</span>
+                  <span>报告：{product.reportCount} 份</span>
+                  <span>当前阶段：<b>{product.currentStage || '未识别'}</b></span>
+                </div>
+                <StageRail completed={product.completedStages || []} current={product.currentStage} />
+              </div>
+              <div className="issue-counts">
+                <div><strong className={product.openCount ? 'danger-text' : 'success-text'}>{product.openCount}</strong><span>未解决</span></div>
+                <div><strong className={product.recurringCount ? 'purple-text' : ''}>{product.recurringCount}</strong><span>复发</span></div>
+                <div><strong className="success-text">{product.resolvedCount}</strong><span>已解决</span></div>
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StatCard({ label, value, tone }) {
+  return <div className={`stat-card ${tone}`}><span>{label}</span><strong>{value}</strong></div>;
+}
+
+function StatusBadge({ status, openCount, recurringCount }) {
+  if (recurringCount > 0) return <span className="status-badge recurring">有复发问题</span>;
+  if (openCount > 0) return <span className="status-badge open">有未解决问题</span>;
+  if (status === 'completed') return <span className="status-badge resolved">已完成</span>;
+  return <span className="status-badge clear">开发中 · 暂无遗留</span>;
+}
+
+function StageRail({ completed, current }) {
+  return (
+    <div className="stage-rail compact">
+      {STAGES.map(stage => (
+        <div key={stage} className={`stage-node ${completed.includes(stage) ? 'done' : ''} ${current === stage ? 'current' : ''}`}>
+          <i />
+          <span>{stage}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/QA部/QA测试报告周结系统/client/src/pages/ReportList.jsx
+++ b/apps/QA部/QA测试报告周结系统/client/src/pages/ReportList.jsx
@@ -39,7 +39,7 @@ export default function ReportList() {
       </div>
       {loading && <p className="hint">加载中…</p>}
       {!loading && list.length === 0 && (
-        <p className="hint">暂无记录，去 <Link to="/">上传</Link> 一份吧。</p>
+        <p className="hint">暂无记录，去 <Link to="/upload">上传</Link> 一份吧。</p>
       )}
       {!loading && list.length > 0 && (
         <div className="table-wrap">
@@ -47,6 +47,8 @@ export default function ReportList() {
             <thead>
               <tr>
                 <th>客户</th>
+                <th>货号</th>
+                <th>阶段</th>
                 <th>文件名</th>
                 <th>归属周</th>
                 <th>上传时间</th>
@@ -59,6 +61,8 @@ export default function ReportList() {
               {list.map(r => (
                 <tr key={r.id}>
                   <td><b>{r.customerName}</b></td>
+                  <td>{r.productNo ? <Link to={`/products/${encodeURIComponent(r.productNo)}`}><b>{r.productNo}</b></Link> : '—'}</td>
+                  <td><span className="stage-badge">{r.stage || '—'}</span></td>
                   <td><Link to={`/reports/${r.id}`}>{r.originalName}</Link></td>
                   <td>{r.weekKey}</td>
                   <td>{new Date(r.uploadedAt).toLocaleString('zh-CN')}</td>

--- a/apps/QA部/QA测试报告周结系统/client/src/pages/Upload.jsx
+++ b/apps/QA部/QA测试报告周结系统/client/src/pages/Upload.jsx
@@ -1,6 +1,9 @@
-import { useState, useRef, useEffect } from 'react';
-import { uploadFile, listCustomers, createCustomer } from '../api.js';
+import { useEffect, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { createCustomer, listCustomers, uploadFile } from '../api.js';
 import SheetImages from '../SheetImages.jsx';
+
+const STAGES = ['FS', 'EP', 'EP1', 'PE2', 'FEP', 'PP', 'PS'];
 
 export default function Upload() {
   const [file, setFile] = useState(null);
@@ -9,16 +12,17 @@ export default function Upload() {
   const [error, setError] = useState('');
   const [customers, setCustomers] = useState([]);
   const [customerId, setCustomerId] = useState('');
+  const [stage, setStage] = useState('');
   const [showCreate, setShowCreate] = useState(false);
   const [newName, setNewName] = useState('');
   const inputRef = useRef();
 
   async function refreshCustomers(autoSelectName) {
-    const r = await listCustomers();
-    setCustomers(r.list || []);
+    const response = await listCustomers();
+    setCustomers(response.list || []);
     if (autoSelectName) {
-      const m = (r.list || []).find(c => c.name === autoSelectName);
-      if (m) setCustomerId(m.id);
+      const match = (response.list || []).find(customer => customer.name === autoSelectName);
+      if (match) setCustomerId(match.id);
     }
   }
   useEffect(() => { refreshCustomers(); }, []);
@@ -27,9 +31,10 @@ export default function Upload() {
     const name = newName.trim();
     if (!name) return;
     try {
-      const r = await createCustomer(name);
-      await refreshCustomers(r.customer.name);
-      setNewName(''); setShowCreate(false);
+      const response = await createCustomer(name);
+      await refreshCustomers(response.customer.name);
+      setNewName('');
+      setShowCreate(false);
     } catch (e) {
       setError(e.message);
     }
@@ -38,10 +43,12 @@ export default function Upload() {
   async function onUpload() {
     if (!file) return;
     if (!customerId) { setError('请先选择客户（或新增一个）'); return; }
-    setBusy(true); setError(''); setResult(null);
+    setBusy(true);
+    setError('');
+    setResult(null);
     try {
-      const r = await uploadFile(file, customerId);
-      setResult(r.report);
+      const response = await uploadFile(file, customerId, stage);
+      setResult(response);
     } catch (e) {
       setError(e.message);
     } finally {
@@ -50,42 +57,58 @@ export default function Upload() {
   }
 
   function reset() {
-    setResult(null); setFile(null); setError('');
+    setResult(null);
+    setFile(null);
+    setError('');
+    setStage('');
     if (inputRef.current) inputRef.current.value = '';
   }
+
+  const report = result?.report;
+  const changes = result?.lifecycleChanges;
 
   return (
     <div className="page">
       <h2>上传测试报告</h2>
       <p className="hint">
-        支持 <code>.xlsx</code> / <code>.xls</code> / <code>.xlsm</code>。系统会自动识别
-        <b style={{ color: '#dc2626' }}> 红色字体 </b>（含红色填充）作为不合格项，按客户和 ISO 周自动归档。
+        系统从报告中的<b>货号 / Product No</b>建立产品档案，自动识别红字 FAIL 与明确 PASS，
+        并按 <b>FS → EP → EP1 → PE2 → FEP → PP → PS</b> 更新问题状态。
       </p>
 
-      <div className="form-row">
-        <label>客户：</label>
-        <select value={customerId} onChange={e => setCustomerId(e.target.value)}>
-          <option value="">-- 请选择客户 --</option>
-          {customers.map(c => <option key={c.id} value={c.id}>{c.name}</option>)}
-        </select>
-        {!showCreate && (
-          <button className="btn-ghost" onClick={() => setShowCreate(true)}>+ 新增客户</button>
-        )}
-        {showCreate && (
-          <span className="inline-create">
-            <input
-              type="text"
-              placeholder="客户名称"
-              value={newName}
-              onChange={e => setNewName(e.target.value)}
-              onKeyDown={e => { if (e.key === 'Enter') onCreateCustomer(); }}
-              maxLength={60}
-              autoFocus
-            />
-            <button onClick={onCreateCustomer} disabled={!newName.trim()}>保存</button>
-            <button className="btn-ghost" onClick={() => { setShowCreate(false); setNewName(''); }}>取消</button>
-          </span>
-        )}
+      <div className="upload-config">
+        <div className="field-group">
+          <label>客户 <b>*</b></label>
+          <div className="field-inline">
+            <select value={customerId} onChange={event => setCustomerId(event.target.value)}>
+              <option value="">-- 请选择客户 --</option>
+              {customers.map(customer => <option key={customer.id} value={customer.id}>{customer.name}</option>)}
+            </select>
+            {!showCreate && <button className="btn-ghost" onClick={() => setShowCreate(true)}>+ 新增客户</button>}
+          </div>
+          {showCreate && (
+            <div className="inline-create">
+              <input
+                type="text"
+                placeholder="客户名称"
+                value={newName}
+                onChange={event => setNewName(event.target.value)}
+                onKeyDown={event => { if (event.key === 'Enter') onCreateCustomer(); }}
+                maxLength={60}
+                autoFocus
+              />
+              <button onClick={onCreateCustomer} disabled={!newName.trim()}>保存</button>
+              <button className="btn-ghost" onClick={() => { setShowCreate(false); setNewName(''); }}>取消</button>
+            </div>
+          )}
+        </div>
+
+        <div className="field-group">
+          <label>测试阶段 <span>（报告可自动识别，也可手动覆盖）</span></label>
+          <select value={stage} onChange={event => setStage(event.target.value)}>
+            <option value="">自动识别</option>
+            {STAGES.map(item => <option key={item} value={item}>{item}</option>)}
+          </select>
+        </div>
       </div>
 
       <div className="uploader">
@@ -93,47 +116,53 @@ export default function Upload() {
           ref={inputRef}
           type="file"
           accept=".xlsx,.xls,.xlsm"
-          onChange={e => setFile(e.target.files[0])}
+          onChange={event => setFile(event.target.files[0])}
         />
-        <button onClick={onUpload} disabled={!file || busy}>{busy ? '解析中…' : '上传并解析'}</button>
+        <button onClick={onUpload} disabled={!file || busy}>{busy ? '解析并更新产品档案…' : '上传并更新生命周期'}</button>
       </div>
 
       {error && <div className="error">{error}</div>}
 
-      {result && (
+      {report && (
         <div className="result">
-          <h3>解析结果</h3>
-          <div className="summary">
-            <span>客户：<b>{result.customerName}</b></span>
-            <span>文件：<b>{result.originalName}</b></span>
-            <span>归属周：<b>{result.weekKey}</b></span>
-            <span>有效行数：{result.totalRows}</span>
-            <span>不合格行数：<b style={{ color: '#dc2626' }}>{result.failCount}</b></span>
-            {result.totalImages > 0 && <span>附图：<b>{result.totalImages}</b> 张</span>}
+          <div className="upload-success-head">
+            <div><span className="success-icon">✓</span><div><h3>报告已归档</h3><p>产品问题台账已按本次结果更新。</p></div></div>
+            <Link className="btn-link" to={`/products/${encodeURIComponent(report.productNo)}`}>查看产品档案 →</Link>
           </div>
-          {result.sheets.map(sh => (
-            <div key={sh.sheetId} className="sheet-block">
-              <h4>Sheet: {sh.name}（{sh.totalRows} 行 / 不合格 {sh.failCount} 行）</h4>
-              {sh.failRows.length > 0 ? (
+
+          <div className="summary">
+            <span>货号：<b>{report.productNo}</b></span>
+            <span>产品：<b>{report.productName || '—'}</b></span>
+            <span>客户：<b>{report.customerName}</b></span>
+            <span>阶段：<b>{report.stage}</b></span>
+            <span>FAIL：<b className="danger-text">{report.failCount}</b></span>
+            <span>明确 PASS：<b className="success-text">{report.passCount || 0}</b></span>
+            {report.totalImages > 0 && <span>附图：<b>{report.totalImages}</b> 张</span>}
+          </div>
+
+          {changes && (
+            <div className="change-grid">
+              <ChangeCard label="新增问题" value={changes.newOpen.length} tone="red" issues={changes.newOpen} />
+              <ChangeCard label="本次已解决" value={changes.resolved.length} tone="green" issues={changes.resolved} />
+              <ChangeCard label="本次复发" value={changes.recurring.length} tone="purple" issues={changes.recurring} />
+              <ChangeCard label="仍未解决" value={(result.product?.openCount || 0)} tone="amber" issues={changes.stillOpen} />
+            </div>
+          )}
+
+          {report.sheets.map(sheet => (
+            <div key={sheet.sheetId} className="sheet-block">
+              <h4>Sheet: {sheet.name}（FAIL {sheet.failCount} / PASS {sheet.passCount || 0}）</h4>
+              {sheet.failRows.length > 0 ? (
                 <div className="table-wrap">
                   <table>
-                    <thead>
-                      <tr>
-                        <th>行号</th>
-                        {sh.headers.map((h, i) => <th key={i}>{h}</th>)}
-                      </tr>
-                    </thead>
+                    <thead><tr><th>行号</th>{sheet.headers.map((header, index) => <th key={index}>{header}</th>)}</tr></thead>
                     <tbody>
-                      {sh.failRows.map(row => (
+                      {sheet.failRows.map(row => (
                         <tr key={row.rowNumber}>
                           <td>{row.rowNumber}</td>
-                          {sh.headers.map((_, i) => {
-                            const c = row.cells[i];
-                            return (
-                              <td key={i} className={c && c.isRed ? 'red-cell' : ''}>
-                                {c ? c.value : ''}
-                              </td>
-                            );
+                          {sheet.headers.map((_, index) => {
+                            const cell = row.cells[index];
+                            return <td key={index} className={cell?.isRed ? 'red-cell' : ''}>{cell?.value || ''}</td>;
                           })}
                         </tr>
                       ))}
@@ -141,12 +170,22 @@ export default function Upload() {
                   </table>
                 </div>
               ) : <p className="hint">本 Sheet 无不合格行</p>}
-              <SheetImages sheet={sh} />
+              <SheetImages sheet={sheet} />
             </div>
           ))}
           <button onClick={reset}>继续上传</button>
         </div>
       )}
+    </div>
+  );
+}
+
+function ChangeCard({ label, value, tone, issues }) {
+  return (
+    <div className={`change-card ${tone}`}>
+      <span>{label}</span>
+      <strong>{value}</strong>
+      {issues?.length > 0 && <small>{issues.slice(0, 2).map(issue => issue.testItem).join('、')}{issues.length > 2 ? '…' : ''}</small>}
     </div>
   );
 }

--- a/apps/QA部/QA测试报告周结系统/client/src/styles.css
+++ b/apps/QA部/QA测试报告周结系统/client/src/styles.css
@@ -199,3 +199,166 @@ tr:hover td { background: #fafafa; }
 .result h3 { margin-top: 24px; }
 a { color: #2563eb; }
 a:hover { text-decoration: underline; }
+
+/* 产品生命周期 */
+.page-heading, .section-heading, .product-detail-head, .upload-success-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+}
+.page-heading h2, .section-heading h3, .product-detail-head h2, .upload-success-head h3 { margin: 0; }
+.page-heading p, .section-heading p, .upload-success-head p { margin: 5px 0 0; color: #6b7280; }
+.btn-link {
+  display: inline-block;
+  padding: 9px 16px;
+  background: #2563eb;
+  color: #fff;
+  border-radius: 6px;
+  text-decoration: none;
+  white-space: nowrap;
+}
+.btn-link:hover { color: #fff; background: #1d4ed8; text-decoration: none; }
+.stat-grid, .change-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  margin: 20px 0;
+}
+.stat-card, .change-card {
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  padding: 15px 17px;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+.stat-card span, .change-card span { color: #6b7280; }
+.stat-card strong, .change-card strong { font-size: 27px; line-height: 1; }
+.stat-card.blue strong { color: #2563eb; }
+.stat-card.red strong, .change-card.red strong { color: #dc2626; }
+.stat-card.green strong, .change-card.green strong { color: #16a34a; }
+.stat-card.purple strong, .change-card.purple strong { color: #7c3aed; }
+.change-card.amber strong { color: #d97706; }
+.change-card small { color: #6b7280; line-height: 1.35; }
+.filter-bar {
+  display: flex;
+  gap: 10px;
+  padding: 14px;
+  background: #f8fafc;
+  border-radius: 8px;
+  margin-bottom: 16px;
+}
+.filter-bar input, .filter-bar select, .field-group select {
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  padding: 9px 11px;
+  background: #fff;
+  font: inherit;
+}
+.filter-bar input { flex: 1; min-width: 240px; }
+.filter-bar select { min-width: 180px; }
+.empty-state { text-align: center; padding: 54px 20px; background: #f8fafc; border-radius: 10px; color: #64748b; }
+.empty-state h3 { color: #334155; }
+.product-list { display: grid; gap: 12px; }
+.product-card {
+  display: flex;
+  align-items: stretch;
+  justify-content: space-between;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  background: #fff;
+  color: inherit;
+  text-decoration: none;
+  overflow: hidden;
+  transition: border-color .15s, box-shadow .15s;
+}
+.product-card:hover { border-color: #93c5fd; box-shadow: 0 4px 14px rgba(37,99,235,.08); text-decoration: none; }
+.product-card-main { padding: 17px 20px; flex: 1; min-width: 0; }
+.product-title-row { display: flex; align-items: center; gap: 10px; }
+.product-no { color: #1d4ed8; font-weight: 800; font-size: 17px; }
+.product-card h3 { margin: 6px 0; font-size: 15px; }
+.product-meta { display: flex; flex-wrap: wrap; gap: 18px; color: #64748b; font-size: 13px; }
+.issue-counts { display: grid; grid-template-columns: repeat(3, 82px); background: #f8fafc; border-left: 1px solid #e2e8f0; }
+.issue-counts > div { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 5px; }
+.issue-counts strong { font-size: 22px; color: #475569; }
+.issue-counts span { font-size: 12px; color: #64748b; }
+.danger-text { color: #dc2626 !important; }
+.success-text { color: #16a34a !important; }
+.purple-text { color: #7c3aed !important; }
+.status-badge, .stage-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 8px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+.status-badge.open { color: #b91c1c; background: #fee2e2; }
+.status-badge.recurring { color: #6d28d9; background: #ede9fe; }
+.status-badge.resolved, .status-badge.clear { color: #15803d; background: #dcfce7; }
+.stage-badge { color: #1d4ed8; background: #dbeafe; }
+.stage-rail { display: flex; align-items: flex-start; margin-top: 18px; overflow-x: auto; }
+.stage-node { position: relative; flex: 1 0 72px; text-align: center; color: #94a3b8; font-size: 12px; }
+.stage-node::before { content: ''; position: absolute; top: 6px; left: 0; right: 0; height: 2px; background: #e2e8f0; z-index: 0; }
+.stage-node:first-child::before { left: 50%; }
+.stage-node:last-child::before { right: 50%; }
+.stage-node i { position: relative; display: block; width: 13px; height: 13px; border-radius: 50%; margin: 0 auto 6px; background: #e2e8f0; border: 2px solid #fff; box-shadow: 0 0 0 1px #cbd5e1; z-index: 1; }
+.stage-node.done::before { background: #60a5fa; }
+.stage-node.done i { background: #3b82f6; box-shadow: 0 0 0 1px #3b82f6; }
+.stage-node.current { color: #1d4ed8; font-weight: 800; }
+.stage-node.current i { background: #1d4ed8; box-shadow: 0 0 0 3px #bfdbfe; }
+.stage-rail.compact { max-width: 620px; margin-top: 14px; }
+.stage-panel { background: #f8fafc; border: 1px solid #e2e8f0; padding: 18px 20px; border-radius: 10px; margin: 18px 0 24px; }
+.stage-panel h3 { margin: 0; font-size: 14px; }
+.back-link { display: inline-block; margin-bottom: 15px; text-decoration: none; }
+.eyebrow { color: #2563eb; font-weight: 700; margin-bottom: 5px; }
+.product-health { min-width: 110px; text-align: center; padding: 13px 18px; border-radius: 10px; }
+.product-health.has-open { background: #fef2f2; color: #b91c1c; }
+.product-health.clear { background: #f0fdf4; color: #15803d; }
+.product-health strong { display: block; font-size: 30px; }
+.product-health span { font-size: 12px; }
+.issue-section, .timeline-section, .resolved-section { margin: 28px 0; }
+.section-heading { border-bottom: 1px solid #e5e7eb; padding-bottom: 11px; margin-bottom: 14px; }
+.section-heading p { font-size: 13px; }
+.count-pill { min-width: 32px; text-align: center; padding: 5px 9px; border-radius: 999px; font-weight: 800; }
+.count-pill.danger { background: #fee2e2; color: #b91c1c; }
+.count-pill.success { background: #dcfce7; color: #15803d; }
+.all-clear { padding: 26px; text-align: center; border: 1px solid #bbf7d0; border-radius: 9px; background: #f0fdf4; color: #15803d; font-weight: 700; }
+.issue-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(360px, 1fr)); gap: 13px; }
+.issue-card { border: 1px solid #fecaca; border-left: 5px solid #dc2626; border-radius: 9px; padding: 15px; background: #fffafa; }
+.issue-card.recurring { border-color: #ddd6fe; border-left-color: #7c3aed; background: #faf5ff; }
+.issue-card-head { display: flex; justify-content: space-between; gap: 12px; }
+.issue-card-head > div { display: flex; align-items: center; gap: 9px; }
+.issue-card h4 { margin: 0; font-size: 16px; }
+.recurrence-count { color: #7c3aed; font-size: 12px; }
+.issue-description { margin: 13px 0; line-height: 1.55; font-weight: 600; }
+.issue-meta { display: flex; flex-wrap: wrap; gap: 15px; color: #64748b; font-size: 12px; }
+.issue-history { margin-top: 12px; border-top: 1px dashed #e2e8f0; padding-top: 8px; }
+.issue-event { display: grid; grid-template-columns: 50px 1fr; gap: 8px; padding: 4px 0; font-size: 12px; }
+.issue-event > span { font-weight: 800; color: #475569; }
+.report-timeline { position: relative; margin-left: 28px; border-left: 2px solid #dbeafe; }
+.timeline-report { display: flex; gap: 14px; margin: 0 0 15px -25px; align-items: flex-start; }
+.timeline-marker { width: 48px; min-width: 48px; height: 32px; display: grid; place-items: center; border-radius: 16px; background: #2563eb; color: #fff; font-size: 11px; font-weight: 800; }
+.timeline-content { flex: 1; border: 1px solid #e2e8f0; border-radius: 8px; padding: 11px 13px; background: #fff; }
+.timeline-meta { display: flex; flex-wrap: wrap; gap: 14px; margin-top: 7px; color: #64748b; font-size: 12px; }
+.upload-config { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; padding: 16px; background: #f8fafc; border-radius: 9px; margin-top: 18px; }
+.field-group { display: flex; flex-direction: column; gap: 8px; }
+.field-group label { font-weight: 700; }
+.field-group label b { color: #dc2626; }
+.field-group label span { font-weight: 400; color: #64748b; font-size: 12px; }
+.field-inline { display: flex; gap: 8px; }
+.field-inline select { flex: 1; }
+.upload-success-head { padding: 14px 0; }
+.upload-success-head > div { display: flex; gap: 12px; align-items: center; }
+.success-icon { width: 36px; height: 36px; display: grid; place-items: center; border-radius: 50%; background: #dcfce7; color: #15803d; font-size: 20px; font-weight: 900; }
+
+@media (max-width: 850px) {
+  .stat-grid, .change-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .product-card { display: block; }
+  .issue-counts { grid-template-columns: repeat(3, 1fr); border-left: 0; border-top: 1px solid #e2e8f0; padding: 12px 0; }
+  .upload-config { grid-template-columns: 1fr; }
+  .issue-grid { grid-template-columns: 1fr; }
+}

--- a/apps/QA部/QA测试报告周结系统/server/lib/excel-parser.js
+++ b/apps/QA部/QA测试报告周结系统/server/lib/excel-parser.js
@@ -1,5 +1,6 @@
 import ExcelJS from 'exceljs';
 import { extractAnnotatedImages } from './xlsx-images.js';
+import { normalizeIssueKey, normalizeStage } from './lifecycle.js';
 
 function argbToRgb(argb) {
   if (!argb) return null;
@@ -98,6 +99,8 @@ function cellIsRed(cell) {
 const CHECK_MARK_RE = /^[■□☐✓×√◇◆▲△○●—\-_\s]+$/;
 const STRONG_FAIL_RE = /FAIL|NG\b|不合格|不通过|异常|超差|超标|缺陷|损坏|破损|裂|起锈|划痕|磨花|擦花|脱漆|偏差/i;
 const WEAK_PASS_RE = /\b(PASS(ED)?|OK|TRUE)\b|合\s*格|通\s*过|完\s*成/i;
+const EXPLICIT_PASS_RE = /\bPASS(?:ED)?\b|合\s*格|通\s*过|通\s*過/i;
+const NEGATED_PASS_RE = /\bNOT\s+PASS(?:ED)?\b|不\s*合\s*格|不\s*通\s*过|未\s*通\s*过|不\s*通\s*過|未\s*通\s*過/i;
 // 整体结论模板行 —— "Conclusion 結論：□PASSED ■FAILED □INF.ONLY" 这种带选项框的行，不计入条目
 const CONCLUSION_LINE_RE = /Conclusion|結\s*論|结\s*论|INF\.?ONLY|僅\s*供\s*參\s*考|仅供参考/i;
 
@@ -211,16 +214,141 @@ export function groupImagesByFailRows(failRows, images) {
   return { groups, sampleImages, orphan };
 }
 
-export async function parseExcelRedRows(buffer) {
+function normalizeHeader(value) {
+  return String(value || '').toUpperCase().replace(/\s+/g, '');
+}
+
+function isResultTable(headers) {
+  return headers.some(header => {
+    const h = normalizeHeader(header);
+    return h.includes('TESTITEM') || h.includes('試驗項目') || h.includes('试验项目') ||
+      h.includes('SAMPLESNO') || h.includes('样板编号') || h.includes('樣板編號') ||
+      h.includes('TESTDESCRIPTION') || h.includes('試驗描述') || h.includes('试验描述');
+  });
+}
+
+function findHeaderIndex(headers, patterns) {
+  return headers.findIndex(header => {
+    const h = normalizeHeader(header);
+    return patterns.some(pattern => h.includes(pattern));
+  });
+}
+
+function looksLikeCondition(value) {
+  const text = String(value || '').trim();
+  return /(?:RPM|R\/MIN|HRS?|MIN|SEC|℃|°C|CM|MM|KG|\d+\s*[X×*]\s*\d+)/i.test(text);
+}
+
+function uniqueRowTexts(sheet, rowNumber, maxCol) {
+  const values = [];
+  for (let col = 1; col <= maxCol; col++) {
+    const value = safeText(sheet.getRow(rowNumber).getCell(col)).trim();
+    if (value && values[values.length - 1] !== value && !values.includes(value)) values.push(value);
+  }
+  return values;
+}
+
+function valueAfterLabel(values, labelRe) {
+  const index = values.findIndex(value => labelRe.test(value));
+  if (index < 0) return '';
+  for (let i = index + 1; i < values.length; i++) {
+    if (!labelRe.test(values[i])) return values[i].trim();
+  }
+  return '';
+}
+
+function extractReportMetadata(wb, fileName = '') {
+  let productNo = '';
+  let productName = '';
+  let stage = '';
+  let stageSource = '';
+  const productNoLabel = /Product\s*(?:No|Number)|產品編號|产品编号|貨號|货号/i;
+  const productNameLabel = /Product\s*Name|產品名稱|产品名称/i;
+
+  for (const sheet of wb.worksheets) {
+    if (sheet.state === 'hidden' || sheet.state === 'veryHidden') continue;
+    const maxCol = sheet.actualColumnCount || sheet.columnCount || 0;
+    for (let rowNumber = 1; rowNumber <= Math.min(15, sheet.rowCount); rowNumber++) {
+      const values = uniqueRowTexts(sheet, rowNumber, maxCol);
+      const joined = values.join(' | ');
+
+      if (!stage) {
+        const checked = joined.match(/[■☑✓]\s*(FEP1|FEP2|EP1|EP2|PE2|FEP|FS|PP|PS|EP)(?=\s|$|□|■|☐|☑)/i);
+        if (checked) {
+          stage = normalizeStage(checked[1]);
+          stageSource = 'report';
+        }
+      }
+
+      if (!productNo) {
+        const inline = joined.match(/(?:Product\s*(?:No|Number)(?:\/Name)?|產品編號|产品编号|貨號|货号)[^：:|]*[：:]\s*([A-Z0-9][A-Z0-9._/-]{1,})/i);
+        if (inline) productNo = inline[1].trim();
+        if (!productNo) {
+          const after = valueAfterLabel(values, productNoLabel);
+          const token = after.match(/[A-Z0-9][A-Z0-9._/-]{1,}/i);
+          if (token && !/^(PRODUCT|REPORT)$/i.test(token[0])) productNo = token[0];
+        }
+      }
+
+      if (!productName) {
+        const after = valueAfterLabel(values, productNameLabel);
+        if (after && !productNoLabel.test(after)) productName = after;
+        const combined = joined.match(/Product\s*No\/Name[^：:|]*[：:]\s*[A-Z0-9._/-]+\s*\/\s*(.+?)(?:\s+Report\s*No|\||$)/i);
+        if (!productName && combined) productName = combined[1].trim();
+      }
+    }
+  }
+
+  if (!productNo && fileName) {
+    const match = String(fileName).match(/^\s*([A-Z0-9][A-Z0-9._/-]{2,})/i);
+    if (match) productNo = match[1];
+  }
+  if (!stage && fileName) {
+    const match = String(fileName).toUpperCase().match(/(?:^|[^A-Z0-9])(FEP1|FEP2|EP1|EP2|PE2|FEP|FS|PP|PS|EP)(?:[^A-Z0-9]|$)/);
+    if (match) {
+      stage = normalizeStage(match[1]);
+      stageSource = 'filename';
+    }
+  }
+
+  let reportDate = '';
+  const dateMatch = String(fileName).match(/(20\d{2})(\d{2})(\d{2})(?!\d)/);
+  if (dateMatch) reportDate = `${dateMatch[1]}-${dateMatch[2]}-${dateMatch[3]}T00:00:00.000Z`;
+
+  return {
+    productNo: String(productNo || '').trim().toUpperCase(),
+    productName: String(productName || '').trim(),
+    stage,
+    stageSource,
+    reportDate
+  };
+}
+
+function buildDescription(cells, descriptionIndex, redCols, fallback = '') {
+  const description = descriptionIndex >= 0 ? String(cells[descriptionIndex]?.value || '').trim() : '';
+  if (description) return description;
+  const redDescription = (redCols || [])
+    .map(col => `${col.header}=${col.value}`)
+    .filter(Boolean)
+    .join('；');
+  return redDescription || fallback;
+}
+
+export async function parseExcelRedRows(buffer, options = {}) {
+  const { includeImages = true, fileName = '' } = options;
   const wb = new ExcelJS.Workbook();
   await wb.xlsx.load(buffer);
 
+  const metadata = extractReportMetadata(wb, fileName);
+
   // 提前解析图片 + 标注（一次性，按 sheet 名归类后供主循环使用）
   let allAnnotated = [];
-  try {
-    allAnnotated = await extractAnnotatedImages(buffer);
-  } catch (e) {
-    console.warn('[parser] extractAnnotatedImages failed, images will be missing:', e.message);
+  if (includeImages) {
+    try {
+      allAnnotated = await extractAnnotatedImages(buffer);
+    } catch (e) {
+      console.warn('[parser] extractAnnotatedImages failed, images will be missing:', e.message);
+    }
   }
 
   const sheets = [];
@@ -239,9 +367,15 @@ export async function parseExcelRedRows(buffer) {
     const { rowNumber: headerRowNumber, headers: rawHeaders } = detectHeaderRow(sheet, maxCol);
     const headerGroups = computeHeaderGroups(rawHeaders);
     const headers = headerGroups.map(g => g.header);
+    const resultTable = isResultTable(headers);
+    const itemIndex = Math.max(0, findHeaderIndex(headers, ['TESTITEM', '試驗項目', '试验项目', 'SAMPLESNO', '样板编号', '樣板編號']));
+    const sampleSizeIndex = findHeaderIndex(headers, ['S/S', 'SAMPLESIZE', '樣板數量', '样板数量']);
+    const descriptionIndex = findHeaderIndex(headers, ['TESTDESCRIPTION', '試驗描述', '试验描述', 'DESCRIPTION', '描述']);
 
     const failRows = [];
+    const testResults = [];
     let dataRowCount = 0;
+    let currentTestItem = '';
     sheet.eachRow({ includeEmpty: false }, (row, rowNumber) => {
       if (rowNumber <= headerRowNumber) return;
       dataRowCount++;
@@ -256,7 +390,18 @@ export async function parseExcelRedRows(buffer) {
         if (isRedRaw) redCellsRaw.push({ colNumber, text });
       });
 
-      if (redCellsRaw.length === 0) return;
+      const snapByCol = new Map(cellSnapshots.map(s => [s.colNumber, s]));
+      const rawRedColSet = new Set(redCellsRaw.map(c => c.colNumber));
+      const compactCells = compactCellsByGroups(headerGroups, snapByCol, rawRedColSet);
+      const rowText = compactCells.map(cell => cell.value).filter(Boolean).join(' ');
+      const candidateItem = String(compactCells[itemIndex]?.value || '').trim();
+      const sampleSize = sampleSizeIndex >= 0 ? String(compactCells[sampleSizeIndex]?.value || '').trim() : '';
+      if (resultTable && candidateItem) {
+        if (!currentTestItem || sampleSize || !looksLikeCondition(candidateItem)) currentTestItem = candidateItem;
+      }
+      const testItem = currentTestItem || candidateItem;
+
+      let failRow = null;
 
       // 行级判定：拼起来所有红字内容看是否包含强不合格信号 vs 弱通过信号
       const seenForAggregate = new Set();
@@ -270,33 +415,49 @@ export async function parseExcelRedRows(buffer) {
       }
       const aggregate = uniqueRedTexts.join(' ');
       const verdict = classifyRow(aggregate);
-      if (verdict !== 'fail') return;
+      if (redCellsRaw.length > 0 && verdict === 'fail') {
+        // 构造去重后的 redCols（按 cell 文本去重，已经把合并区里的重复消掉）
+        const seen = new Set();
+        const redCols = [];
+        const colToHeader = (col) => {
+          const g = headerGroups.find(hg => hg.cols.includes(col));
+          return g ? g.header : `第${col}列`;
+        };
+        for (const c of redCellsRaw) {
+          const key = c.text.trim();
+          if (!key || isCheckmarkOnly(key)) continue;
+          if (seen.has(key)) continue;
+          seen.add(key);
+          redCols.push({ col: c.colNumber, header: colToHeader(c.colNumber), value: c.text });
+        }
+        if (redCols.length > 0) {
+          failRow = { rowNumber, redCols, cells: compactCells };
+          failRows.push(failRow);
+          if (resultTable && testItem) {
+            const description = buildDescription(compactCells, descriptionIndex, redCols, aggregate);
+            testResults.push({
+              rowNumber,
+              testItem,
+              issueKey: normalizeIssueKey(testItem),
+              status: 'fail',
+              description,
+              cells: compactCells
+            });
+          }
+        }
+      }
 
-      // 构造去重后的 redCols（按 cell 文本去重，已经把合并区里的重复消掉）
-      const seen = new Set();
-      const redCols = [];
-      const colToHeader = (col) => {
-        const g = headerGroups.find(hg => hg.cols.includes(col));
-        return g ? g.header : `第${col}列`;
-      };
-      for (const c of redCellsRaw) {
-        const key = c.text.trim();
-        if (!key || isCheckmarkOnly(key)) continue;
-        if (seen.has(key)) continue;
-        seen.add(key);
-        redCols.push({
-          col: c.colNumber,
-          header: colToHeader(c.colNumber),
-          value: c.text
+      if (!failRow && resultTable && testItem && !CONCLUSION_LINE_RE.test(rowText) &&
+          EXPLICIT_PASS_RE.test(rowText) && !NEGATED_PASS_RE.test(rowText) && !STRONG_FAIL_RE.test(rowText)) {
+        testResults.push({
+          rowNumber,
+          testItem,
+          issueKey: normalizeIssueKey(testItem),
+          status: 'pass',
+          description: buildDescription(compactCells, descriptionIndex, [], 'PASS'),
+          cells: compactCells
         });
       }
-      if (redCols.length === 0) return;
-
-      const redColSet = new Set(redCellsRaw.map(c => c.colNumber));
-      const snapByCol = new Map(cellSnapshots.map(s => [s.colNumber, s]));
-      const cells = compactCellsByGroups(headerGroups, snapByCol, redColSet);
-
-      failRows.push({ rowNumber, redCols, cells });
     });
 
     sheets.push({
@@ -305,10 +466,12 @@ export async function parseExcelRedRows(buffer) {
       headerRowNumber,
       headers,
       failRows,
+      testResults,
+      passCount: testResults.filter(result => result.status === 'pass').length,
       totalRows: dataRowCount,
       failCount: failRows.length
     });
   });
 
-  return { sheets, rawImages };
+  return { sheets, rawImages, metadata };
 }

--- a/apps/QA部/QA测试报告周结系统/server/lib/lifecycle.js
+++ b/apps/QA部/QA测试报告周结系统/server/lib/lifecycle.js
@@ -1,0 +1,213 @@
+export const STAGES = ['FS', 'EP', 'EP1', 'PE2', 'FEP', 'PP', 'PS'];
+
+export function normalizeProductNo(value) {
+  return String(value || '').trim().toUpperCase().replace(/\s+/g, '');
+}
+
+export function normalizeStage(value) {
+  const aliases = { FEP1: 'EP1', EP2: 'PE2', FEP2: 'PE2' };
+  const raw = String(value || '').trim().toUpperCase();
+  const stage = aliases[raw] || raw;
+  return STAGES.includes(stage) ? stage : '';
+}
+
+export function stageIndex(stage) {
+  const index = STAGES.indexOf(normalizeStage(stage));
+  return index < 0 ? Number.MAX_SAFE_INTEGER : index;
+}
+
+export function normalizeIssueKey(value) {
+  return String(value || '')
+    .trim()
+    .toUpperCase()
+    .replace(/[\s:：()（）\[\]【】,，.。/\\_\-]+/g, '');
+}
+
+function reportSort(a, b) {
+  const byStage = stageIndex(a.stage) - stageIndex(b.stage);
+  if (byStage !== 0) return byStage;
+  return String(a.reportDate || a.uploadedAt || '').localeCompare(String(b.reportDate || b.uploadedAt || ''));
+}
+
+function compactReportResults(report) {
+  const byKey = new Map();
+  for (const sheet of report.sheets || []) {
+    for (const result of sheet.testResults || []) {
+      const key = result.issueKey || normalizeIssueKey(result.testItem);
+      if (!key) continue;
+      if (!byKey.has(key)) {
+        byKey.set(key, {
+          issueKey: key,
+          testItem: result.testItem,
+          statuses: new Set(),
+          descriptions: [],
+          evidence: []
+        });
+      }
+      const item = byKey.get(key);
+      item.statuses.add(result.status);
+      if (result.description && !item.descriptions.includes(result.description)) item.descriptions.push(result.description);
+      item.evidence.push({
+        sheetName: sheet.name,
+        rowNumber: result.rowNumber,
+        status: result.status,
+        description: result.description,
+        cells: result.cells || []
+      });
+    }
+  }
+
+  return Array.from(byKey.values()).map(item => ({
+    ...item,
+    status: item.statuses.has('fail') ? 'fail' : 'pass',
+    statuses: undefined,
+    description: item.descriptions.join('；')
+  }));
+}
+
+function buildIssueLedger(reports) {
+  const issueMap = new Map();
+
+  for (const report of reports) {
+    const reportResults = compactReportResults(report);
+    for (const result of reportResults) {
+      let issue = issueMap.get(result.issueKey);
+
+      if (result.status === 'fail') {
+        if (!issue) {
+          issue = {
+            issueKey: result.issueKey,
+            testItem: result.testItem,
+            status: 'open',
+            recurrenceCount: 0,
+            firstSeenAt: report.reportDate || report.uploadedAt,
+            firstSeenStage: report.stage,
+            lastSeenAt: report.reportDate || report.uploadedAt,
+            lastSeenStage: report.stage,
+            latestDescription: result.description,
+            history: []
+          };
+          issueMap.set(result.issueKey, issue);
+        } else if (issue.status === 'resolved') {
+          issue.status = 'recurring';
+          issue.recurrenceCount += 1;
+          issue.reopenedAt = report.reportDate || report.uploadedAt;
+          issue.reopenedStage = report.stage;
+          issue.resolvedAt = null;
+          issue.resolvedStage = null;
+        } else if (issue.recurrenceCount > 0) {
+          issue.status = 'recurring';
+        }
+
+        issue.lastSeenAt = report.reportDate || report.uploadedAt;
+        issue.lastSeenStage = report.stage;
+        issue.latestDescription = result.description || issue.latestDescription;
+        issue.history.push({
+          type: issue.status === 'recurring' ? 'recurring' : 'fail',
+          reportId: report.id,
+          stage: report.stage,
+          reportDate: report.reportDate || report.uploadedAt,
+          originalName: report.originalName,
+          description: result.description,
+          evidence: result.evidence
+        });
+      } else if (issue && issue.status !== 'resolved') {
+        issue.status = 'resolved';
+        issue.resolvedAt = report.reportDate || report.uploadedAt;
+        issue.resolvedStage = report.stage;
+        issue.history.push({
+          type: 'pass',
+          reportId: report.id,
+          stage: report.stage,
+          reportDate: report.reportDate || report.uploadedAt,
+          originalName: report.originalName,
+          description: result.description || 'PASS',
+          evidence: result.evidence
+        });
+      }
+    }
+  }
+
+  return Array.from(issueMap.values()).map(issue => {
+    const openStageSet = new Set(
+      issue.history
+        .filter(h => h.type === 'fail' || h.type === 'recurring')
+        .map(h => h.stage)
+        .filter(Boolean)
+    );
+    return { ...issue, affectedStages: Array.from(openStageSet) };
+  }).sort((a, b) => {
+    const priority = { recurring: 0, open: 1, resolved: 2 };
+    const statusDiff = priority[a.status] - priority[b.status];
+    if (statusDiff !== 0) return statusDiff;
+    return String(b.lastSeenAt || '').localeCompare(String(a.lastSeenAt || ''));
+  });
+}
+
+export function buildProducts(reportList) {
+  const groups = new Map();
+  for (const report of reportList || []) {
+    const productNo = normalizeProductNo(report.productNo);
+    if (!productNo) continue;
+    if (!groups.has(productNo)) groups.set(productNo, []);
+    groups.get(productNo).push(report);
+  }
+
+  const products = [];
+  for (const [productNo, groupReports] of groups.entries()) {
+    const reports = [...groupReports].sort(reportSort);
+    const latest = reports[reports.length - 1];
+    const issues = buildIssueLedger(reports);
+    const openIssues = issues.filter(i => i.status === 'open' || i.status === 'recurring');
+    const recurringIssues = issues.filter(i => i.status === 'recurring');
+    const resolvedIssues = issues.filter(i => i.status === 'resolved');
+    const completedStages = Array.from(new Set(reports.map(r => normalizeStage(r.stage)).filter(Boolean)))
+      .sort((a, b) => stageIndex(a) - stageIndex(b));
+    const currentStage = completedStages[completedStages.length - 1] || '';
+    const customers = Array.from(new Set(reports.map(r => r.customerName).filter(Boolean)));
+
+    products.push({
+      productNo,
+      productName: latest.productName || reports.find(r => r.productName)?.productName || '',
+      customerName: latest.customerName || customers[0] || '未分类',
+      customers,
+      currentStage,
+      completedStages,
+      reportCount: reports.length,
+      openCount: openIssues.length,
+      recurringCount: recurringIssues.length,
+      resolvedCount: resolvedIssues.length,
+      status: currentStage === 'PS' && openIssues.length === 0 ? 'completed' : 'developing',
+      latestReportAt: latest.reportDate || latest.uploadedAt,
+      reports,
+      issues,
+      openIssues,
+      resolvedIssues
+    });
+  }
+
+  return products.sort((a, b) => {
+    if (a.openCount !== b.openCount) return b.openCount - a.openCount;
+    return String(b.latestReportAt || '').localeCompare(String(a.latestReportAt || ''));
+  });
+}
+
+export function summarizeProduct(product) {
+  if (!product) return null;
+  const { reports, issues, openIssues, resolvedIssues, ...summary } = product;
+  return summary;
+}
+
+export function diffLifecycle(beforeProduct, afterProduct) {
+  const before = new Map((beforeProduct?.issues || []).map(i => [i.issueKey, i]));
+  const changes = { newOpen: [], resolved: [], recurring: [], stillOpen: [] };
+
+  for (const issue of afterProduct?.issues || []) {
+    const old = before.get(issue.issueKey);
+    if (!old && issue.status !== 'resolved') changes.newOpen.push(issue);
+    else if (old && old.status !== 'resolved' && issue.status === 'resolved') changes.resolved.push(issue);
+    else if (old && old.status === 'resolved' && issue.status === 'recurring') changes.recurring.push(issue);
+    else if (old && old.status !== 'resolved' && issue.status !== 'resolved') changes.stillOpen.push(issue);
+  }
+  return changes;
+}

--- a/apps/QA部/QA测试报告周结系统/server/lib/report-migration.js
+++ b/apps/QA部/QA测试报告周结系统/server/lib/report-migration.js
@@ -1,0 +1,56 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { parseExcelRedRows } from './excel-parser.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const DATA_PATH = process.env.DATA_PATH || path.join(__dirname, '..', 'data');
+const REPORTS_FILE = path.join(DATA_PATH, 'reports.json');
+const UPLOAD_PATH = path.join(__dirname, '..', 'uploads');
+
+export async function migrateReportMetadata() {
+  if (!fs.existsSync(REPORTS_FILE)) return { migrated: 0, skipped: 0 };
+  const reports = JSON.parse(fs.readFileSync(REPORTS_FILE, 'utf8'));
+  let migrated = 0;
+  let skipped = 0;
+
+  for (const report of reports) {
+    const hasTestResults = (report.sheets || []).every(sheet => Array.isArray(sheet.testResults));
+    if (report.productNo && report.stage && hasTestResults) continue;
+
+    const source = path.join(UPLOAD_PATH, report.storedName || '');
+    if (!report.storedName || !fs.existsSync(source)) {
+      skipped++;
+      continue;
+    }
+
+    try {
+      const buffer = fs.readFileSync(source);
+      const parsed = await parseExcelRedRows(buffer, {
+        includeImages: false,
+        fileName: report.originalName || report.storedName
+      });
+      report.productNo = report.productNo || parsed.metadata.productNo;
+      report.productName = report.productName || parsed.metadata.productName;
+      report.stage = report.stage || parsed.metadata.stage;
+      report.stageSource = report.stageSource || parsed.metadata.stageSource;
+      report.reportDate = report.reportDate || parsed.metadata.reportDate || report.uploadedAt;
+
+      const parsedSheets = new Map(parsed.sheets.map(sheet => [String(sheet.name).trim(), sheet]));
+      for (const sheet of report.sheets || []) {
+        const updated = parsedSheets.get(String(sheet.name).trim());
+        sheet.testResults = updated?.testResults || [];
+        sheet.passCount = updated?.passCount || 0;
+      }
+      report.passCount = (report.sheets || []).reduce((sum, sheet) => sum + (sheet.passCount || 0), 0);
+      migrated++;
+    } catch (error) {
+      console.warn(`[migration] report ${report.id} skipped: ${error.message}`);
+      skipped++;
+    }
+  }
+
+  if (migrated > 0) fs.writeFileSync(REPORTS_FILE, JSON.stringify(reports, null, 2), 'utf8');
+  return { migrated, skipped };
+}

--- a/apps/QA部/QA测试报告周结系统/server/routes/products.js
+++ b/apps/QA部/QA测试报告周结系统/server/routes/products.js
@@ -1,0 +1,69 @@
+import { Router } from 'express';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { STAGES, buildProducts, normalizeProductNo, summarizeProduct } from '../lib/lifecycle.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const DATA_PATH = process.env.DATA_PATH || path.join(__dirname, '..', 'data');
+const REPORTS_FILE = path.join(DATA_PATH, 'reports.json');
+
+function readAll() {
+  if (!fs.existsSync(REPORTS_FILE)) return [];
+  return JSON.parse(fs.readFileSync(REPORTS_FILE, 'utf8'));
+}
+
+const router = Router();
+
+router.get('/', (req, res) => {
+  let reports = readAll();
+  const customerId = String(req.query.customerId || '');
+  const query = String(req.query.q || '').trim().toUpperCase();
+  if (customerId) reports = reports.filter(report => String(report.customerId || '') === customerId);
+
+  let products = buildProducts(reports);
+  if (query) {
+    products = products.filter(product =>
+      product.productNo.includes(query) ||
+      String(product.productName || '').toUpperCase().includes(query) ||
+      String(product.customerName || '').toUpperCase().includes(query)
+    );
+  }
+  res.json({ ok: true, stages: STAGES, list: products.map(summarizeProduct) });
+});
+
+router.get('/:productNo', (req, res) => {
+  const productNo = normalizeProductNo(decodeURIComponent(req.params.productNo));
+  const product = buildProducts(readAll()).find(item => item.productNo === productNo);
+  if (!product) return res.status(404).json({ error: '未找到该货号的产品记录' });
+
+  const reports = product.reports.map(report => ({
+    id: report.id,
+    originalName: report.originalName,
+    customerId: report.customerId,
+    customerName: report.customerName,
+    productNo: report.productNo,
+    productName: report.productName,
+    stage: report.stage,
+    reportDate: report.reportDate,
+    uploadedAt: report.uploadedAt,
+    failCount: report.failCount,
+    passCount: report.passCount || 0,
+    totalImages: report.totalImages || 0
+  }));
+
+  res.json({
+    ok: true,
+    stages: STAGES,
+    product: {
+      ...summarizeProduct(product),
+      reports,
+      issues: product.issues,
+      openIssues: product.openIssues,
+      resolvedIssues: product.resolvedIssues
+    }
+  });
+});
+
+export default router;

--- a/apps/QA部/QA测试报告周结系统/server/routes/reports.js
+++ b/apps/QA部/QA测试报告周结系统/server/routes/reports.js
@@ -13,7 +13,7 @@ const REPORTS_FILE = path.join(DATA_PATH, 'reports.json');
 const UPLOAD_PATH = path.join(__dirname, '..', 'uploads');
 
 function urlToLocal(url) {
-  // 兼容子路径前缀: /uploads/images/<id>/<file> 或 /qa-weekly-report/uploads/images/...
+  // 兼容 /uploads/... 与 /qa-weekly-report/uploads/... 等子路径前缀。
   const m = url && url.match(/\/uploads\/images\/([^/]+)\/([^/]+)$/);
   if (!m) return null;
   return path.join(UPLOAD_PATH, 'images', m[1], m[2]);
@@ -87,7 +87,12 @@ router.get('/', (req, res) => {
     year: r.year,
     week: r.week,
     totalRows: r.totalRows,
-    failCount: r.failCount
+    failCount: r.failCount,
+    passCount: r.passCount || 0,
+    productNo: r.productNo || '',
+    productName: r.productName || '',
+    stage: r.stage || '',
+    reportDate: r.reportDate || r.uploadedAt
   }));
   res.json({ ok: true, list: out });
 });

--- a/apps/QA部/QA测试报告周结系统/server/routes/upload.js
+++ b/apps/QA部/QA测试报告周结系统/server/routes/upload.js
@@ -5,6 +5,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { customAlphabet } from 'nanoid';
 import { parseExcelRedRows, groupImagesByFailRows } from '../lib/excel-parser.js';
+import { buildProducts, diffLifecycle, normalizeProductNo, normalizeStage, summarizeProduct } from '../lib/lifecycle.js';
 import { getCustomerById } from './customers.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -58,8 +59,9 @@ const router = Router();
 router.post('/', upload.single('file'), async (req, res) => {
   try {
     if (!req.file) return res.status(400).json({ error: '没有收到文件' });
+    const originalName = decodeFilename(req.file.originalname);
     const buffer = fs.readFileSync(req.file.path);
-    const { sheets, rawImages } = await parseExcelRedRows(buffer);
+    const { sheets, rawImages, metadata } = await parseExcelRedRows(buffer, { fileName: originalName });
 
     const totalFail = sheets.reduce((s, sh) => s + sh.failCount, 0);
     const totalRows = sheets.reduce((s, sh) => s + sh.totalRows, 0);
@@ -69,13 +71,26 @@ router.post('/', upload.single('file'), async (req, res) => {
     const customerId = (req.body && req.body.customerId) ? String(req.body.customerId) : '';
     const customer = customerId ? getCustomerById(customerId) : null;
     if (customerId && !customer) {
+      fs.rmSync(req.file.path, { force: true });
       return res.status(400).json({ error: '指定的客户不存在' });
+    }
+
+    const productNo = normalizeProductNo(metadata.productNo);
+    const manualStage = normalizeStage(req.body && req.body.stage);
+    const stage = manualStage || normalizeStage(metadata.stage);
+    if (!productNo) {
+      fs.rmSync(req.file.path, { force: true });
+      return res.status(400).json({ error: '无法从报告中识别货号 / Product No，请检查报告格式' });
+    }
+    if (!stage) {
+      fs.rmSync(req.file.path, { force: true });
+      return res.status(400).json({ error: '无法识别测试阶段，请在上传时选择 FS / EP / EP1 / PE2 / FEP / PP / PS' });
     }
 
     const reportId = nanoid();
 
     // 保存图片到 uploads/images/<reportId>/
-    // BASE_PATH 默认 '/'，子路径部署（如 /qa-weekly-report/）时由环境变量注入，确保返回给前端的 URL 包含子路径前缀
+    // 子路径部署时由 BASE_PATH 注入，确保图片 URL 在门户内可访问。
     const BASE_PATH = (process.env.BASE_PATH || '/').replace(/\/$/, '');
     let savedImages = [];
     if (rawImages.length > 0) {
@@ -109,10 +124,15 @@ router.post('/', upload.single('file'), async (req, res) => {
 
     const report = {
       id: reportId,
-      originalName: decodeFilename(req.file.originalname),
+      originalName,
       storedName: req.file.filename,
       customerId: customer ? customer.id : '',
       customerName: customer ? customer.name : '未分类',
+      productNo,
+      productName: metadata.productName,
+      stage,
+      stageSource: manualStage ? 'manual' : metadata.stageSource,
+      reportDate: metadata.reportDate || now.toISOString(),
       uploadedBy: (req.body && req.body.uploader) || '',
       uploadedAt: now.toISOString(),
       weekKey: isoWeek.key,
@@ -120,6 +140,7 @@ router.post('/', upload.single('file'), async (req, res) => {
       week: isoWeek.week,
       totalRows,
       failCount: totalFail,
+      passCount: sheets.reduce((sum, sheet) => sum + (sheet.passCount || 0), 0),
       totalImages: savedImages.length,
       sheets
     };
@@ -127,10 +148,19 @@ router.post('/', upload.single('file'), async (req, res) => {
     const list = fs.existsSync(REPORTS_FILE)
       ? JSON.parse(fs.readFileSync(REPORTS_FILE, 'utf8'))
       : [];
+    const beforeProduct = buildProducts(list).find(product => product.productNo === productNo);
     list.unshift(report);
     fs.writeFileSync(REPORTS_FILE, JSON.stringify(list, null, 2), 'utf8');
 
-    res.json({ ok: true, report });
+    const afterProduct = buildProducts(list).find(product => product.productNo === productNo);
+    const lifecycleChanges = diffLifecycle(beforeProduct, afterProduct);
+
+    res.json({
+      ok: true,
+      report,
+      product: summarizeProduct(afterProduct),
+      lifecycleChanges
+    });
   } catch (err) {
     console.error('[upload] error:', err);
     res.status(500).json({ error: err.message || '解析失败' });

--- a/apps/QA部/QA测试报告周结系统/server/server.js
+++ b/apps/QA部/QA测试报告周结系统/server/server.js
@@ -7,6 +7,8 @@ import { fileURLToPath } from 'url';
 import uploadRouter from './routes/upload.js';
 import reportsRouter from './routes/reports.js';
 import customersRouter from './routes/customers.js';
+import productsRouter from './routes/products.js';
+import { migrateReportMetadata } from './lib/report-migration.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -22,6 +24,7 @@ app.get('/api/health', (_req, res) => res.json({ status: 'ok', time: new Date().
 app.use('/api/upload', uploadRouter);
 app.use('/api/reports', reportsRouter);
 app.use('/api/customers', customersRouter);
+app.use('/api/products', productsRouter);
 
 // 上传的图片通过 /uploads/images/<reportId>/<file> 访问
 app.use('/uploads/images', express.static(path.join(__dirname, 'uploads', 'images')));
@@ -30,6 +33,11 @@ const clientDist = path.join(__dirname, '..', 'client', 'dist');
 if (fs.existsSync(clientDist)) {
   app.use(express.static(clientDist));
   app.get(/^\/(?!api).*/, (_req, res) => res.sendFile(path.join(clientDist, 'index.html')));
+}
+
+const migration = await migrateReportMetadata();
+if (migration.migrated || migration.skipped) {
+  console.log(`[qa-weekly-report] metadata migration: ${migration.migrated} migrated, ${migration.skipped} skipped`);
 }
 
 app.listen(PORT, '0.0.0.0', () => {


### PR DESCRIPTION
## 变更内容
- 按报告货号聚合同一产品，固定阶段 FS → EP → EP1 → PE2 → FEP → PP → PS
- 只有后续报告明确 PASS 才关闭旧问题；遗漏项目继续保持未解决
- 已解决后再次 FAIL 标记为复发并重点展示
- 自动识别报告货号、产品名、阶段、PASS/FAIL，并迁移历史报告元数据
- 新增产品追踪首页、阶段时间线、问题闭环和复发记录

## 验证
- 前端正式构建通过（Vite 43 modules）
- 服务端 7 个文件语法检查通过
- 生命周期用例：遗漏保留、PASS 关闭、再次 FAIL 复发
- 真实 FA586-1 Excel：货号/产品/FEP 识别正确，FAIL 4、PASS 1
- 浏览器实测产品列表、详情、上传阶段选项，控制台无错误