### PR TITLE
完善唱片机加工管理导入导出与部门流程

### DIFF
--- a/apps/PMC跟仓管/加工管理/pcba/db.py
+++ b/apps/PMC跟仓管/加工管理/pcba/db.py
@@ -86,6 +86,8 @@ CREATE TABLE IF NOT EXISTS semi_finished_monthly_totals (
     material TEXT NOT NULL,
     sticker_type TEXT NOT NULL,
     opening_stock INTEGER NOT NULL DEFAULT 0,
+    assembly_opening_stock INTEGER NOT NULL DEFAULT 0,
+    hongya_opening_stock INTEGER NOT NULL DEFAULT 0,
     monthly_inbound INTEGER NOT NULL DEFAULT 0,
     monthly_outbound INTEGER NOT NULL DEFAULT 0,
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
@@ -191,6 +193,16 @@ def _migrate_schema(conn):
         conn.execute(
             "ALTER TABLE semi_finished_monthly_totals "
             "ADD COLUMN opening_stock INTEGER NOT NULL DEFAULT 0"
+        )
+    if not _column_exists(conn, "semi_finished_monthly_totals", "assembly_opening_stock"):
+        conn.execute(
+            "ALTER TABLE semi_finished_monthly_totals "
+            "ADD COLUMN assembly_opening_stock INTEGER NOT NULL DEFAULT 0"
+        )
+    if not _column_exists(conn, "semi_finished_monthly_totals", "hongya_opening_stock"):
+        conn.execute(
+            "ALTER TABLE semi_finished_monthly_totals "
+            "ADD COLUMN hongya_opening_stock INTEGER NOT NULL DEFAULT 0"
         )
     _migrate_department_names(conn)
 

--- a/apps/PMC跟仓管/加工管理/pcba/main.py
+++ b/apps/PMC跟仓管/加工管理/pcba/main.py
@@ -714,6 +714,13 @@ def _is_legacy_assembly_workbook(wb):
     )
 
 
+def _is_legacy_assembly_pcba_workbook(wb):
+    return (
+        "成品入仓明细" in wb.sheetnames
+        and any("领料明细" in name for name in wb.sheetnames)
+    )
+
+
 def _is_legacy_heyuan_workbook(wb):
     return (
         "成品入仓明细" in wb.sheetnames
@@ -745,6 +752,27 @@ def _legacy_int(value, row_no, field, allow_blank=True):
         raise HTTPException(status_code=400, detail=f"第{row_no}行：{field}必须是数字")
 
 
+def _legacy_semi_finished_sticker_rows(ws, header_row):
+    if header_row:
+        return [
+            (row_no, _cell_text(ws.cell(row_no, 1).value))
+            for row_no in range(header_row + 1, ws.max_row + 1)
+            if "#NFC" in _cell_text(ws.cell(row_no, 1).value)
+        ]
+    rows = [
+        (row_no, _cell_text(ws.cell(row_no, 1).value))
+        for row_no in range(1, ws.max_row + 1)
+        if "#NFC" in _cell_text(ws.cell(row_no, 1).value)
+    ]
+    if rows:
+        return rows
+    if "36#CD" in ws.title:
+        for row_no in range(1, ws.max_row + 1):
+            if _cell_text(ws.cell(row_no, 1).value) == "数量":
+                return [(row_no, "36#NFC贴纸")]
+    return []
+
+
 def _parse_legacy_semi_finished_workbook(conn, wb, department):
     if department != SEMI_FINISHED_DEPARTMENT:
         raise HTTPException(status_code=400, detail="半成品台账只能在碟片半成品部门导入")
@@ -758,7 +786,8 @@ def _parse_legacy_semi_finished_workbook(conn, wb, department):
         if not rec_type:
             continue
         header_row = _find_legacy_item_header_row(ws)
-        if not header_row:
+        sticker_rows = _legacy_semi_finished_sticker_rows(ws, header_row)
+        if not sticker_rows:
             continue
 
         location_id = None
@@ -767,14 +796,14 @@ def _parse_legacy_semi_finished_workbook(conn, wb, department):
                 conn, _legacy_location_from_sheet(ws.title), 1
             )
         detail_columns = _legacy_detail_columns(ws)
-        monthly_col = _legacy_monthly_column(ws, header_row, monthly_header)
-        opening_stock_columns = _legacy_opening_stock_columns(ws, header_row)
-        for row_no in range(header_row + 1, ws.max_row + 1):
-            sticker_type = _cell_text(ws.cell(row_no, 1).value)
-            if not sticker_type:
-                continue
-            if "#NFC" not in sticker_type:
-                continue
+        monthly_col = (
+            _legacy_monthly_column(ws, header_row, monthly_header)
+            if header_row else 2
+        )
+        opening_stock_columns = (
+            _legacy_opening_stock_columns(ws, header_row) if header_row else []
+        )
+        for row_no, sticker_type in sticker_rows:
             sticker_type = _normalize_sticker_type(conn, NFC_MATERIAL, sticker_type)
             key = (NFC_MATERIAL, sticker_type)
 
@@ -791,14 +820,19 @@ def _parse_legacy_semi_finished_workbook(conn, wb, department):
                             "material": NFC_MATERIAL,
                             "sticker_type": sticker_type,
                             "opening_stock": 0,
+                            "assembly_opening_stock": 0,
+                            "hongya_opening_stock": 0,
                             "monthly_inbound": 0,
                             "monthly_outbound": 0,
                         },
                     )
                     monthly[monthly_key] += monthly_qty
 
-            opening_stock_candidate = 0
-            has_opening_stock = False
+            opening_stock_candidates = {
+                "opening_stock": 0,
+                "assembly_opening_stock": 0,
+                "hongya_opening_stock": 0,
+            }
             for opening_col in opening_stock_columns:
                 opening_qty = _legacy_int(
                     ws.cell(row_no, opening_col).value,
@@ -806,23 +840,38 @@ def _parse_legacy_semi_finished_workbook(conn, wb, department):
                     "上月库存数",
                 )
                 if opening_qty is not None:
-                    has_opening_stock = True
-                    opening_stock_candidate += opening_qty
-            if has_opening_stock:
+                    header_text = _cell_text(ws.cell(header_row, opening_col).value)
+                    opening_key = "opening_stock"
+                    if rec_type == "semi_inbound" and "鸿亚" in header_text:
+                        opening_key = "hongya_opening_stock"
+                    elif rec_type == "semi_inbound" and (
+                        "装配" in header_text or "东莞车间" in header_text
+                    ):
+                        opening_key = "assembly_opening_stock"
+                    opening_stock_candidates[opening_key] += opening_qty
+            if any(opening_stock_candidates.values()):
                 monthly = monthly_totals.setdefault(
                     key,
                     {
                         "material": NFC_MATERIAL,
                         "sticker_type": sticker_type,
                         "opening_stock": 0,
+                        "assembly_opening_stock": 0,
+                        "hongya_opening_stock": 0,
                         "monthly_inbound": 0,
                         "monthly_outbound": 0,
                     },
                 )
-                monthly["opening_stock"] = max(
-                    monthly["opening_stock"],
-                    opening_stock_candidate,
-                )
+                for opening_key, opening_qty in opening_stock_candidates.items():
+                    monthly[opening_key] = max(monthly[opening_key], opening_qty)
+                if rec_type == "semi_inbound":
+                    inbound_opening_stock = (
+                        monthly["assembly_opening_stock"]
+                        + monthly["hongya_opening_stock"]
+                    )
+                    monthly["opening_stock"] = max(
+                        monthly["opening_stock"], inbound_opening_stock
+                    )
 
             for col_no, rec_date, doc_no in detail_columns:
                 qty = _legacy_int(ws.cell(row_no, col_no).value, row_no, "数量")
@@ -853,10 +902,60 @@ def _parse_legacy_assembly_workbook(conn, wb, department):
     bodies = []
     location_id = _location_id_from_name(conn, "东莞车间", 1)
     workbook_year = _legacy_workbook_year(wb)
+    summary_month = None
     sheet_types = {
         "领料明细": "issue",
         "半成品入仓明细": "semi_finished",
     }
+
+    if "总表" in wb.sheetnames:
+        total_ws = wb["总表"]
+        for col_no in range(1, total_ws.max_column + 1):
+            header_text = re.sub(
+                r"\s+", "", _cell_text(total_ws.cell(1, col_no).value)
+            )
+            match = re.search(r"(\d{1,2})月领料", header_text)
+            if match:
+                month = int(match.group(1))
+                if month in SUMMARY_MONTHS:
+                    summary_month = month
+                    break
+        header_row = _find_legacy_item_header_row(total_ws)
+        opening_col = None
+        for col_no in range(1, min(total_ws.max_column, 10) + 1):
+            if "截止" in _cell_text(total_ws.cell(header_row or 2, col_no).value):
+                opening_col = col_no
+                break
+        if header_row and opening_col:
+            opening_label = _cell_text(total_ws.cell(header_row, opening_col).value)
+            opening_date = _legacy_cutoff_date(opening_label, workbook_year)
+            for row_no in range(header_row + 1, total_ws.max_row + 1):
+                sticker_type = _cell_text(total_ws.cell(row_no, 1).value)
+                if not sticker_type or "#NFC" not in sticker_type:
+                    continue
+                qty = _legacy_int(
+                    total_ws.cell(row_no, opening_col).value,
+                    row_no,
+                    opening_label,
+                )
+                if qty is None or qty <= 0:
+                    continue
+                sticker_type = _normalize_sticker_type(
+                    conn, NFC_MATERIAL, sticker_type
+                )
+                body = RecordIn(
+                    rec_type="issue",
+                    location_id=location_id,
+                    rec_date=opening_date,
+                    doc_no=opening_label,
+                    material=NFC_MATERIAL,
+                    sticker_type=sticker_type,
+                    qty=qty,
+                    remark="总表期初领料导入",
+                    summary_month=6,
+                )
+                _validate_record(body, department)
+                bodies.append(body)
 
     for sheet_name, rec_type in sheet_types.items():
         if sheet_name not in wb.sheetnames:
@@ -884,12 +983,98 @@ def _parse_legacy_assembly_workbook(conn, wb, department):
                     sticker_type=sticker_type,
                     qty=qty,
                     remark=f"{ws.title}导入",
+                    summary_month=summary_month,
                 )
                 _validate_record(body, department)
                 bodies.append(body)
 
     if not bodies:
         raise HTTPException(status_code=400, detail="东莞车间台账没有可导入的数据")
+    return bodies
+
+
+def _parse_legacy_assembly_pcba_workbook(conn, wb, department):
+    if department != ASSEMBLY_DEPARTMENT:
+        raise HTTPException(status_code=400, detail="东莞车间台账只能在东莞车间部门导入")
+
+    bodies = []
+    location_id = _location_id_from_name(conn, ASSEMBLY_DEPARTMENT, 1)
+    for ws in wb.worksheets:
+        if "领料明细" not in ws.title:
+            continue
+        headers = _legacy_header_map(ws)
+        for row_no in range(2, ws.max_row + 1):
+            material = _normalize_pcba_material(
+                _legacy_header_value(ws, headers, row_no, "物料名称")
+            )
+            if material != PCBA_MATERIAL:
+                continue
+            qty = _legacy_int(
+                _legacy_header_value(ws, headers, row_no, "领料数"),
+                row_no,
+                "领料数",
+            )
+            if qty is None or qty <= 0:
+                continue
+            date_value = _legacy_header_value(ws, headers, row_no, "日期")
+            body = RecordIn(
+                rec_type="issue",
+                location_id=location_id,
+                rec_date=_outsource_date_value(date_value),
+                doc_no=_legacy_doc_no(
+                    _legacy_header_value(ws, headers, row_no, "领料编号"),
+                    date_value,
+                    f"{ws.title}-{row_no}",
+                ),
+                material=PCBA_MATERIAL,
+                qty=qty,
+                remark=_first_value(
+                    {"备注": _legacy_header_value(ws, headers, row_no, "备注")},
+                    "备注",
+                ) or f"{ws.title}导入",
+            )
+            _validate_record(body, department)
+            bodies.append(body)
+
+    ws = wb["成品入仓明细"]
+    headers = _legacy_header_map(ws)
+    for row_no in range(2, ws.max_row + 1):
+        qty = _legacy_int(
+            _legacy_header_value(ws, headers, row_no, "数量（pcs）", "数量"),
+            row_no,
+            "数量",
+        )
+        if qty is None or qty <= 0:
+            continue
+        contract = _cell_text(_legacy_header_value(ws, headers, row_no, "合同号"))
+        item_no = _cell_text(_legacy_header_value(ws, headers, row_no, "货号"))
+        product_name = _cell_text(
+            _legacy_header_value(ws, headers, row_no, "品名/规格")
+        )
+        body = RecordIn(
+            rec_type="finished",
+            location_id=location_id,
+            rec_date=_outsource_date_value(
+                _legacy_header_value(ws, headers, row_no, "日期")
+            ),
+            doc_no=_cell_text(
+                _legacy_header_value(ws, headers, row_no, "送货单号")
+            ),
+            material=PCBA_MATERIAL,
+            qty=qty,
+            remark=_first_value(
+                {"备注": _legacy_header_value(ws, headers, row_no, "备注")},
+                "备注",
+            ) or "成品入仓明细导入",
+            contract_no=contract or None,
+            item_no=item_no or None,
+            product_name=product_name or None,
+        )
+        _validate_record(body, department)
+        bodies.append(body)
+
+    if not bodies:
+        raise HTTPException(status_code=400, detail="东莞车间PCBA台账没有可导入的数据")
     return bodies
 
 
@@ -1036,11 +1221,16 @@ def _legacy_outsource_nfc_detail_columns(ws, default_year=None):
     if not header_row:
         return []
     columns = []
+    date_occurrences = {}
     for col_no in range(1, ws.max_column + 1):
         rec_date = _legacy_cutoff_date(ws.cell(1, col_no).value, default_year)
         if not rec_date:
             continue
-        doc_no = _cell_text(ws.cell(header_row, col_no).value) or rec_date
+        doc_no = _cell_text(ws.cell(header_row, col_no).value)
+        if not doc_no:
+            occurrence = date_occurrences.get(rec_date, 0) + 1
+            date_occurrences[rec_date] = occurrence
+            doc_no = f"{rec_date}#{occurrence:02d}"
         columns.append((col_no, rec_date, doc_no))
     return columns
 
@@ -1091,22 +1281,46 @@ def _parse_legacy_outsource_nfc_workbook(conn, wb, department):
     return bodies
 
 
+def _legacy_heyuan_workbook_year(wb):
+    for ws in wb.worksheets:
+        if "明细" not in ws.title:
+            continue
+        headers = _legacy_header_map(ws)
+        date_col = headers.get("日期")
+        if not date_col:
+            continue
+        for row_no in range(2, ws.max_row + 1):
+            rec_date = _legacy_excel_date(ws.cell(row_no, date_col).value)
+            if rec_date:
+                return date.fromisoformat(rec_date).year
+    return date.today().year
+
+
 def _parse_legacy_heyuan_workbook(conn, wb, department):
     if department != HEYUAN_DEPARTMENT:
         raise HTTPException(status_code=400, detail="河源华兴台账只能在河源华兴部门导入")
 
     bodies = []
+    workbook_year = _legacy_heyuan_workbook_year(wb)
     location_id = _location_id_from_name(conn, HEYUAN_DEPARTMENT, 1)
     for ws in wb.worksheets:
         if "领料明细" not in ws.title:
             continue
         headers = _legacy_header_map(ws)
+        section_month = None
         for row_no in range(2, ws.max_row + 1):
             material = _cell_text(_legacy_header_value(ws, headers, row_no, "物料名称"))
-            if not material or "小计" in material:
+            if "小计" in material:
+                month_match = re.search(r"(\d{1,2})月", material)
+                if month_match:
+                    month = int(month_match.group(1)) + 1
+                    section_month = month if month in SUMMARY_MONTHS else None
                 continue
-            material = _normalize_pcba_material(material)
-            if material != PCBA_MATERIAL:
+            if not material:
+                continue
+            is_cd = "36#" in material and ("CD" in material.upper() or "唱片" in material)
+            material = NFC_MATERIAL if is_cd else _normalize_pcba_material(material)
+            if material not in (PCBA_MATERIAL, NFC_MATERIAL):
                 continue
             qty = _legacy_int(
                 _legacy_header_value(ws, headers, row_no, "领料数"),
@@ -1119,17 +1333,24 @@ def _parse_legacy_heyuan_workbook(conn, wb, department):
             doc_no = _cell_text(_legacy_header_value(ws, headers, row_no, "领料编号"))
             if not doc_no:
                 doc_no = _cell_text(date_value)
+            rec_date = _outsource_date_value(date_value)
+            summary_month = section_month
+            if is_cd and not rec_date and "6月" in _cell_text(date_value):
+                rec_date = date(workbook_year or date.today().year, 6, 27).isoformat()
+                summary_month = 6
             body = RecordIn(
                 rec_type="issue",
                 location_id=location_id,
-                rec_date=_outsource_date_value(date_value),
+                rec_date=rec_date,
                 doc_no=doc_no,
                 material=material,
+                sticker_type="36#NFC贴纸" if is_cd else None,
                 qty=qty,
                 remark=_first_value(
                     {"备注": _legacy_header_value(ws, headers, row_no, "备注")},
                     "备注",
                 ) or f"{ws.title}导入",
+                summary_month=summary_month,
             )
             if qty > 0:
                 _validate_record(body, department)
@@ -1138,9 +1359,16 @@ def _parse_legacy_heyuan_workbook(conn, wb, department):
     if "成品入仓明细" in wb.sheetnames:
         ws = wb["成品入仓明细"]
         headers = _legacy_header_map(ws)
+        section_month = None
         for row_no in range(2, ws.max_row + 1):
             name = _cell_text(_legacy_header_value(ws, headers, row_no, "品名/规格"))
-            if not name or "小计" in name:
+            if "小计" in name:
+                month_match = re.search(r"(\d{1,2})月", name)
+                if month_match:
+                    month = int(month_match.group(1)) + 1
+                    section_month = month if month in SUMMARY_MONTHS else None
+                continue
+            if not name:
                 continue
             qty = _legacy_int(
                 _legacy_header_value(ws, headers, row_no, "数量（pcs）", "数量"),
@@ -1151,6 +1379,9 @@ def _parse_legacy_heyuan_workbook(conn, wb, department):
                 continue
             contract = _cell_text(_legacy_header_value(ws, headers, row_no, "合同号"))
             item_no = _cell_text(_legacy_header_value(ws, headers, row_no, "货号"))
+            source_remark = _cell_text(
+                _legacy_header_value(ws, headers, row_no, "备注")
+            )
             body = RecordIn(
                 rec_type="finished",
                 location_id=location_id,
@@ -1160,9 +1391,11 @@ def _parse_legacy_heyuan_workbook(conn, wb, department):
                 doc_no=_cell_text(_legacy_header_value(ws, headers, row_no, "送货单号")),
                 material=PCBA_MATERIAL,
                 qty=qty,
-                remark=" ".join(
-                    part for part in [contract, item_no, name, "成品入仓明细导入"] if part
-                ),
+                remark=source_remark or "成品入仓明细导入",
+                contract_no=contract or None,
+                item_no=item_no or None,
+                product_name=name or None,
+                summary_month=section_month,
             )
             _validate_record(body, department)
             bodies.append(body)
@@ -1565,10 +1798,14 @@ def _upsert_semi_finished_monthly_totals(conn, department, rows):
     for row in rows:
         conn.execute(
             "INSERT INTO semi_finished_monthly_totals("
-            "department, material, sticker_type, opening_stock, monthly_inbound, monthly_outbound"
-            ") VALUES (?,?,?,?,?,?) "
+            "department, material, sticker_type, opening_stock, "
+            "assembly_opening_stock, hongya_opening_stock, "
+            "monthly_inbound, monthly_outbound"
+            ") VALUES (?,?,?,?,?,?,?,?) "
             "ON CONFLICT(department, material, sticker_type) DO UPDATE SET "
             "opening_stock=excluded.opening_stock, "
+            "assembly_opening_stock=excluded.assembly_opening_stock, "
+            "hongya_opening_stock=excluded.hongya_opening_stock, "
             "monthly_inbound=excluded.monthly_inbound, "
             "monthly_outbound=excluded.monthly_outbound, "
             "updated_at=datetime('now')",
@@ -1577,6 +1814,8 @@ def _upsert_semi_finished_monthly_totals(conn, department, rows):
                 row["material"],
                 row["sticker_type"],
                 int(row["opening_stock"] or 0),
+                int(row.get("assembly_opening_stock") or 0),
+                int(row.get("hongya_opening_stock") or 0),
                 int(row["monthly_inbound"] or 0),
                 int(row["monthly_outbound"] or 0),
             ),
@@ -1978,6 +2217,13 @@ class RecordIn(BaseModel):
 def _validate_record(body: RecordIn, department: Optional[str] = None):
     if body.rec_type not in VALID_TYPES:
         raise HTTPException(status_code=400, detail="类型无效")
+    if (
+        department == OUTSOURCE_DEPARTMENT
+        and _normalize_pcba_material(body.material) != PCBA_MATERIAL
+    ):
+        raise HTTPException(status_code=400, detail="利鸿只允许使用77794-PCBA板")
+    if department == HONGYA_DEPARTMENT and body.material != NFC_MATERIAL:
+        raise HTTPException(status_code=400, detail="鸿亚只允许使用NFC贴纸")
     if department == OUTSOURCE_DEPARTMENT and body.rec_type == "finished":
         raise HTTPException(status_code=400, detail="利鸿只能录入领料/半成品出库")
     if _is_outsource_department(department) and body.rec_type not in ("issue", "finished", "semi_finished"):
@@ -2702,26 +2948,226 @@ def _outsource_pcba_export_workbook(records, department=None):
     return wb
 
 
+def _heyuan_issue_detail_sheet(wb, title, records, material_label, month_slots):
+    ws = wb.create_sheet(title)
+    ws.append(["日期", "领料编号", "物料名称", "领料数", "备注"])
+    records = sorted(
+        records,
+        key=lambda row: (
+            _record_month(row),
+            _record_export_date(row) or "",
+            _cell_text(row.get("doc_no")),
+        ),
+    )
+    row_no = 2
+    styled_rows = {1}
+    months = [6, *EXPORT_MONTHS]
+    for month in months:
+        month_records = [row for row in records if _record_month(row) == month]
+        if month not in month_slots and not month_records:
+            continue
+        capacity = max(month_slots.get(month, 0), len(month_records))
+        for row in month_records:
+            display_date = _record_export_date(row)
+            if month == 6 and _cell_text(row.get("doc_no")) == "月结":
+                display_date = "6月"
+            ws.cell(row_no, 1).value = display_date
+            ws.cell(row_no, 2).value = row.get("doc_no")
+            ws.cell(row_no, 3).value = material_label
+            ws.cell(row_no, 4).value = row.get("qty")
+            ws.cell(row_no, 5).value = row.get("remark")
+            styled_rows.add(row_no)
+            row_no += 1
+        row_no += capacity - len(month_records)
+        ws.cell(row_no, 3).value = f"{month}月小计："
+        ws.cell(row_no, 4).value = _sum_qty(month_records) or 0
+        styled_rows.add(row_no)
+        row_no += 1
+
+    max_row = max(1, row_no - 1)
+    _apply_legacy_sheet_style(ws, max_row, 5)
+    for blank_row in set(range(2, max_row + 1)) - styled_rows:
+        for cell in ws[blank_row][:5]:
+            cell.border = Border()
+    ws.column_dimensions["A"].width = 10.5
+    ws.column_dimensions["B"].width = 22.125
+    return ws
+
+
+def _heyuan_summary_section(ws, header_row, label, pcba_records, cd_records):
+    headers = ["物料名称", label, "截6月月结"]
+    headers += [f"{month}月" for month in EXPORT_MONTHS]
+    headers.append("备注")
+    for col_no, value in enumerate(headers, start=1):
+        ws.cell(header_row, col_no).value = value
+    for row_no, material_label, records in (
+        (header_row + 1, "PCBA主板", pcba_records),
+        (header_row + 2, "36#唱片CD", cd_records),
+    ):
+        month_values = _supplier_pcba_month_sums(records)
+        ws.cell(row_no, 1).value = material_label
+        ws.cell(row_no, 2).value = sum(month_values) or 0
+        for col_no, value in enumerate(month_values, start=3):
+            ws.cell(row_no, col_no).value = value or None
+
+
+def _heyuan_balance_records(issue, finished):
+    return issue + [
+        {**row, "qty": -int(row.get("qty") or 0)} for row in finished
+    ]
+
+
+def _heyuan_finished_detail_sheet(wb, records):
+    ws = wb.create_sheet("成品入仓明细")
+    ws.append(["日期", "送货单号", "合同号", "货号", "品名/规格", "数量（pcs）", "备注"])
+    records = sorted(
+        records,
+        key=lambda row: (
+            _record_month(row),
+            _record_export_date(row) or "",
+            _cell_text(row.get("doc_no")),
+        ),
+    )
+    for row in records:
+        ws.append([
+            _record_export_date(row),
+            row.get("doc_no"),
+            row.get("contract_no"),
+            row.get("item_no") or "77794",
+            row.get("product_name") or row.get("material") or PCBA_MATERIAL,
+            row.get("qty"),
+            row.get("remark"),
+        ])
+    if records:
+        ws.append([None, None, None, None, "小计：", _sum_qty(records), None])
+    _apply_legacy_sheet_style(ws, ws.max_row, 7)
+    ws.column_dimensions["A"].width = 12.5
+    ws.column_dimensions["C"].width = 17
+    ws.column_dimensions["D"].width = 16
+    ws.column_dimensions["F"].width = 12.5
+    return ws
+
+
 def _heyuan_pcba_export_workbook(records):
     wb = Workbook()
     ws = wb.active
     ws.title = "总表"
     issue = [row for row in records if row["rec_type"] == "issue"]
     finished = [row for row in records if row["rec_type"] == "finished"]
-    headers = ["物料名称", "领料总数", "截6月月结"]
+    pcba_issue = [row for row in issue if row.get("material") != NFC_MATERIAL]
+    cd_issue = [
+        row for row in issue
+        if row.get("material") == NFC_MATERIAL
+        and row.get("sticker_type") == "36#NFC贴纸"
+    ]
+    pcba_finished = [row for row in finished if row.get("material") != NFC_MATERIAL]
+    cd_finished = [
+        row for row in finished
+        if row.get("material") == NFC_MATERIAL
+        and row.get("sticker_type") == "36#NFC贴纸"
+    ]
+
+    _heyuan_summary_section(ws, 1, "领料总数", pcba_issue, cd_issue)
+    _heyuan_summary_section(ws, 5, "成品总数", pcba_finished, cd_finished)
+    _heyuan_summary_section(
+        ws,
+        9,
+        "理论结存数",
+        _heyuan_balance_records(pcba_issue, pcba_finished),
+        _heyuan_balance_records(cd_issue, cd_finished),
+    )
+    _apply_legacy_sheet_style(ws, 11, 10)
+    for blank_row in (4, 8):
+        for cell in ws[blank_row][:10]:
+            cell.border = Border()
+    ws.column_dimensions["A"].width = 11.125
+    ws.column_dimensions["B"].width = 13.375
+    ws.column_dimensions["C"].width = 11.125
+    ws.column_dimensions["D"].width = 18
+
+    _heyuan_issue_detail_sheet(
+        wb, "36#CD领料明细", cd_issue, "36#唱片CD", {6: 1, 7: 14}
+    )
+    _heyuan_issue_detail_sheet(
+        wb, "PCB板领料明细", pcba_issue, PCBA_MATERIAL, {6: 3, 7: 16}
+    )
+    _heyuan_finished_detail_sheet(wb, finished)
+    return wb
+
+
+def _assembly_pcba_summary_section(ws, header_row, label, records):
+    headers = ["物料名称", label, "截6月月结"]
     headers += [f"{month}月" for month in EXPORT_MONTHS]
     headers.append("备注")
-    ws.append(headers)
-    ws.append(["PCBA主板", _sum_qty(issue), *_supplier_pcba_month_sums(issue), None])
-    if finished:
-        ws.append(["成品入仓总数", _sum_qty(finished), *_supplier_pcba_month_sums(finished), None])
-    _apply_legacy_sheet_style(ws, ws.max_row, len(headers))
+    for col_no, value in enumerate(headers, start=1):
+        ws.cell(header_row, col_no).value = value
+
+    month_sums = _supplier_pcba_month_sums(records)
+    ws.cell(header_row + 1, 1).value = "PCBA主板"
+    ws.cell(header_row + 1, 2).value = _sum_qty(records)
+    for col_no, value in enumerate(month_sums, start=3):
+        ws.cell(header_row + 1, col_no).value = value or None
+    ws.cell(header_row + 2, 1).value = "36#唱片CD"
+    ws.cell(header_row + 2, 2).value = 0
+
+
+def _assembly_pcba_issue_sheet(wb, title, records):
+    ws = wb.create_sheet(title)
+    ws.append(["日期", "领料编号", "物料名称", "领料数", "备注"])
+    for row in records:
+        ws.append([
+            _record_export_date(row),
+            row.get("doc_no"),
+            "PCBA主板",
+            row.get("qty"),
+            row.get("remark"),
+        ])
+    ws.append([None, None, "小计：", _sum_qty(records), None])
+    _apply_legacy_sheet_style(ws, ws.max_row, 5)
+    ws.column_dimensions["A"].width = 20
+    ws.column_dimensions["E"].width = 20
+
+
+def _assembly_pcba_finished_sheet(wb, records):
+    ws = wb.create_sheet("成品入仓明细")
+    ws.append(["日期", "送货单号", "合同号", "货号", "品名/规格", "数量（pcs）", "备注"])
+    for row in records:
+        ws.append([
+            _record_export_date(row),
+            row.get("doc_no"),
+            row.get("contract_no"),
+            row.get("item_no"),
+            row.get("product_name"),
+            row.get("qty"),
+            row.get("remark"),
+        ])
+    _apply_legacy_sheet_style(ws, ws.max_row, 7)
+    ws.column_dimensions["A"].width = 20
+    ws.column_dimensions["B"].width = 18
+    ws.column_dimensions["E"].width = 18
+    ws.column_dimensions["G"].width = 22
+
+
+def _assembly_pcba_export_workbook(records):
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "总表"
+    issue = [row for row in records if row["rec_type"] == "issue"]
+    finished = [row for row in records if row["rec_type"] == "finished"]
+
+    _assembly_pcba_summary_section(ws, 1, "领料总数", issue)
+    _assembly_pcba_summary_section(ws, 5, "成品总数", finished)
+    balance_records = [
+        {**row, "qty": -int(row.get("qty") or 0)} for row in finished
+    ] + issue
+    _assembly_pcba_summary_section(ws, 9, "理论结存数", balance_records)
+    _apply_legacy_sheet_style(ws, 11, 10)
     ws.column_dimensions["A"].width = 14
     ws.column_dimensions["B"].width = 14
 
-    _supplier_pcba_detail_sheet(wb, "36#CD领料明细", [], "领料编号", "领料数")
-    _supplier_pcba_detail_sheet(wb, "PCB板领料明细", issue, "领料编号", "领料数")
-    _pcba_inbound_detail_sheet(wb, "成品入仓明细", finished)
+    _assembly_pcba_issue_sheet(wb, "36#CD领料明细", [])
+    _assembly_pcba_issue_sheet(wb, "PCB主板领料明细", issue)
+    _assembly_pcba_finished_sheet(wb, finished)
     return wb
 
 
@@ -2893,10 +3339,256 @@ def _supplier_nfc_export_workbook(records, sticker_types):
     return wb
 
 
+def _natural_text_sort_key(value):
+    text = _cell_text(value)
+    parts = re.split(r"(\d+)", text.casefold())
+    return (
+        not text,
+        tuple(
+            (0, int(part)) if part.isdigit() else (1, part)
+            for part in parts
+            if part
+        ),
+    )
+
+
+def _hongya_nfc_detail_sheet(wb, title, records, sticker_names):
+    ws = wb.create_sheet(title)
+    groups = sorted(
+        _supplier_nfc_detail_groups(records),
+        key=lambda group: (
+            group["rec_date"] is None,
+            group["rec_date"] or "",
+            _natural_text_sort_key(group["doc_no"]),
+        ),
+    )
+    ws.cell(1, 2).value = "当月入仓总数"
+    ws.cell(2, 1).value = "物料名称"
+    for col_no, group in enumerate(groups, start=3):
+        ws.cell(1, col_no).value = group["rec_date"]
+
+    for row_no, sticker_type in enumerate(sticker_names, start=3):
+        sticker_records = [
+            row for row in records if row.get("sticker_type") == sticker_type
+        ]
+        ws.cell(row_no, 1).value = _format_nfc_sticker_name(sticker_type)
+        ws.cell(row_no, 2).value = _sum_qty(sticker_records) or 0
+        for col_no, group in enumerate(groups, start=3):
+            qty = _sum_qty([
+                row for row in group["records"]
+                if row.get("sticker_type") == sticker_type
+            ])
+            if qty:
+                ws.cell(row_no, col_no).value = qty
+
+    subtotal_row = len(sticker_names) + 4
+    ws.cell(subtotal_row, 1).value = "小计："
+    ws.cell(subtotal_row, 2).value = _sum_qty(records) or 0
+    for col_no, group in enumerate(groups, start=3):
+        ws.cell(subtotal_row, col_no).value = _sum_qty(group["records"]) or None
+
+    _apply_legacy_sheet_style(ws, subtotal_row, max(2, len(groups) + 2))
+    ws.column_dimensions["A"].width = 13
+    ws.column_dimensions["B"].width = 11
+    for col_no in range(3, len(groups) + 3):
+        ws.column_dimensions[ws.cell(1, col_no).column_letter].width = 10
+    return ws
+
+
+def _hongya_nfc_export_workbook(records, sticker_types):
+    issue = [row for row in records if row["rec_type"] == "issue"]
+    inbound = [row for row in records if row["rec_type"] == "finished"]
+    sticker_names = _supplier_nfc_sticker_names(records, sticker_types)
+
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "总表"
+    ws.cell(1, 2).value = "累计领料总数"
+    ws.cell(2, 1).value = "物料名称"
+    ws.cell(2, 3).value = "截至6月27号"
+    for col_no, month in enumerate(EXPORT_MONTHS, start=4):
+        ws.cell(1, col_no).value = f"{month}月领料\n总数"
+    ws.cell(1, 11).value = "应存数"
+    ws.cell(1, 12).value = "累计入仓总数"
+    ws.cell(1, 13).value = "东莞"
+    ws.cell(2, 13).value = "截至6月27号"
+    for col_no, month in enumerate(EXPORT_MONTHS, start=14):
+        ws.cell(1, col_no).value = f"{month}月入仓\n总数"
+
+    for row_no, sticker_type in enumerate(sticker_names, start=3):
+        sticker_issue = [
+            row for row in issue if row.get("sticker_type") == sticker_type
+        ]
+        sticker_inbound = [
+            row for row in inbound if row.get("sticker_type") == sticker_type
+        ]
+        issue_total = _sum_qty(sticker_issue)
+        inbound_total = _sum_qty(sticker_inbound)
+        ws.cell(row_no, 1).value = _format_nfc_sticker_name(sticker_type)
+        ws.cell(row_no, 2).value = issue_total or 0
+        ws.cell(row_no, 3).value = _month_sum(sticker_issue, 6) or None
+        for col_no, month in enumerate(EXPORT_MONTHS, start=4):
+            ws.cell(row_no, col_no).value = _month_sum(sticker_issue, month) or None
+        ws.cell(row_no, 11).value = issue_total - inbound_total
+        ws.cell(row_no, 12).value = inbound_total or 0
+        ws.cell(row_no, 13).value = _month_sum(sticker_inbound, 6) or None
+        for col_no, month in enumerate(EXPORT_MONTHS, start=14):
+            ws.cell(row_no, col_no).value = _month_sum(sticker_inbound, month) or None
+
+    subtotal_row = len(sticker_names) + 4
+    ws.cell(subtotal_row, 1).value = "小计："
+    for col_no in range(2, 20):
+        ws.cell(subtotal_row, col_no).value = sum(
+            int(ws.cell(row_no, col_no).value or 0)
+            for row_no in range(3, subtotal_row - 1)
+        )
+
+    for cell_range in (
+        "B1:B2", "D1:D2", "E1:E2", "F1:F2", "G1:G2", "H1:H2", "I1:I2",
+        "K1:K2", "L1:L2", "N1:N2", "O1:O2", "P1:P2", "Q1:Q2", "R1:R2", "S1:S2",
+    ):
+        ws.merge_cells(cell_range)
+    _apply_legacy_sheet_style(ws, subtotal_row, 19)
+    ws.column_dimensions["A"].width = 13
+    ws.column_dimensions["B"].width = 11
+    ws.column_dimensions["C"].width = 11
+    ws.column_dimensions["D"].width = 12
+    ws.column_dimensions["K"].width = 10
+    ws.column_dimensions["L"].width = 10
+    ws.column_dimensions["M"].width = 10
+
+    _hongya_nfc_detail_sheet(wb, "领料明细", issue, sticker_names)
+    _hongya_nfc_detail_sheet(wb, "入仓明细", inbound, sticker_names)
+    return wb
+
+
+def _assembly_nfc_detail_sheet(wb, title, records, sticker_names, total_header):
+    ws = wb.create_sheet(title)
+    records = [
+        row for row in records
+        if _record_month(row) in EXPORT_MONTHS
+    ]
+    groups = sorted(
+        _supplier_nfc_detail_groups(records),
+        key=lambda group: (
+            group["rec_date"] is None,
+            group["rec_date"] or "",
+            _natural_text_sort_key(group["doc_no"]),
+        ),
+    )
+    ws.cell(1, 2).value = total_header
+    ws.cell(2, 1).value = "物料名称"
+    for col_no, group in enumerate(groups, start=3):
+        ws.cell(1, col_no).value = group["rec_date"]
+        ws.cell(2, col_no).value = group["doc_no"]
+        ws.cell(2, col_no).number_format = "@"
+
+    for row_no, sticker_type in enumerate(sticker_names, start=3):
+        ws.cell(row_no, 1).value = _format_nfc_sticker_name(sticker_type)
+        sticker_records = [
+            row for row in records if row.get("sticker_type") == sticker_type
+        ]
+        ws.cell(row_no, 2).value = _sum_qty(sticker_records) or 0
+        for col_no, group in enumerate(groups, start=3):
+            group_records = [
+                row for row in group["records"]
+                if row.get("sticker_type") == sticker_type
+            ]
+            qty = _sum_qty(group_records)
+            if qty:
+                ws.cell(row_no, col_no).value = qty
+
+    total_row = len(sticker_names) + 4
+    ws.cell(total_row, 1).value = "小计："
+    ws.cell(total_row, 2).value = _sum_qty(records) or 0
+    for col_no, group in enumerate(groups, start=3):
+        ws.cell(total_row, col_no).value = _sum_qty(group["records"]) or None
+    _apply_legacy_sheet_style(ws, total_row, max(2, len(groups) + 2))
+    ws.column_dimensions["A"].width = 13
+    ws.column_dimensions["B"].width = 13
+    return ws
+
+
+def _assembly_nfc_export_workbook(records, sticker_types):
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "总表"
+    issue = [row for row in records if row["rec_type"] == "issue"]
+    semi_finished = [
+        row for row in records if row["rec_type"] == "semi_finished"
+    ]
+    sticker_names = _supplier_nfc_sticker_names(records, sticker_types)
+
+    ws.cell(1, 2).value = "累计入仓总数"
+    ws.cell(1, 3).value = "东莞"
+    ws.cell(2, 1).value = "物料名称"
+    ws.cell(2, 3).value = "截止6月27号"
+    for col_no, month in enumerate(EXPORT_MONTHS, start=4):
+        ws.cell(1, col_no).value = f"{month}月领料\n总数"
+    ws.cell(1, 11).value = "应存数"
+    ws.cell(1, 12).value = "累计出仓总数"
+    ws.cell(1, 13).value = "东莞"
+    ws.cell(1, 14).value = "邵阳"
+    ws.cell(2, 13).value = "截止6月27号"
+    for col_no, month in enumerate(EXPORT_MONTHS, start=15):
+        ws.cell(1, col_no).value = f"{month}月入仓\n总数"
+
+    for row_no, sticker_type in enumerate(sticker_names, start=3):
+        sticker_issue = [
+            row for row in issue if row.get("sticker_type") == sticker_type
+        ]
+        sticker_finished = [
+            row for row in semi_finished
+            if row.get("sticker_type") == sticker_type
+        ]
+        issue_total = _sum_qty(sticker_issue)
+        finished_total = _sum_qty(sticker_finished)
+        ws.cell(row_no, 1).value = _format_nfc_sticker_name(sticker_type)
+        ws.cell(row_no, 2).value = issue_total or 0
+        ws.cell(row_no, 3).value = _month_sum(sticker_issue, 6) or None
+        for col_no, month in enumerate(EXPORT_MONTHS, start=4):
+            ws.cell(row_no, col_no).value = (
+                _month_sum(sticker_issue, month) or None
+            )
+        ws.cell(row_no, 11).value = issue_total - finished_total
+        ws.cell(row_no, 12).value = finished_total or 0
+        ws.cell(row_no, 13).value = _month_sum(sticker_finished, 6) or None
+        for col_no, month in enumerate(EXPORT_MONTHS, start=15):
+            ws.cell(row_no, col_no).value = (
+                _month_sum(sticker_finished, month) or None
+            )
+
+    total_row = len(sticker_names) + 4
+    ws.cell(total_row, 1).value = "小计："
+    for col_no in (2, 3, *range(4, 10), 11, 12, 13, 14, *range(15, 21)):
+        ws.cell(total_row, col_no).value = sum(
+            int(ws.cell(row_no, col_no).value or 0)
+            for row_no in range(3, total_row - 1)
+        )
+    _apply_legacy_sheet_style(ws, total_row, 20)
+    ws.column_dimensions["A"].width = 13
+    ws.column_dimensions["B"].width = 13
+    ws.column_dimensions["C"].width = 13
+
+    _assembly_nfc_detail_sheet(
+        wb, "领料明细", issue, sticker_names, "当月领料总数"
+    )
+    _assembly_nfc_detail_sheet(
+        wb,
+        "半成品入仓明细",
+        semi_finished,
+        sticker_names,
+        "当月入仓总数",
+    )
+    return wb
+
+
 def _monthly_totals_map(monthly_totals):
     return {
         row["sticker_type"]: {
             "opening_stock": int(row.get("opening_stock") or 0),
+            "assembly_opening_stock": int(row.get("assembly_opening_stock") or 0),
+            "hongya_opening_stock": int(row.get("hongya_opening_stock") or 0),
             "monthly_inbound": int(row.get("monthly_inbound") or 0),
             "monthly_outbound": int(row.get("monthly_outbound") or 0),
         }
@@ -2925,13 +3617,26 @@ def _semi_month_total(total_row, records, key, rec_type):
 
 
 def _semi_finished_detail_sheet(
-    wb, title, records, sticker_names, totals_by_sticker, is_inbound
+    wb, title, records, sticker_names, totals_by_sticker, is_inbound,
+    location_name=None, use_stored_totals=True,
 ):
     ws = wb.create_sheet(title)
     rec_type = "semi_inbound" if is_inbound else "semi_outbound"
     total_key = "monthly_inbound" if is_inbound else "monthly_outbound"
     total_header = "当月入仓总数" if is_inbound else "当月出仓总数"
-    sheet_records = [row for row in records if row["rec_type"] == rec_type]
+    sheet_records = [
+        row for row in records
+        if row["rec_type"] == rec_type
+        and (location_name is None or row.get("location_name") == location_name)
+    ]
+    groups = sorted(
+        _supplier_nfc_detail_groups(sheet_records),
+        key=lambda group: (
+            group["rec_date"] is None,
+            group["rec_date"] or "",
+            _natural_text_sort_key(group["doc_no"]),
+        ),
+    )
     start_col = 5 if is_inbound else 4
     header_row = 3 if is_inbound else 5
     data_row_start = header_row + 1
@@ -2948,9 +3653,10 @@ def _semi_finished_detail_sheet(
         ws.cell(5, 2).value = total_header
         ws.cell(5, 3).value = "6/24盘点截数"
 
-    for offset, row in enumerate(sheet_records, start=start_col):
-        ws.cell(1, offset).value = _record_export_date(row)
-        ws.cell(2, offset).value = row.get("doc_no")
+    for offset, group in enumerate(groups, start=start_col):
+        ws.cell(1, offset).value = group["rec_date"]
+        ws.cell(2, offset).value = group["doc_no"]
+        ws.cell(2, offset).number_format = "@"
 
     for row_no, sticker_type in enumerate(sticker_names, start=data_row_start):
         sticker_records = [
@@ -2958,13 +3664,32 @@ def _semi_finished_detail_sheet(
         ]
         total_row = totals_by_sticker.get(sticker_type, {})
         ws.cell(row_no, 1).value = _format_nfc_sticker_name(sticker_type)
-        ws.cell(row_no, 2).value = _semi_month_total(
-            total_row, sticker_records, total_key, rec_type
-        ) or 0
-        ws.cell(row_no, 3).value = int(total_row.get("opening_stock") or 0) or None
-        for col_no, record in enumerate(sheet_records, start=start_col):
-            if record.get("sticker_type") == sticker_type:
-                ws.cell(row_no, col_no).value = record.get("qty")
+        if use_stored_totals:
+            month_total = _semi_month_total(
+                total_row, sticker_records, total_key, rec_type
+            )
+            opening_stock = int(total_row.get("opening_stock") or 0)
+        else:
+            month_total = _sum_qty(sticker_records)
+            opening_stock = 0
+        ws.cell(row_no, 2).value = month_total or 0
+        if is_inbound:
+            ws.cell(row_no, 3).value = (
+                int(total_row.get("assembly_opening_stock") or 0) or None
+            )
+            ws.cell(row_no, 4).value = (
+                int(total_row.get("hongya_opening_stock") or 0) or None
+            )
+        else:
+            ws.cell(row_no, 3).value = opening_stock or None
+        for col_no, group in enumerate(groups, start=start_col):
+            group_records = [
+                row for row in group["records"]
+                if row.get("sticker_type") == sticker_type
+            ]
+            qty = _sum_qty(group_records)
+            if qty:
+                ws.cell(row_no, col_no).value = qty
 
     total_row_no = data_row_start + len(sticker_names)
     ws.cell(total_row_no, 1).value = "小计："
@@ -2976,11 +3701,11 @@ def _semi_finished_detail_sheet(
         ws.cell(row_no, 3).value or 0
         for row_no in range(data_row_start, total_row_no)
     ) or None
-    for col_no, record in enumerate(sheet_records, start=start_col):
-        ws.cell(total_row_no, col_no).value = record.get("qty")
+    for col_no, group in enumerate(groups, start=start_col):
+        ws.cell(total_row_no, col_no).value = _sum_qty(group["records"]) or None
 
     _apply_legacy_sheet_style(
-        ws, total_row_no, max(start_col - 1, len(sheet_records) + start_col - 1)
+        ws, total_row_no, max(start_col - 1, len(groups) + start_col - 1)
     )
     ws.column_dimensions["A"].width = 13
     ws.column_dimensions["B"].width = 12
@@ -3037,11 +3762,25 @@ def _semi_finished_export_workbook(records, sticker_types, monthly_totals):
     _semi_finished_detail_sheet(
         wb, "入库明细", records, sticker_names, totals_by_sticker, True
     )
-    _semi_finished_detail_sheet(
-        wb, "邵阳领料", records, sticker_names, totals_by_sticker, False
-    )
-    wb.create_sheet("河源华兴36#CD领料")
-    wb.create_sheet("车间36#CD领料")
+    outbound_locations = {
+        row.get("location_name") for row in outbound if row.get("location_name")
+    }
+    use_stored_outbound_totals = len(outbound_locations) <= 1
+    for sheet_name, location_name in (
+        ("邵阳领料", SHAOYANG_DEPARTMENT),
+        ("河源华兴36#CD领料", HEYUAN_DEPARTMENT),
+        ("车间36#CD领料", ASSEMBLY_DEPARTMENT),
+    ):
+        _semi_finished_detail_sheet(
+            wb,
+            sheet_name,
+            records,
+            sticker_names,
+            totals_by_sticker,
+            False,
+            location_name=location_name,
+            use_stored_totals=use_stored_outbound_totals,
+        )
     return wb
 
 
@@ -3068,7 +3807,11 @@ def export_records(
         )
         params = [user["department"]]
         sql, params = _append_date_filter(sql, params, filters)
-        if material:
+        heyuan_combined_export = (
+            user["department"] == HEYUAN_DEPARTMENT
+            and material == PCBA_MATERIAL
+        )
+        if material and not heyuan_combined_export:
             sql += " AND r.material=?"
             params.append(material)
         sql += " ORDER BY r.id"
@@ -3080,6 +3823,7 @@ def export_records(
         ]
         totals_sql = (
             "SELECT material, sticker_type, opening_stock, "
+            "assembly_opening_stock, hongya_opening_stock, "
             "monthly_inbound, monthly_outbound "
             "FROM semi_finished_monthly_totals WHERE department=?"
         )
@@ -3106,6 +3850,21 @@ def export_records(
         return _xlsx_response(
             _supplier_nfc_export_workbook(records, sticker_types),
             "来料仓77772#NFC出入明细.xlsx",
+        )
+    if user["department"] == ASSEMBLY_DEPARTMENT and material == PCBA_MATERIAL:
+        return _xlsx_response(
+            _assembly_pcba_export_workbook(records),
+            "东莞车间77794#PCB主板出入明细.xlsx",
+        )
+    if user["department"] == ASSEMBLY_DEPARTMENT and material == NFC_MATERIAL:
+        return _xlsx_response(
+            _assembly_nfc_export_workbook(records, sticker_types),
+            "东莞车间77772#NFC贴纸出入明细.xlsx",
+        )
+    if user["department"] == HONGYA_DEPARTMENT and material == NFC_MATERIAL:
+        return _xlsx_response(
+            _hongya_nfc_export_workbook(records, sticker_types),
+            "东莞加工厂鸿亚77772#NFC贴纸出入明细.xlsx",
         )
     if _is_outsource_department(user["department"]) and material == PCBA_MATERIAL:
         return _xlsx_response(
@@ -3150,70 +3909,188 @@ def _record_body_from_import_row(conn, row_no, row, department):
     return body
 
 
-@app.post("/api/records/import")
-def import_records(file: UploadFile = File(...), user=Depends(current_user)):
+def _parse_record_import_workbook(conn, wb, file, user):
+    legacy_semi_finished_import = _is_legacy_semi_finished_workbook(wb)
+    legacy_assembly_import = _is_legacy_assembly_workbook(wb)
+    legacy_assembly_pcba_import = (
+        user["department"] == ASSEMBLY_DEPARTMENT
+        and _is_legacy_assembly_pcba_workbook(wb)
+    )
+    legacy_outsource_import = _is_legacy_outsource_workbook(wb)
+    legacy_outsource_nfc_import = (
+        _is_outsource_department(user["department"])
+        and _is_legacy_outsource_nfc_workbook(wb)
+    )
+    legacy_heyuan_import = _is_legacy_heyuan_workbook(wb)
+    legacy_supplier_import = _is_legacy_supplier_workbook(wb)
+    legacy_import = (
+        legacy_semi_finished_import
+        or legacy_assembly_import
+        or legacy_assembly_pcba_import
+        or legacy_outsource_import
+        or legacy_outsource_nfc_import
+        or legacy_heyuan_import
+        or legacy_supplier_import
+    )
+    if legacy_semi_finished_import:
+        _require_filename_contains(file, SEMI_FINISHED_FILENAME_KEYWORD)
+        bodies, monthly_totals = _parse_legacy_semi_finished_workbook(
+            conn, wb, user["department"]
+        )
+    elif legacy_assembly_import:
+        _require_filename_contains(file, ASSEMBLY_DEPARTMENT)
+        bodies = _parse_legacy_assembly_workbook(conn, wb, user["department"])
+        monthly_totals = []
+    elif legacy_assembly_pcba_import:
+        _require_filename_contains(file, ASSEMBLY_DEPARTMENT)
+        bodies = _parse_legacy_assembly_pcba_workbook(
+            conn, wb, user["department"]
+        )
+        monthly_totals = []
+    elif legacy_outsource_import:
+        _require_filename_contains(file, user["department"])
+        bodies = _parse_legacy_outsource_workbook(conn, wb, user["department"])
+        monthly_totals = []
+    elif legacy_outsource_nfc_import:
+        _require_filename_contains(file, user["department"])
+        bodies = _parse_legacy_outsource_nfc_workbook(
+            conn, wb, user["department"]
+        )
+        monthly_totals = []
+    elif legacy_heyuan_import:
+        bodies = _parse_legacy_heyuan_workbook(conn, wb, user["department"])
+        monthly_totals = []
+    elif legacy_supplier_import:
+        bodies = _parse_legacy_supplier_workbook(conn, wb, user["department"])
+        monthly_totals = []
+    else:
+        rows = _worksheet_rows(wb.active)
+        if not rows:
+            raise HTTPException(status_code=400, detail="Excel 没有可导入的数据")
+        bodies = [
+            _record_body_from_import_row(conn, row_no, row, user["department"])
+            for row_no, row in rows
+        ]
+        monthly_totals = []
+    return bodies, monthly_totals, legacy_import
+
+
+def _import_document_key(body):
+    doc_no = _cell_text(body.doc_no)
+    if not doc_no:
+        return None
+    return body.rec_type, body.location_id or 0, doc_no.casefold()
+
+
+def _group_import_documents(bodies):
+    documents = {}
+    without_document = []
+    for body in bodies:
+        key = _import_document_key(body)
+        if key is None:
+            without_document.append(body)
+        else:
+            documents.setdefault(key, []).append(body)
+    return documents, without_document
+
+
+def _existing_document_ids(conn, department, key):
+    rec_type, location_id, doc_no = key
+    rows = conn.execute(
+        "SELECT id FROM records WHERE department=? AND source_record_id IS NULL "
+        "AND rec_type=? AND COALESCE(location_id, 0)=? "
+        "AND LOWER(TRIM(COALESCE(doc_no, '')))=? ORDER BY id",
+        (department, rec_type, location_id, doc_no),
+    ).fetchall()
+    return [row["id"] for row in rows]
+
+
+def _document_check_result(conn, department, documents, blank_rows):
+    duplicates = []
+    for key, bodies in documents.items():
+        existing_ids = _existing_document_ids(conn, department, key)
+        if not existing_ids:
+            continue
+        first = bodies[0]
+        duplicates.append({
+            "doc_no": first.doc_no,
+            "rec_type": first.rec_type,
+            "target_department": _location_name_from_id(conn, first.location_id),
+            "file_rows": len(bodies),
+            "existing_rows": len(existing_ids),
+        })
+    return {
+        "documents": len(documents),
+        "duplicates": len(duplicates),
+        "duplicate_documents": duplicates,
+        "blank_doc_rows": len(blank_rows),
+    }
+
+
+@app.post("/api/records/import-check")
+def check_record_import(file: UploadFile = File(...), user=Depends(current_user)):
     wb = _load_upload_workbook(file)
     conn = db.get_conn()
     try:
-        legacy_semi_finished_import = _is_legacy_semi_finished_workbook(wb)
-        legacy_assembly_import = _is_legacy_assembly_workbook(wb)
-        legacy_outsource_import = _is_legacy_outsource_workbook(wb)
-        legacy_outsource_nfc_import = (
-            _is_outsource_department(user["department"])
-            and _is_legacy_outsource_nfc_workbook(wb)
+        bodies, _monthly_totals, _legacy_import = _parse_record_import_workbook(
+            conn, wb, file, user
         )
-        legacy_heyuan_import = _is_legacy_heyuan_workbook(wb)
-        legacy_supplier_import = _is_legacy_supplier_workbook(wb)
-        legacy_import = (
-            legacy_semi_finished_import
-            or legacy_assembly_import
-            or legacy_outsource_import
-            or legacy_outsource_nfc_import
-            or legacy_heyuan_import
-            or legacy_supplier_import
+        documents, blank_rows = _group_import_documents(bodies)
+        return _document_check_result(
+            conn, user["department"], documents, blank_rows
         )
-        if legacy_semi_finished_import:
-            _require_filename_contains(file, SEMI_FINISHED_FILENAME_KEYWORD)
-            bodies, monthly_totals = _parse_legacy_semi_finished_workbook(
-                conn, wb, user["department"]
-            )
-        elif legacy_assembly_import:
-            _require_filename_contains(file, ASSEMBLY_DEPARTMENT)
-            bodies = _parse_legacy_assembly_workbook(conn, wb, user["department"])
-            monthly_totals = []
-        elif legacy_outsource_import:
-            _require_filename_contains(file, user["department"])
-            bodies = _parse_legacy_outsource_workbook(conn, wb, user["department"])
-            monthly_totals = []
-        elif legacy_outsource_nfc_import:
-            _require_filename_contains(file, user["department"])
-            bodies = _parse_legacy_outsource_nfc_workbook(
-                conn, wb, user["department"]
-            )
-            monthly_totals = []
-        elif legacy_heyuan_import:
-            bodies = _parse_legacy_heyuan_workbook(conn, wb, user["department"])
-            monthly_totals = []
-        elif legacy_supplier_import:
-            bodies = _parse_legacy_supplier_workbook(conn, wb, user["department"])
-            monthly_totals = []
+    finally:
+        conn.close()
+
+
+@app.post("/api/records/import")
+def import_records(
+    file: UploadFile = File(...),
+    mode: str = Form("skip"),
+    user=Depends(current_user),
+):
+    if mode not in ("skip", "replace"):
+        raise HTTPException(status_code=400, detail="导入模式无效")
+    wb = _load_upload_workbook(file)
+    conn = db.get_conn()
+    try:
+        bodies, monthly_totals, legacy_import = _parse_record_import_workbook(
+            conn, wb, file, user
+        )
+        documents, blank_rows = _group_import_documents(bodies)
+        duplicate_keys = {
+            key: _existing_document_ids(conn, user["department"], key)
+            for key in documents
+        }
+        duplicate_keys = {
+            key: ids for key, ids in duplicate_keys.items() if ids
+        }
+        replaced_documents = 0
+        skipped_documents = 0
+        skipped_document_rows = 0
+        if mode == "replace":
+            for existing_ids in duplicate_keys.values():
+                _delete_record_ids_with_links(conn, existing_ids)
+                replaced_documents += 1
         else:
-            rows = _worksheet_rows(wb.active)
-            if not rows:
-                raise HTTPException(status_code=400, detail="Excel 没有可导入的数据")
-            bodies = [
-                _record_body_from_import_row(conn, row_no, row, user["department"])
-                for row_no, row in rows
-            ]
-            monthly_totals = []
+            skipped_documents = len(duplicate_keys)
+            skipped_document_rows = sum(
+                len(documents[key]) for key in duplicate_keys
+            )
+
+        import_bodies = list(blank_rows)
+        for key, document_bodies in documents.items():
+            if mode == "skip" and key in duplicate_keys:
+                continue
+            import_bodies.extend(document_bodies)
         ids = []
-        skipped = 0
-        for body in bodies:
+        skipped = skipped_document_rows
+        for body in import_bodies:
             record_id = _insert_record_body(
                 conn,
                 body,
                 user,
-                skip_duplicate=legacy_import,
+                skip_duplicate=(legacy_import or _import_document_key(body) is None),
             )
             if record_id is None:
                 skipped += 1
@@ -3232,6 +4109,8 @@ def import_records(file: UploadFile = File(...), user=Depends(current_user)):
         "ids": ids,
         "monthly_totals": len(monthly_totals),
         "skipped": skipped,
+        "skipped_documents": skipped_documents,
+        "replaced_documents": replaced_documents,
     }
 
 

--- a/apps/PMC跟仓管/加工管理/pcba/main.py
+++ b/apps/PMC跟仓管/加工管理/pcba/main.py
@@ -1102,6 +1102,17 @@ def _normalize_pcba_material(value=None):
     return text
 
 
+def _normalize_material_filter(material, department):
+    material = _clean_optional(material)
+    if (
+        department == OUTSOURCE_DEPARTMENT
+        and material
+        and _normalize_pcba_material(material) == PCBA_MATERIAL
+    ):
+        return PCBA_MATERIAL
+    return material
+
+
 def _outsource_date_value(value):
     rec_date = _legacy_excel_date(value)
     return rec_date
@@ -2217,11 +2228,11 @@ class RecordIn(BaseModel):
 def _validate_record(body: RecordIn, department: Optional[str] = None):
     if body.rec_type not in VALID_TYPES:
         raise HTTPException(status_code=400, detail="类型无效")
-    if (
-        department == OUTSOURCE_DEPARTMENT
-        and _normalize_pcba_material(body.material) != PCBA_MATERIAL
-    ):
-        raise HTTPException(status_code=400, detail="利鸿只允许使用77794-PCBA板")
+    if department == OUTSOURCE_DEPARTMENT:
+        normalized_material = _normalize_pcba_material(body.material)
+        if normalized_material != PCBA_MATERIAL:
+            raise HTTPException(status_code=400, detail="利鸿只允许使用77794-PCBA板")
+        body.material = normalized_material
     if department == HONGYA_DEPARTMENT and body.material != NFC_MATERIAL:
         raise HTTPException(status_code=400, detail="鸿亚只允许使用NFC贴纸")
     if department == OUTSOURCE_DEPARTMENT and body.rec_type == "finished":
@@ -2956,7 +2967,7 @@ def _heyuan_issue_detail_sheet(wb, title, records, material_label, month_slots):
         key=lambda row: (
             _record_month(row),
             _record_export_date(row) or "",
-            _cell_text(row.get("doc_no")),
+            _natural_text_sort_key(row.get("doc_no")),
         ),
     )
     row_no = 2
@@ -3025,7 +3036,7 @@ def _heyuan_finished_detail_sheet(wb, records):
         key=lambda row: (
             _record_month(row),
             _record_export_date(row) or "",
-            _cell_text(row.get("doc_no")),
+            _natural_text_sort_key(row.get("doc_no")),
         ),
     )
     for row in records:
@@ -3765,7 +3776,6 @@ def _semi_finished_export_workbook(records, sticker_types, monthly_totals):
     outbound_locations = {
         row.get("location_name") for row in outbound if row.get("location_name")
     }
-    use_stored_outbound_totals = len(outbound_locations) <= 1
     for sheet_name, location_name in (
         ("邵阳领料", SHAOYANG_DEPARTMENT),
         ("河源华兴36#CD领料", HEYUAN_DEPARTMENT),
@@ -3779,7 +3789,7 @@ def _semi_finished_export_workbook(records, sticker_types, monthly_totals):
             totals_by_sticker,
             False,
             location_name=location_name,
-            use_stored_totals=use_stored_outbound_totals,
+            use_stored_totals=(outbound_locations == {location_name}),
         )
     return wb
 
@@ -3793,7 +3803,7 @@ def export_records(
     material: Optional[str] = None,
 ):
     filters = _date_filter(date_from, date_to, doc_no)
-    material = _clean_optional(material)
+    material = _normalize_material_filter(material, user["department"])
     conn = db.get_conn()
     try:
         sql = (
@@ -3979,7 +3989,12 @@ def _import_document_key(body):
     doc_no = _cell_text(body.doc_no)
     if not doc_no:
         return None
-    return body.rec_type, body.location_id or 0, doc_no.casefold()
+    return (
+        body.rec_type,
+        body.location_id or 0,
+        body.rec_date or "",
+        doc_no.casefold(),
+    )
 
 
 def _group_import_documents(bodies):
@@ -3995,12 +4010,13 @@ def _group_import_documents(bodies):
 
 
 def _existing_document_ids(conn, department, key):
-    rec_type, location_id, doc_no = key
+    rec_type, location_id, rec_date, doc_no = key
     rows = conn.execute(
         "SELECT id FROM records WHERE department=? AND source_record_id IS NULL "
         "AND rec_type=? AND COALESCE(location_id, 0)=? "
+        "AND COALESCE(rec_date, '')=? "
         "AND LOWER(TRIM(COALESCE(doc_no, '')))=? ORDER BY id",
-        (department, rec_type, location_id, doc_no),
+        (department, rec_type, location_id, rec_date, doc_no),
     ).fetchall()
     return [row["id"] for row in rows]
 
@@ -4069,6 +4085,12 @@ def import_records(
         skipped_documents = 0
         skipped_document_rows = 0
         if mode == "replace":
+            for existing_ids in duplicate_keys.values():
+                for record_id in existing_ids:
+                    row = _get_record_or_404(
+                        conn, record_id, user["department"]
+                    )
+                    _check_owner(row, user)
             for existing_ids in duplicate_keys.values():
                 _delete_record_ids_with_links(conn, existing_ids)
                 replaced_documents += 1
@@ -4419,8 +4441,8 @@ def public_summary(
     department: Optional[str] = None,
 ):
     filters = _date_filter(date_from, date_to)
-    material = _clean_optional(material)
     department = _validate_department(_clean_optional(department), required=False)
+    material = _normalize_material_filter(material, department)
     public_filters = {
         **filters,
         "material": material,

--- a/apps/PMC跟仓管/加工管理/pcba/static/app.html
+++ b/apps/PMC跟仓管/加工管理/pcba/static/app.html
@@ -55,12 +55,23 @@
       </div>
       <div class="section-actions">
         <button class="ghost-btn" onclick="downloadRecordTemplate()">下载模板</button>
-        <button class="primary-btn slim" onclick="chooseImportFile('recordImportFile')">导入Excel</button>
         <button class="ghost-btn" onclick="exportRecords()">导出Excel</button>
-        <input id="recordImportFile" type="file" accept=".xlsx" onchange="importRecords(this)" hidden>
         <span id="editBanner" class="status-pill subtle"></span>
       </div>
     </div>
+
+    <div class="record-import-panel">
+      <input id="recordImportFile" type="file" accept=".xlsx" onchange="onRecordImportFileSelected(this)" hidden>
+      <button class="ghost-btn" onclick="chooseImportFile('recordImportFile')">选择Excel</button>
+      <span id="recordImportFileName" class="file-name">未选择文件</span>
+      <select id="recordImportMode" title="导入模式">
+        <option value="skip">跳过重复</option>
+        <option value="replace">覆盖导入</option>
+      </select>
+      <button class="ghost-btn" onclick="checkRecordImport()">查重</button>
+      <button class="primary-btn slim" onclick="importSelectedRecords()">开始导入</button>
+    </div>
+    <div id="recordImportCheckResult" class="import-check-result" style="display:none"></div>
 
     <div id="entryTypeTabs" class="entry-type-tabs"></div>
     <div id="entryMaterialTabs" class="entry-type-tabs material-tabs"></div>
@@ -310,6 +321,6 @@
   </section>
 </main>
 
-  <script src="/static/app.js?v=28"></script>
+  <script src="/static/app.js?v=30"></script>
 </body>
 </html>

--- a/apps/PMC跟仓管/加工管理/pcba/static/app.js
+++ b/apps/PMC跟仓管/加工管理/pcba/static/app.js
@@ -83,6 +83,10 @@ function isLihong() {
   return ME && ME.department === OUTSOURCE_DEPARTMENT;
 }
 
+function isHongya() {
+  return ME && ME.department === HONGYA_DEPARTMENT;
+}
+
 function shouldHideLocationForType(type) {
   return type === 'inbound_raw'
     || (ME && ME.department === SEMI_FINISHED_DEPARTMENT && type !== 'semi_outbound')
@@ -204,6 +208,8 @@ function setEntryType(type) {
 }
 
 function entryMaterialOptions() {
+  if (isLihong()) return MATERIALS.filter(m => m.name === PCBA_MATERIAL);
+  if (isHongya()) return MATERIALS.filter(m => m.name === NFC_MATERIAL);
   const preferred = [NFC_MATERIAL, PCBA_MATERIAL];
   const byName = new Map(MATERIALS.map(m => [m.name, m]));
   const ordered = preferred
@@ -419,12 +425,13 @@ async function loadMaterials() {
     return a.id - b.id;
   });
   MATERIALS = mats;
+  const entryMats = entryMaterialOptions();
 
-  el('material').innerHTML = mats
+  el('material').innerHTML = entryMats
     .map(m => `<option value="${esc(m.name)}">${esc(m.name)}</option>`)
     .join('');
-  if (!mats.some(m => m.name === ACTIVE_ENTRY_MATERIAL)) {
-    ACTIVE_ENTRY_MATERIAL = mats[0] ? mats[0].name : '';
+  if (!entryMats.some(m => m.name === ACTIVE_ENTRY_MATERIAL)) {
+    ACTIVE_ENTRY_MATERIAL = entryMats[0] ? entryMats[0].name : '';
   }
   el('material').value = ACTIVE_ENTRY_MATERIAL;
   renderEntryMaterialTabs();
@@ -1249,6 +1256,8 @@ async function importFile(input, endpoint, errId, afterImport) {
     const parts = [`导入成功：${fmt(count)} 条`];
     if (data.monthly_totals) parts.push(`更新当月汇总 ${fmt(data.monthly_totals)} 项`);
     if (data.skipped) parts.push(`跳过 ${fmt(data.skipped)} 条重复数据`);
+    if (data.skipped_documents) parts.push(`跳过 ${fmt(data.skipped_documents)} 张重复单据`);
+    if (data.replaced_documents) parts.push(`覆盖 ${fmt(data.replaced_documents)} 张单据`);
     setMessage(errId, parts.join('，'), true);
     if (afterImport) await afterImport();
   } else {
@@ -1257,12 +1266,86 @@ async function importFile(input, endpoint, errId, afterImport) {
   }
 }
 
-async function importRecords(input) {
-  await importFile(input, '/api/records/import', 'entryErr', async () => {
+function onRecordImportFileSelected(input) {
+  updateFileName('recordImportFile', 'recordImportFileName');
+  el('recordImportCheckResult').style.display = 'none';
+  el('recordImportCheckResult').innerHTML = '';
+  setMessage('entryErr', '', false);
+}
+
+function selectedRecordImportFile() {
+  return el('recordImportFile').files && el('recordImportFile').files[0];
+}
+
+function recordImportFormData(includeMode) {
+  const file = selectedRecordImportFile();
+  if (!file) {
+    setMessage('entryErr', '请先选择 Excel 文件', false);
+    return null;
+  }
+  const form = new FormData();
+  form.append('file', file);
+  if (includeMode) form.append('mode', el('recordImportMode').value || 'skip');
+  return form;
+}
+
+async function checkRecordImport() {
+  const form = recordImportFormData(false);
+  if (!form) return;
+  const r = await api('/api/records/import-check', {method: 'POST', body: form});
+  if (!r.ok) {
+    const e = await r.json().catch(() => ({}));
+    setMessage('entryErr', e.detail || '查重失败', false);
+    return;
+  }
+  const data = await r.json();
+  const duplicates = data.duplicate_documents || [];
+  const result = el('recordImportCheckResult');
+  result.style.display = '';
+  result.innerHTML = `
+    <div class="import-check-summary">
+      <strong>查重结果</strong>
+      <span>文件单据 ${fmt(data.documents)} 张</span>
+      <span>重复 ${fmt(data.duplicates)} 张</span>
+      ${data.blank_doc_rows ? `<span>无单号明细 ${fmt(data.blank_doc_rows)} 条</span>` : ''}
+    </div>
+    ${duplicates.length ? `<div class="duplicate-doc-list">${duplicates.map(row => `
+      <span title="文件 ${fmt(row.file_rows)} 条，已有 ${fmt(row.existing_rows)} 条">
+        ${esc(row.doc_no)}${row.target_department ? ` · ${esc(row.target_department)}` : ''}
+      </span>`).join('')}</div>` : '<p>没有发现重复单据，可以直接导入。</p>'}
+  `;
+  setMessage('entryErr', duplicates.length ? '查重完成，请选择导入模式' : '查重完成，没有重复单据', true);
+}
+
+async function importSelectedRecords() {
+  const mode = el('recordImportMode').value || 'skip';
+  if (mode === 'replace' && !confirm('覆盖导入会替换文件中同单号的原明细及自动联动记录，确定继续吗？')) {
+    return;
+  }
+  const form = recordImportFormData(true);
+  if (!form) return;
+  const r = await api('/api/records/import', {method: 'POST', body: form});
+  if (!r.ok) {
+    const e = await r.json().catch(() => ({}));
+    setMessage('entryErr', e.detail || '导入失败', false);
+    return;
+  }
+  const data = await r.json();
+  const parts = [`导入成功：${fmt(data.created || 0)} 条`];
+  if (data.monthly_totals) parts.push(`更新当月汇总 ${fmt(data.monthly_totals)} 项`);
+  if (data.skipped_documents) parts.push(`跳过 ${fmt(data.skipped_documents)} 张重复单据`);
+  if (data.replaced_documents) parts.push(`覆盖 ${fmt(data.replaced_documents)} 张单据`);
+  setMessage('entryErr', parts.join('，'), true);
+  await (async () => {
     cancelEdit();
     await loadRecords();
     if (el('summary').style.display !== 'none') await loadSummary();
   });
+}
+
+async function importRecords(input) {
+  onRecordImportFileSelected(input);
+  await importSelectedRecords();
 }
 
 function exportMaterials() {

--- a/apps/PMC跟仓管/加工管理/pcba/static/style.css
+++ b/apps/PMC跟仓管/加工管理/pcba/static/style.css
@@ -463,6 +463,59 @@ label {
   background: rgba(248, 250, 252, 0.72);
 }
 
+.record-import-panel {
+  display: grid;
+  grid-template-columns: auto minmax(160px, 1fr) 150px auto auto;
+  gap: 10px;
+  align-items: center;
+  margin: 0 0 14px;
+  padding: 12px;
+  border: 1px solid var(--soft-line);
+  border-radius: 8px;
+  background: rgba(248, 250, 252, 0.78);
+}
+
+.record-import-panel .file-name {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--muted);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.record-import-panel select {
+  min-height: 42px;
+}
+
+.import-check-result {
+  margin: -4px 0 14px;
+  padding: 12px;
+  border: 1px solid #bfdbfe;
+  border-radius: 8px;
+  background: #eff6ff;
+}
+
+.import-check-summary,
+.duplicate-doc-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 14px;
+  align-items: center;
+}
+
+.duplicate-doc-list {
+  margin-top: 10px;
+}
+
+.duplicate-doc-list span {
+  padding: 5px 8px;
+  border: 1px solid #fecaca;
+  border-radius: 6px;
+  color: #991b1b;
+  background: #fff;
+  font-size: 13px;
+}
+
 .sticker-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(132px, 1fr));

--- a/apps/PMC跟仓管/加工管理/tests/test_api_public_summary.py
+++ b/apps/PMC跟仓管/加工管理/tests/test_api_public_summary.py
@@ -130,7 +130,7 @@ def test_public_summary_uses_outsource_balance_direction(client):
     departments = {row["department"]: row for row in data["department_totals"]}
 
     assert data["totals"] == {"inbound": 60, "outbound": 100, "balance": 40}
-    assert materials["PCBA板"]["balance"] == 40
+    assert materials["77794-PCBA板"]["balance"] == 40
     assert departments["东莞加工厂利鸿"]["balance"] == 40
 
 

--- a/apps/PMC跟仓管/加工管理/tests/test_api_records.py
+++ b/apps/PMC跟仓管/加工管理/tests/test_api_records.py
@@ -562,6 +562,21 @@ def test_lihong_rejects_nfc_material(client):
     assert "利鸿只允许使用77794-PCBA板" in issue.json()["detail"]
 
 
+def test_lihong_normalizes_pcba_alias_before_saving(client):
+    admin_login(client, "东莞加工厂利鸿")
+
+    created = client.post("/api/records", json={
+        "rec_type": "semi_finished",
+        "material": "PCBA板",
+        "doc_no": "LIHONG-ALIAS-001",
+        "qty": 15,
+    })
+
+    assert created.status_code == 200
+    row = client.get("/api/records?doc_no=LIHONG-ALIAS-001").json()[0]
+    assert row["material"] == "77794-PCBA板"
+
+
 def test_outsource_can_create_issue_with_target_department(client):
     admin_login(client, "东莞加工厂利鸿")
     semi = loc_id(client, "碟片半成品")

--- a/apps/PMC跟仓管/加工管理/tests/test_api_records.py
+++ b/apps/PMC跟仓管/加工管理/tests/test_api_records.py
@@ -537,13 +537,29 @@ def test_lihong_rejects_finished_and_accepts_semifinished_outbound(client):
         "rec_type": "finished", "material": "PCBA板", "qty": 40})
     assert finished.status_code == 400
     semi_finished = client.post("/api/records", json={
-        "rec_type": "semi_finished", "material": "NFC贴纸", "qty": 15})
+        "rec_type": "semi_finished", "material": "77794-PCBA板", "qty": 15})
     assert semi_finished.status_code == 200
 
     rows = client.get("/api/records").json()
     by_type = {r["rec_type"]: r for r in rows}
     assert by_type["semi_finished"]["qty"] == 15
     assert by_type["semi_finished"]["location_id"] is None
+
+
+def test_lihong_rejects_nfc_material(client):
+    admin_login(client, "东莞加工厂利鸿")
+    semi = loc_id(client, "碟片半成品")
+
+    issue = client.post("/api/records", json={
+        "rec_type": "issue", "location_id": semi,
+        "material": "NFC贴纸", "sticker_type": "1#NFC贴纸", "qty": 20})
+    semi_finished = client.post("/api/records", json={
+        "rec_type": "semi_finished", "material": "NFC贴纸",
+        "sticker_type": "1#NFC贴纸", "qty": 15})
+
+    assert issue.status_code == 400
+    assert semi_finished.status_code == 400
+    assert "利鸿只允许使用77794-PCBA板" in issue.json()["detail"]
 
 
 def test_outsource_can_create_issue_with_target_department(client):
@@ -568,7 +584,8 @@ def test_hongya_outsource_can_create_all_outsource_types(client):
         "rec_type": "finished", "material": "NFC贴纸",
         "sticker_type": "1#NFC贴纸", "qty": 80})
     semi_finished = client.post("/api/records", json={
-        "rec_type": "semi_finished", "material": "77794-PCBA板", "qty": 15})
+        "rec_type": "semi_finished", "material": "NFC贴纸",
+        "sticker_type": "1#NFC贴纸", "qty": 15})
 
     assert issue.status_code == 200
     assert finished.status_code == 200
@@ -590,12 +607,12 @@ def test_outsource_rejects_other_warehouse_record_types(client):
 
 def test_semi_finished_department_can_create_inbound_and_outbound(client):
     admin_login(client, "碟片半成品")
-    hongya = loc_id(client, "东莞加工厂鸿亚")
+    lihong = loc_id(client, "东莞加工厂利鸿")
     inbound = client.post("/api/records", json={
         "rec_type": "semi_inbound", "material": "PCBA板", "qty": 80})
     assert inbound.status_code == 200
     outbound = client.post("/api/records", json={
-        "rec_type": "semi_outbound", "location_id": hongya,
+        "rec_type": "semi_outbound", "location_id": lihong,
         "material": "PCBA板", "qty": 30})
     assert outbound.status_code == 200
 
@@ -604,7 +621,7 @@ def test_semi_finished_department_can_create_inbound_and_outbound(client):
     assert by_type["semi_inbound"]["qty"] == 80
     assert by_type["semi_outbound"]["qty"] == 30
     assert by_type["semi_inbound"]["location_id"] is None
-    assert by_type["semi_outbound"]["location_id"] == hongya
+    assert by_type["semi_outbound"]["location_id"] == lihong
 
 
 def test_semi_finished_outbound_requires_target_department(client):
@@ -762,6 +779,28 @@ def test_semifinished_outbound_to_hongya_auto_creates_hongya_issue(client):
     assert rows[0]["location_id"] == hongya
 
 
+def test_hongya_only_accepts_nfc_material(client):
+    admin_login(client, "东莞加工厂鸿亚")
+
+    rejected = client.post("/api/records", json={
+        "rec_type": "finished",
+        "material": "77794-PCBA板",
+        "doc_no": "HY-PCBA-001",
+        "qty": 10,
+    })
+    accepted = client.post("/api/records", json={
+        "rec_type": "finished",
+        "material": "NFC贴纸",
+        "sticker_type": "1#NFC贴纸",
+        "doc_no": "HY-NFC-001",
+        "qty": 10,
+    })
+
+    assert rejected.status_code == 400
+    assert rejected.json()["detail"] == "鸿亚只允许使用NFC贴纸"
+    assert accepted.status_code == 200
+
+
 def test_outsource_issue_requires_target_department(client):
     admin_login(client, "东莞加工厂鸿亚")
 
@@ -885,4 +924,3 @@ def test_semifinished_36_nfc_to_shaoyang_huadeng_auto_creates_shaoyang_issue(cli
     assert rows[0]["location_name"] == "邵阳华登"
     assert rows[0]["sticker_type"] == "36#NFC贴纸"
     assert rows[0]["qty"] == 66
-

--- a/apps/PMC跟仓管/加工管理/tests/test_api_summary.py
+++ b/apps/PMC跟仓管/加工管理/tests/test_api_summary.py
@@ -197,11 +197,11 @@ def test_assembly_summary_subtracts_semi_finished(client):
 
 def test_semi_finished_department_summary_uses_warehouse_balance(client):
     admin_login(client, "碟片半成品")
-    hongya = loc_id(client, "东莞加工厂鸿亚")
+    lihong = loc_id(client, "东莞加工厂利鸿")
     client.post("/api/records", json={
         "rec_type": "semi_inbound", "material": "PCBA板", "qty": 80})
     client.post("/api/records", json={
-        "rec_type": "semi_outbound", "location_id": hongya,
+        "rec_type": "semi_outbound", "location_id": lihong,
         "material": "PCBA板", "qty": 30})
 
     s = client.get("/api/summary").json()
@@ -228,7 +228,7 @@ def test_lihong_summary_uses_issue_minus_semifinished_outbound(client):
     client.post("/api/records", json={
         "rec_type": "issue", "location_id": lid, "material": "PCBA板", "qty": 70})
     client.post("/api/records", json={
-        "rec_type": "semi_finished", "material": "NFC贴纸", "qty": 30})
+        "rec_type": "semi_finished", "material": "77794-PCBA板", "qty": 30})
 
     s = client.get("/api/summary").json()
     assert s["raw"]["issue"] == 70
@@ -298,4 +298,3 @@ def test_xinshao_summary_uses_issue_minus_finished_balance(client):
 def test_summary_requires_login(client):
     r = client.get("/api/summary")
     assert r.status_code == 401
-

--- a/apps/PMC跟仓管/加工管理/tests/test_db.py
+++ b/apps/PMC跟仓管/加工管理/tests/test_db.py
@@ -323,5 +323,10 @@ def test_init_migrates_existing_records_to_default_department(db_path):
     assert "supplier" in record_columns
     assert "po_no" in record_columns
     assert "customer_name" in record_columns
+    monthly_columns = [
+        r["name"]
+        for r in conn.execute("PRAGMA table_info(semi_finished_monthly_totals)").fetchall()
+    ]
+    assert "assembly_opening_stock" in monthly_columns
+    assert "hongya_opening_stock" in monthly_columns
     conn.close()
-

--- a/apps/PMC跟仓管/加工管理/tests/test_db.py
+++ b/apps/PMC跟仓管/加工管理/tests/test_db.py
@@ -330,3 +330,27 @@ def test_init_migrates_existing_records_to_default_department(db_path):
     assert "assembly_opening_stock" in monthly_columns
     assert "hongya_opening_stock" in monthly_columns
     conn.close()
+
+
+def test_init_normalizes_existing_lihong_pcba_material_alias(db_path):
+    from pcba import db
+
+    db.init_db()
+    conn = db.get_conn()
+    conn.execute(
+        "INSERT INTO records(rec_type, material, qty, department, created_by) "
+        "VALUES (?, ?, ?, ?, ?)",
+        ("semi_finished", "PCBA板", 10, "东莞加工厂利鸿", 1),
+    )
+    conn.commit()
+    conn.close()
+
+    db.init_db()
+    conn = db.get_conn()
+    material = conn.execute(
+        "SELECT material FROM records WHERE department=?",
+        ("东莞加工厂利鸿",),
+    ).fetchone()["material"]
+    conn.close()
+
+    assert material == "77794-PCBA板"

--- a/apps/PMC跟仓管/加工管理/tests/test_export.py
+++ b/apps/PMC跟仓管/加工管理/tests/test_export.py
@@ -213,11 +213,11 @@ def test_export_includes_semi_finished_detail_sheet(client):
 
 def test_semi_finished_department_export_has_inbound_and_outbound_sheets(client):
     admin_login(client, "碟片半成品")
-    hongya = loc_id(client, "东莞加工厂鸿亚")
+    lihong = loc_id(client, "东莞加工厂利鸿")
     client.post("/api/records", json={
         "rec_type": "semi_inbound", "material": "PCBA板", "qty": 80})
     client.post("/api/records", json={
-        "rec_type": "semi_outbound", "location_id": hongya,
+        "rec_type": "semi_outbound", "location_id": lihong,
         "material": "PCBA板", "qty": 30})
 
     r = client.get("/api/export")
@@ -236,7 +236,7 @@ def test_lihong_summary_export_uses_semifinished_outbound_only(client):
     client.post("/api/records", json={
         "rec_type": "issue", "location_id": lid, "material": "PCBA板", "qty": 70})
     client.post("/api/records", json={
-        "rec_type": "semi_finished", "material": "NFC贴纸", "qty": 30})
+        "rec_type": "semi_finished", "material": "77794-PCBA板", "qty": 30})
 
     r = client.get("/api/export")
     wb = openpyxl.load_workbook(io.BytesIO(r.content), data_only=True)
@@ -264,8 +264,6 @@ def test_shaoyang_finished_export_includes_po_and_customer_columns(client):
     assert ws.cell(row=2, column=4).value == "PO-001"
     assert ws.cell(row=2, column=5).value == "客户A"
     assert ws.cell(row=2, column=6).value == 45
-
-
 def test_xinshao_finished_export_includes_po_and_customer_columns(client):
     admin_login(client, "新邵")
     lid = loc_id(client, "新邵")
@@ -281,4 +279,3 @@ def test_xinshao_finished_export_includes_po_and_customer_columns(client):
     assert ws.cell(row=2, column=4).value == "PO-X01"
     assert ws.cell(row=2, column=5).value == "客户X"
     assert ws.cell(row=2, column=6).value == 45
-

--- a/apps/PMC跟仓管/加工管理/tests/test_import_export.py
+++ b/apps/PMC跟仓管/加工管理/tests/test_import_export.py
@@ -772,6 +772,66 @@ def test_record_import_replace_mode_replaces_document_and_auto_records(client):
     assert target_rows[0]["source_record_id"] is not None
 
 
+def test_record_import_replace_rejects_records_owned_by_another_user(client):
+    login(client)
+    created = client.post("/api/records", json={
+        "rec_type": "inbound_raw",
+        "material": "77794-PCBA板",
+        "rec_date": "2026-07-01",
+        "doc_no": "ADMIN-OWNED-001",
+        "qty": 10,
+    })
+    assert created.status_code == 200
+
+    client.post("/api/logout")
+    login(client, "兴信B来料仓", "123456", DEFAULT_DEPARTMENT)
+    replacing = workbook_bytes(
+        ["类型", "物料名称", "日期", "单据编号", "数量"],
+        [["入库", "77794-PCBA板", "2026-07-01", "ADMIN-OWNED-001", 20]],
+    )
+    replaced = upload_bytes(
+        client,
+        "/api/records/import",
+        replacing,
+        data={"mode": "replace"},
+    )
+
+    assert replaced.status_code == 403
+    rows = client.get("/api/records?doc_no=ADMIN-OWNED-001").json()
+    assert len(rows) == 1
+    assert rows[0]["qty"] == 10
+
+
+def test_record_import_same_document_number_on_different_dates_is_not_duplicate(client):
+    login(client, "兴信B来料仓", "123456", DEFAULT_DEPARTMENT)
+    headers = ["类型", "物料名称", "日期", "单据编号", "数量"]
+    first = upload_xlsx(
+        client,
+        "/api/records/import",
+        headers,
+        [["入库", "77794-PCBA板", "2026-07-01", "PERIODIC-001", 10]],
+    )
+    second_content = workbook_bytes(
+        headers,
+        [["入库", "77794-PCBA板", "2026-08-01", "PERIODIC-001", 20]],
+    )
+    second = upload_bytes(
+        client,
+        "/api/records/import",
+        second_content,
+        data={"mode": "skip"},
+    )
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert second.json()["created"] == 1
+    rows = client.get("/api/records?doc_no=PERIODIC-001").json()
+    assert {(row["rec_date"], row["qty"]) for row in rows} == {
+        ("2026-07-01", 10),
+        ("2026-08-01", 20),
+    }
+
+
 def test_semi_finished_export_splits_outbound_by_target_department(client):
     login(client, "碟片半成品", "123456", "碟片半成品")
     locations = {
@@ -940,6 +1000,47 @@ def test_heyuan_record_export_uses_legacy_pcba_workbook(client):
     assert wb["总表"].cell(11, 2).value == 75
 
 
+def test_heyuan_export_naturally_sorts_same_day_document_numbers(client):
+    login(client, "河源华兴", "123456", "河源华兴")
+    heyuan = loc_id(client, "河源华兴")
+    for doc_no in ("LL-10", "LL-2"):
+        response = client.post("/api/records", json={
+            "rec_type": "issue",
+            "location_id": heyuan,
+            "material": "77794-PCBA板",
+            "rec_date": "2026-07-08",
+            "doc_no": doc_no,
+            "qty": 10,
+        })
+        assert response.status_code == 200
+    for doc_no in ("BS-10", "BS-2"):
+        response = client.post("/api/records", json={
+            "rec_type": "finished",
+            "location_id": heyuan,
+            "material": "77794-PCBA板",
+            "rec_date": "2026-07-09",
+            "doc_no": doc_no,
+            "qty": 5,
+        })
+        assert response.status_code == 200
+
+    exported = client.get("/api/records/export?material=77794-PCBA板")
+    wb = openpyxl.load_workbook(io.BytesIO(exported.content), data_only=True)
+    issue_docs = [
+        row[1]
+        for row in wb["PCB板领料明细"].iter_rows(min_row=2, values_only=True)
+        if isinstance(row[1], str) and row[1].startswith("LL-")
+    ]
+    finished_docs = [
+        row[1]
+        for row in wb["成品入仓明细"].iter_rows(min_row=2, values_only=True)
+        if isinstance(row[1], str) and row[1].startswith("BS-")
+    ]
+
+    assert issue_docs == ["LL-2", "LL-10"]
+    assert finished_docs == ["BS-2", "BS-10"]
+
+
 def test_heyuan_empty_finished_export_keeps_header_only(client):
     login(client, "河源华兴", "123456", "河源华兴")
 
@@ -1024,6 +1125,24 @@ def test_semi_finished_legacy_workbook_imports_detail_rows_and_monthly_totals(cl
     assert second.json()["created"] == 0
     assert second.json()["skipped"] == 3
     assert len(client.get("/api/records").json()) == 3
+
+
+def test_semi_finished_export_keeps_stored_total_on_matching_outbound_sheet(client):
+    login(client, "碟片半成品", "123456", "碟片半成品")
+    imported = upload_bytes(
+        client,
+        "/api/records/import",
+        legacy_semi_finished_workbook_bytes(),
+        "塑胶仓77772#CD半成品出入明细.xlsx",
+    )
+    exported = client.get("/api/records/export?material=NFC贴纸")
+    wb = openpyxl.load_workbook(io.BytesIO(exported.content), data_only=True)
+
+    assert imported.status_code == 200
+    assert exported.status_code == 200
+    assert wb["邵阳领料"].cell(6, 2).value == 40
+    assert wb["河源华兴36#CD领料"].cell(6, 2).value == 0
+    assert wb["车间36#CD领料"].cell(6, 2).value == 0
 
 
 def test_semi_finished_legacy_workbook_rejects_filename_without_department(client):

--- a/apps/PMC跟仓管/加工管理/tests/test_import_export.py
+++ b/apps/PMC跟仓管/加工管理/tests/test_import_export.py
@@ -89,6 +89,61 @@ def legacy_semi_finished_workbook_bytes():
     return buf.getvalue()
 
 
+def routed_semi_finished_workbook_bytes(shaoyang_qty=10):
+    wb = openpyxl.Workbook()
+    inbound = wb.active
+    inbound.title = "入库明细"
+    inbound["D1"] = "日期"
+    inbound["E1"] = "2026-07-01"
+    inbound["D2"] = "入库单号"
+    inbound["E2"] = "RK-ROUTE-001"
+    inbound["A3"] = "物料名称"
+    inbound["B3"] = "当月入仓总数"
+    inbound["A4"] = "36#NFC\n贴纸"
+    inbound["B4"] = 100
+    inbound["E4"] = 100
+    inbound["A5"] = "37#NFC\n贴纸"
+    inbound["B5"] = 50
+    inbound["E5"] = 50
+
+    shaoyang = wb.create_sheet("邵阳领料")
+    shaoyang["D1"] = "2026-07-02"
+    shaoyang["D2"] = "LL-SY-001"
+    shaoyang["A5"] = "物料名称"
+    shaoyang["B5"] = "当月出仓总数"
+    shaoyang["A6"] = "36#NFC\n贴纸"
+    shaoyang["B6"] = shaoyang_qty
+    shaoyang["D6"] = shaoyang_qty
+
+    heyuan = wb.create_sheet("河源华兴36#CD领料")
+    heyuan["C1"] = "2026-07-02"
+    heyuan["C2"] = "LL-HY-001"
+    heyuan["A3"] = "供应商"
+    heyuan["B3"] = "上级名称"
+    heyuan["C3"] = "河源华兴"
+    heyuan["A4"] = "数量"
+    heyuan["B4"] = 20
+    heyuan["C4"] = 20
+
+    workshop = wb.create_sheet("车间36#CD领料")
+    workshop["C1"] = "2026-07-02"
+    workshop["C2"] = "LL-DG-001"
+    workshop["A3"] = "供应商"
+    workshop["B3"] = "上级名称"
+    workshop["C3"] = "HD"
+    workshop["A4"] = "25#NFC贴纸"
+    workshop["A5"] = "36#NFC贴纸"
+    workshop["B5"] = 30
+    workshop["C5"] = 30
+    workshop["A6"] = "44#NFC贴纸"
+
+    total = wb.create_sheet("总表", 0)
+    total["A1"] = "总表不用导入"
+    buf = io.BytesIO()
+    wb.save(buf)
+    return buf.getvalue()
+
+
 def legacy_assembly_nfc_workbook_bytes():
     wb = openpyxl.Workbook()
     total_ws = wb.active
@@ -96,6 +151,7 @@ def legacy_assembly_nfc_workbook_bytes():
     total_ws["A2"] = "物料名称"
     total_ws["B1"] = "累计入仓总数"
     total_ws["C1"] = "东莞"
+    total_ws["C2"] = "截止6月27号"
     total_ws["D1"] = "7月领料\n总数"
     total_ws["E1"] = "2026-07-01"
     total_ws["A3"] = "1#NFC\n贴纸"
@@ -105,7 +161,7 @@ def legacy_assembly_nfc_workbook_bytes():
 
     issue_ws = wb.create_sheet("领料明细")
     issue_ws["B1"] = "当月领料总数"
-    issue_ws["C1"] = "7月1日"
+    issue_ws["C1"] = "6月29日"
     issue_ws["A2"] = "物料名称"
     issue_ws["C2"] = "DG-LL-001"
     issue_ws["A3"] = "1#NFC\n贴纸"
@@ -114,12 +170,42 @@ def legacy_assembly_nfc_workbook_bytes():
 
     semi_ws = wb.create_sheet("半成品入仓明细")
     semi_ws["B1"] = "当月入仓总数"
-    semi_ws["C1"] = "7月2日"
+    semi_ws["C1"] = "6月30日"
     semi_ws["A2"] = "物料名称"
     semi_ws["C2"] = "DG-RK-001"
     semi_ws["A3"] = "1#NFC\n贴纸"
     semi_ws["B3"] = 25
     semi_ws["C3"] = 25
+
+    buf = io.BytesIO()
+    wb.save(buf)
+    return buf.getvalue()
+
+
+def legacy_assembly_pcba_workbook_bytes():
+    wb = openpyxl.Workbook()
+    total_ws = wb.active
+    total_ws.title = "总表"
+    total_ws.append(["物料名称", "领料总数", "截6月月结", "7月"])
+    total_ws.append(["PCBA主板", 20800, None, 20800])
+
+    issue_ws = wb.create_sheet("PCB主板领料明细")
+    issue_ws.append(["日期", "领料编号", "物料名称", "领料数", "备注"])
+    issue_ws.append(["2026-07-06", 2202830, "PCBA主板", 20800, None])
+
+    finished_ws = wb.create_sheet("成品入仓明细")
+    finished_ws.append(
+        ["日期", "送货单号", "合同号", "货号", "品名/规格", "数量（pcs）", "备注"]
+    )
+    finished_ws.append(
+        ["2026-07-07", 2510160, 4500204119, "MSLD182-77794", None, 11328, None]
+    )
+    finished_ws.append(
+        ["2026-07-09", 2510080, 4500204119, "MSLD182-77794", None, 17088, None]
+    )
+    finished_ws.append(
+        ["2026-07-09", 2510079, 4500204118, "MSLD182-77794", None, 17280, None]
+    )
 
     buf = io.BytesIO()
     wb.save(buf)
@@ -153,22 +239,31 @@ def legacy_outsource_workbook_bytes():
 
 def legacy_heyuan_workbook_bytes():
     wb = openpyxl.Workbook()
-    ws = wb.active
-    ws.title = "PCB板领料明细"
+    total_ws = wb.active
+    total_ws.title = "总表"
+    total_ws.append(["物料名称", "领料总数", "截6月月结", "7月"])
+    total_ws.append(["PCBA主板", 125, 100, 25])
+    total_ws.append(["36#唱片CD", 75, 50, 25])
+
+    ws = wb.create_sheet("PCB板领料明细")
     ws.append(["日期", "领料编号", "物料名称", "领料数", "备注"])
     ws.append(["2026-06-20", 2519360, "77794-PCBA板", 100, None])
-    ws.append(["2026-07-01", 2518791, "77794-PCBA板", 30, None])
+    ws.append([None, None, "6月小计：", 100, None])
+    ws.append(["2026-06-30", 2518791, "77794-PCBA板", 30, None])
     ws.append(["2026-07-02", "退不良品", "77794-PCBA板", -5, None])
     ws.append([None, None, "7月小计：", 25, None])
+
+    cd_ws = wb.create_sheet("36#CD领料明细")
+    cd_ws.append(["日期", "领料编号", "物料名称", "领料数", "备注"])
+    cd_ws.append(["6月", "月结", "36#唱片CD", 50, None])
+    cd_ws.append([None, None, "6月小计：", 50, None])
+    cd_ws.append(["2026-07-08", 2611533, "36#唱片CD", 25, None])
+    cd_ws.append([None, None, "7月小计：", 25, None])
 
     finished_ws = wb.create_sheet("成品入仓明细")
     finished_ws.append(["日期", "送货单号", "合同号", "货号", "品名/规格", "数量（pcs）", "备注"])
     finished_ws.append(["2026-07-03", "HY2026070301", "HYHT", 77794, "成品唱机", 20, None])
     finished_ws.append([None, None, None, None, "7月小计：", 20, None])
-
-    total_ws = wb.create_sheet("总表")
-    total_ws.append(["物料名称", "领料总数", "截6月月结", "7月"])
-    total_ws.append(["PCBA主板", 125, 100, 25])
 
     buf = io.BytesIO()
     wb.save(buf)
@@ -275,27 +370,32 @@ def legacy_hongya_nfc_workbook_bytes():
     issue_ws = wb.create_sheet("领料明细")
     issue_ws.cell(1, 2).value = "当月领料总数"
     issue_ws.cell(1, 3).value = "2026-07-01"
+    issue_ws.cell(1, 4).value = "2026-07-01"
     issue_ws.cell(2, 1).value = "物料名称"
     issue_ws.cell(3, 1).value = "1#NFC\n贴纸"
     issue_ws.cell(3, 2).value = 30
-    issue_ws.cell(3, 3).value = 30
+    issue_ws.cell(3, 3).value = 10
+    issue_ws.cell(3, 4).value = 20
 
     inbound_ws = wb.create_sheet("入仓明细")
     inbound_ws.cell(1, 2).value = "当月入仓总数"
     inbound_ws.cell(1, 3).value = "2026-07-02"
+    inbound_ws.cell(1, 4).value = "2026-07-02"
     inbound_ws.cell(2, 1).value = "物料名称"
     inbound_ws.cell(3, 1).value = "1#NFC\n贴纸"
     inbound_ws.cell(3, 2).value = 20
-    inbound_ws.cell(3, 3).value = 20
+    inbound_ws.cell(3, 3).value = 5
+    inbound_ws.cell(3, 4).value = 15
 
     buf = io.BytesIO()
     wb.save(buf)
     return buf.getvalue()
 
 
-def upload_bytes(client, path, content, filename="legacy.xlsx"):
+def upload_bytes(client, path, content, filename="legacy.xlsx", data=None):
     return client.post(
         path,
+        data=data or {},
         files={
             "file": (
                 filename,
@@ -533,7 +633,9 @@ def test_semi_finished_export_uses_legacy_matrix_workbook(client):
     assert inbound.cell(3, 3).value == "6/24\n东莞车间入库截数"
     assert inbound.cell(4, 1).value == "1#NFC\n贴纸"
     assert inbound.cell(4, 2).value == 100
-    assert inbound.cell(4, 3).value == 25
+    assert inbound.cell(3, 4).value == "6/24\n鸿亚入库截数"
+    assert inbound.cell(4, 3).value == 10
+    assert inbound.cell(4, 4).value == 15
     assert inbound.cell(1, 5).value == "2026-07-01"
     assert inbound.cell(2, 5).value == "RK-001"
     assert inbound.cell(4, 5).value == 30
@@ -547,6 +649,168 @@ def test_semi_finished_export_uses_legacy_matrix_workbook(client):
     assert outbound.cell(1, 4).value == "2026-07-03"
     assert outbound.cell(2, 4).value == "LL-001"
     assert outbound.cell(6, 4).value == 35
+
+
+def test_semi_finished_import_routes_outbound_sheets_to_departments(client):
+    login(client, "碟片半成品", "123456", "碟片半成品")
+
+    imported = upload_bytes(
+        client,
+        "/api/records/import",
+        routed_semi_finished_workbook_bytes(),
+        "塑胶仓77772#CD半成品出入明细.xlsx",
+    )
+    records = client.get("/api/records").json()
+    outbound = {
+        row["doc_no"]: row["location_name"]
+        for row in records
+        if row["rec_type"] == "semi_outbound"
+    }
+
+    assert imported.status_code == 200
+    assert outbound == {
+        "LL-SY-001": "邵阳华登",
+        "LL-HY-001": "河源华兴",
+        "LL-DG-001": "东莞车间",
+    }
+
+
+def test_record_import_check_groups_duplicate_documents_without_writing(client):
+    login(client, "碟片半成品", "123456", "碟片半成品")
+    content = routed_semi_finished_workbook_bytes()
+    first = upload_bytes(
+        client,
+        "/api/records/import",
+        content,
+        "塑胶仓77772#CD半成品出入明细.xlsx",
+    )
+    before = client.get("/api/records").json()
+
+    checked = upload_bytes(
+        client,
+        "/api/records/import-check",
+        content,
+        "塑胶仓77772#CD半成品出入明细.xlsx",
+    )
+    after = client.get("/api/records").json()
+
+    assert first.status_code == 200
+    assert checked.status_code == 200
+    result = checked.json()
+    assert result["documents"] == 4
+    assert result["duplicates"] == 4
+    assert {row["doc_no"] for row in result["duplicate_documents"]} == {
+        "RK-ROUTE-001", "LL-SY-001", "LL-HY-001", "LL-DG-001",
+    }
+    inbound_duplicate = next(
+        row for row in result["duplicate_documents"]
+        if row["doc_no"] == "RK-ROUTE-001"
+    )
+    assert inbound_duplicate["file_rows"] == 2
+    assert len(after) == len(before)
+
+
+def test_record_import_skip_mode_skips_whole_duplicate_documents(client):
+    login(client, "碟片半成品", "123456", "碟片半成品")
+    content = routed_semi_finished_workbook_bytes()
+    first = upload_bytes(
+        client,
+        "/api/records/import",
+        content,
+        "塑胶仓77772#CD半成品出入明细.xlsx",
+    )
+    second = upload_bytes(
+        client,
+        "/api/records/import",
+        content,
+        "塑胶仓77772#CD半成品出入明细.xlsx",
+        data={"mode": "skip"},
+    )
+
+    assert first.status_code == 200
+    assert first.json()["created"] == 5
+    assert second.status_code == 200
+    assert second.json()["created"] == 0
+    assert second.json()["skipped_documents"] == 4
+    assert len(client.get("/api/records").json()) == 5
+
+
+def test_record_import_replace_mode_replaces_document_and_auto_records(client):
+    login(client, "碟片半成品", "123456", "碟片半成品")
+    filename = "塑胶仓77772#CD半成品出入明细.xlsx"
+    first = upload_bytes(
+        client,
+        "/api/records/import",
+        routed_semi_finished_workbook_bytes(shaoyang_qty=10),
+        filename,
+    )
+    replaced = upload_bytes(
+        client,
+        "/api/records/import",
+        routed_semi_finished_workbook_bytes(shaoyang_qty=15),
+        filename,
+        data={"mode": "replace"},
+    )
+    source_rows = client.get("/api/records").json()
+
+    assert first.status_code == 200
+    assert replaced.status_code == 200
+    assert replaced.json()["replaced_documents"] == 4
+    shaoyang_source = [
+        row for row in source_rows if row["doc_no"] == "LL-SY-001"
+    ]
+    assert len(shaoyang_source) == 1
+    assert shaoyang_source[0]["qty"] == 15
+
+    login(client, "邵阳华登", "123456", "邵阳华登")
+    target_rows = [
+        row for row in client.get("/api/records").json()
+        if row["doc_no"] == "LL-SY-001"
+    ]
+    assert len(target_rows) == 1
+    assert target_rows[0]["qty"] == 15
+    assert target_rows[0]["source_record_id"] is not None
+
+
+def test_semi_finished_export_splits_outbound_by_target_department(client):
+    login(client, "碟片半成品", "123456", "碟片半成品")
+    locations = {
+        name: loc_id(client, name)
+        for name in ("邵阳华登", "河源华兴", "东莞车间")
+    }
+    for location_name, doc_no, qty in (
+        ("邵阳华登", "LL-SY-001", 10),
+        ("河源华兴", "LL-HY-001", 20),
+        ("东莞车间", "LL-DG-001", 30),
+    ):
+        response = client.post("/api/records", json={
+            "rec_type": "semi_outbound",
+            "location_id": locations[location_name],
+            "material": "NFC贴纸",
+            "sticker_type": "36#NFC贴纸",
+            "rec_date": "2026-07-02",
+            "doc_no": doc_no,
+            "qty": qty,
+        })
+        assert response.status_code == 200
+
+    exported = client.get("/api/records/export?material=NFC贴纸")
+    wb = openpyxl.load_workbook(io.BytesIO(exported.content), data_only=True)
+
+    def sticker_qty(sheet_name):
+        ws = wb[sheet_name]
+        row_no = next(
+            row for row in range(1, ws.max_row + 1)
+            if ws.cell(row, 1).value == "36#NFC\n贴纸"
+        )
+        return ws.cell(row_no, 4).value
+
+    assert wb["邵阳领料"].cell(2, 4).value == "LL-SY-001"
+    assert sticker_qty("邵阳领料") == 10
+    assert wb["河源华兴36#CD领料"].cell(2, 4).value == "LL-HY-001"
+    assert sticker_qty("河源华兴36#CD领料") == 20
+    assert wb["车间36#CD领料"].cell(2, 4).value == "LL-DG-001"
+    assert sticker_qty("车间36#CD领料") == 30
 
 
 def test_outsource_record_export_uses_legacy_pcba_workbook(client):
@@ -595,9 +859,35 @@ def test_heyuan_record_export_uses_legacy_pcba_workbook(client):
         "rec_type": "issue",
         "location_id": heyuan,
         "material": "77794-PCBA板",
+        "rec_date": "2026-06-20",
+        "doc_no": "LL-HY-JUNE",
+        "qty": 40,
+    })
+    client.post("/api/records", json={
+        "rec_type": "issue",
+        "location_id": heyuan,
+        "material": "77794-PCBA板",
         "rec_date": "2026-07-03",
         "doc_no": "LL-HY-001",
         "qty": 88,
+    })
+    client.post("/api/records", json={
+        "rec_type": "issue",
+        "location_id": heyuan,
+        "material": "NFC贴纸",
+        "sticker_type": "36#NFC贴纸",
+        "rec_date": "2026-06-27",
+        "doc_no": "月结",
+        "qty": 50,
+    })
+    client.post("/api/records", json={
+        "rec_type": "issue",
+        "location_id": heyuan,
+        "material": "NFC贴纸",
+        "sticker_type": "36#NFC贴纸",
+        "rec_date": "2026-07-08",
+        "doc_no": "2611533",
+        "qty": 25,
     })
     client.post("/api/records", json={
         "rec_type": "finished",
@@ -618,12 +908,46 @@ def test_heyuan_record_export_uses_legacy_pcba_workbook(client):
         "日期", "领料编号", "物料名称", "领料数", "备注"]
     assert [cell.value for cell in wb["成品入仓明细"][1][:7]] == [
         "日期", "送货单号", "合同号", "货号", "品名/规格", "数量（pcs）", "备注"]
-    assert wb["PCB板领料明细"].cell(2, 2).value == "LL-HY-001"
-    assert wb["PCB板领料明细"].cell(2, 4).value == 88
+    assert wb["PCB板领料明细"].cell(2, 2).value == "LL-HY-JUNE"
+    assert wb["PCB板领料明细"].cell(2, 4).value == 40
+    assert wb["PCB板领料明细"].cell(5, 3).value == "6月小计："
+    assert wb["PCB板领料明细"].cell(5, 4).value == 40
+    assert wb["PCB板领料明细"].cell(6, 2).value == "LL-HY-001"
+    assert wb["PCB板领料明细"].cell(6, 4).value == 88
+    assert wb["PCB板领料明细"].cell(22, 3).value == "7月小计："
+    assert wb["PCB板领料明细"].cell(22, 4).value == 88
+    assert wb["36#CD领料明细"].cell(2, 2).value == "月结"
+    assert wb["36#CD领料明细"].cell(2, 4).value == 50
+    assert wb["36#CD领料明细"].cell(3, 3).value == "6月小计："
+    assert wb["36#CD领料明细"].cell(4, 2).value == "2611533"
+    assert wb["36#CD领料明细"].cell(4, 4).value == 25
+    assert wb["36#CD领料明细"].cell(18, 3).value == "7月小计："
+    assert wb["36#CD领料明细"].cell(18, 4).value == 25
     assert wb["成品入仓明细"].cell(2, 2).value == "BS-HY-001"
     assert wb["成品入仓明细"].cell(2, 6).value == 66
     assert wb["总表"].cell(2, 1).value == "PCBA主板"
-    assert wb["总表"].cell(2, 2).value == 88
+    assert wb["总表"].cell(2, 2).value == 128
+    assert wb["总表"].cell(2, 3).value == 40
+    assert wb["总表"].cell(2, 4).value == 88
+    assert wb["总表"].cell(3, 1).value == "36#唱片CD"
+    assert wb["总表"].cell(3, 2).value == 75
+    assert wb["总表"].cell(3, 3).value == 50
+    assert wb["总表"].cell(3, 4).value == 25
+    assert wb["总表"].cell(5, 2).value == "成品总数"
+    assert wb["总表"].cell(6, 2).value == 66
+    assert wb["总表"].cell(9, 2).value == "理论结存数"
+    assert wb["总表"].cell(10, 2).value == 62
+    assert wb["总表"].cell(11, 2).value == 75
+
+
+def test_heyuan_empty_finished_export_keeps_header_only(client):
+    login(client, "河源华兴", "123456", "河源华兴")
+
+    r = client.get("/api/records/export?material=77794-PCBA板")
+    wb = openpyxl.load_workbook(io.BytesIO(r.content), data_only=True)
+
+    assert r.status_code == 200
+    assert wb["成品入仓明细"].max_row == 1
 
 
 def test_operator_can_import_record_rows_from_xlsx(client):
@@ -742,17 +1066,187 @@ def test_assembly_nfc_legacy_workbook_imports_matrix_rows(client):
     records = client.get("/api/records").json()
 
     assert r.status_code == 200
-    assert r.json()["created"] == 2
+    assert r.json()["created"] == 3
     assert r.json()["monthly_totals"] == 0
     rows = {(row["rec_type"], row["doc_no"]): row for row in records}
     assert rows[("issue", "DG-LL-001")]["qty"] == 60
-    assert rows[("issue", "DG-LL-001")]["rec_date"] == "2026-07-01"
+    assert rows[("issue", "DG-LL-001")]["rec_date"] == "2026-06-29"
+    assert rows[("issue", "DG-LL-001")]["summary_month"] == 7
     assert rows[("issue", "DG-LL-001")]["material"] == "NFC贴纸"
     assert rows[("issue", "DG-LL-001")]["sticker_type"] == "1#NFC贴纸"
     assert rows[("issue", "DG-LL-001")]["location_name"] == "东莞车间"
     assert rows[("semi_finished", "DG-RK-001")]["qty"] == 25
-    assert rows[("semi_finished", "DG-RK-001")]["rec_date"] == "2026-07-02"
+    assert rows[("semi_finished", "DG-RK-001")]["rec_date"] == "2026-06-30"
+    assert rows[("semi_finished", "DG-RK-001")]["summary_month"] == 7
     assert rows[("semi_finished", "DG-RK-001")]["location_name"] == "东莞车间"
+
+
+def test_assembly_nfc_export_matches_import_workbook_format(client):
+    login(client, "东莞车间", "123456", "东莞车间")
+    imported = upload_bytes(
+        client,
+        "/api/records/import",
+        legacy_assembly_nfc_workbook_bytes(),
+        "东莞车间77772#NFC贴纸出入明细.xlsx",
+    )
+
+    exported = client.get("/api/records/export?material=NFC贴纸")
+    wb = openpyxl.load_workbook(io.BytesIO(exported.content), data_only=True)
+
+    assert imported.status_code == 200
+    assert exported.status_code == 200
+    assert wb.sheetnames == ["总表", "领料明细", "半成品入仓明细"]
+    assert wb["总表"].cell(1, 2).value == "累计入仓总数"
+    assert wb["总表"].cell(1, 4).value == "7月领料\n总数"
+    assert wb["总表"].cell(1, 11).value == "应存数"
+    assert wb["总表"].cell(1, 12).value == "累计出仓总数"
+    assert wb["总表"].cell(1, 15).value == "7月入仓\n总数"
+    assert wb["总表"].cell(3, 1).value == "1#NFC\n贴纸"
+    assert wb["总表"].cell(3, 2).value == 100
+    assert wb["总表"].cell(3, 3).value == 40
+    assert wb["总表"].cell(3, 4).value == 60
+    assert wb["总表"].cell(3, 11).value == 75
+    assert wb["总表"].cell(3, 12).value == 25
+    assert wb["总表"].cell(3, 15).value == 25
+
+    issue = wb["领料明细"]
+    assert issue.cell(1, 2).value == "当月领料总数"
+    assert issue.cell(1, 3).value == "2026-06-29"
+    assert issue.cell(2, 3).value == "DG-LL-001"
+    assert issue.cell(3, 1).value == "1#NFC\n贴纸"
+    assert issue.cell(3, 2).value == 60
+    assert issue.cell(3, 3).value == 60
+
+    inbound = wb["半成品入仓明细"]
+    assert inbound.cell(1, 2).value == "当月入仓总数"
+    assert inbound.cell(1, 3).value == "2026-06-30"
+    assert inbound.cell(2, 3).value == "DG-RK-001"
+    assert inbound.cell(3, 1).value == "1#NFC\n贴纸"
+    assert inbound.cell(3, 2).value == 25
+    assert inbound.cell(3, 3).value == 25
+
+    reimported = upload_bytes(
+        client,
+        "/api/records/import",
+        exported.content,
+        "东莞车间77772#NFC贴纸出入明细.xlsx",
+    )
+    assert reimported.status_code == 200
+    assert reimported.json()["created"] == 0
+    assert reimported.json()["skipped"] == 3
+
+
+def test_assembly_nfc_export_sorts_document_columns_by_date(client):
+    login(client, "东莞车间", "123456", "东莞车间")
+    assembly = loc_id(client, "东莞车间")
+    dated_documents = [
+        ("2026-07-10", "10"),
+        ("2026-07-03", "10"),
+        ("2026-06-29", "29"),
+        ("2026-07-03", "2"),
+        ("2026-07-01", "1"),
+    ]
+    for rec_type, prefix in (("issue", "LL"), ("semi_finished", "RK")):
+        for index, (rec_date, document_number) in enumerate(
+            dated_documents, start=1
+        ):
+            response = client.post("/api/records", json={
+                "rec_type": rec_type,
+                "location_id": assembly,
+                "material": "NFC贴纸",
+                "sticker_type": "1#NFC贴纸",
+                "rec_date": rec_date,
+                "doc_no": f"{prefix}-{document_number}",
+                "qty": index,
+                "summary_month": 7,
+            })
+            assert response.status_code == 200
+
+    exported = client.get("/api/records/export?material=NFC贴纸")
+    wb = openpyxl.load_workbook(io.BytesIO(exported.content), data_only=True)
+
+    assert [wb["领料明细"].cell(1, col).value for col in range(3, 8)] == [
+        "2026-06-29", "2026-07-01", "2026-07-03", "2026-07-03", "2026-07-10",
+    ]
+    assert [wb["领料明细"].cell(2, col).value for col in range(5, 7)] == [
+        "LL-2", "LL-10",
+    ]
+    assert [
+        wb["半成品入仓明细"].cell(1, col).value for col in range(3, 8)
+    ] == [
+        "2026-06-29", "2026-07-01", "2026-07-03", "2026-07-03", "2026-07-10",
+    ]
+    assert [
+        wb["半成品入仓明细"].cell(2, col).value for col in range(5, 7)
+    ] == ["RK-2", "RK-10"]
+
+
+def test_assembly_pcba_legacy_workbook_imports_issue_and_finished_rows(client):
+    login(client, "东莞车间", "123456", "东莞车间")
+
+    r = upload_bytes(
+        client,
+        "/api/records/import",
+        legacy_assembly_pcba_workbook_bytes(),
+        "东莞车间77794#PCB主板出入明细.xlsx",
+    )
+    records = client.get("/api/records").json()
+
+    assert r.status_code == 200
+    assert r.json()["created"] == 4
+    by_type_doc = {(row["rec_type"], row["doc_no"]): row for row in records}
+    assert by_type_doc[("issue", "2202830")]["qty"] == 20800
+    assert by_type_doc[("issue", "2202830")]["material"] == "77794-PCBA板"
+    assert by_type_doc[("issue", "2202830")]["location_name"] == "东莞车间"
+    assert by_type_doc[("finished", "2510160")]["qty"] == 11328
+    assert by_type_doc[("finished", "2510160")]["item_no"] == "MSLD182-77794"
+    assert by_type_doc[("finished", "2510160")]["location_name"] == "东莞车间"
+
+
+def test_assembly_pcba_export_matches_import_workbook_format(client):
+    login(client, "东莞车间", "123456", "东莞车间")
+    imported = upload_bytes(
+        client,
+        "/api/records/import",
+        legacy_assembly_pcba_workbook_bytes(),
+        "东莞车间77794#PCB主板出入明细.xlsx",
+    )
+
+    exported = client.get("/api/records/export?material=77794-PCBA板")
+    wb = openpyxl.load_workbook(io.BytesIO(exported.content), data_only=True)
+
+    assert imported.status_code == 200
+    assert exported.status_code == 200
+    assert wb.sheetnames == [
+        "总表", "36#CD领料明细", "PCB主板领料明细", "成品入仓明细",
+    ]
+    assert [cell.value for cell in wb["PCB主板领料明细"][1][:5]] == [
+        "日期", "领料编号", "物料名称", "领料数", "备注",
+    ]
+    assert [cell.value for cell in wb["成品入仓明细"][1][:7]] == [
+        "日期", "送货单号", "合同号", "货号", "品名/规格", "数量（pcs）", "备注",
+    ]
+    assert wb["PCB主板领料明细"].cell(2, 2).value == "2202830"
+    assert wb["PCB主板领料明细"].cell(2, 3).value == "PCBA主板"
+    assert wb["PCB主板领料明细"].cell(2, 4).value == 20800
+    assert wb["成品入仓明细"].cell(2, 2).value == "2510160"
+    assert wb["成品入仓明细"].cell(2, 3).value == "4500204119"
+    assert wb["成品入仓明细"].cell(2, 4).value == "MSLD182-77794"
+    assert wb["成品入仓明细"].cell(2, 5).value is None
+    assert wb["成品入仓明细"].cell(2, 6).value == 11328
+    assert wb["总表"].cell(1, 2).value == "领料总数"
+    assert wb["总表"].cell(5, 2).value == "成品总数"
+    assert wb["总表"].cell(9, 2).value == "理论结存数"
+
+    reimported = upload_bytes(
+        client,
+        "/api/records/import",
+        exported.content,
+        "东莞车间77794#PCB主板出入明细.xlsx",
+    )
+    assert reimported.status_code == 200
+    assert reimported.json()["created"] == 0
+    assert reimported.json()["skipped"] == 4
 
 
 def test_outsource_legacy_workbook_rejects_filename_without_department(client):
@@ -867,14 +1361,16 @@ def test_hongya_nfc_legacy_workbook_imports_issue_and_finished_rows(client):
     records = client.get("/api/records").json()
 
     assert r.status_code == 200
-    assert r.json()["created"] == 2
+    assert r.json()["created"] == 4
     rows = {(row["rec_type"], row["doc_no"]): row for row in records}
-    assert rows[("issue", "2026-07-01")]["qty"] == 30
-    assert rows[("finished", "2026-07-02")]["qty"] == 20
-    assert rows[("issue", "2026-07-01")]["material"] == "NFC贴纸"
-    assert rows[("issue", "2026-07-01")]["sticker_type"] == "1#NFC贴纸"
-    assert rows[("issue", "2026-07-01")]["location_name"] == "东莞加工厂鸿亚"
-    assert rows[("finished", "2026-07-02")]["location_name"] is None
+    assert rows[("issue", "2026-07-01#01")]["qty"] == 10
+    assert rows[("issue", "2026-07-01#02")]["qty"] == 20
+    assert rows[("finished", "2026-07-02#01")]["qty"] == 5
+    assert rows[("finished", "2026-07-02#02")]["qty"] == 15
+    assert rows[("issue", "2026-07-01#01")]["material"] == "NFC贴纸"
+    assert rows[("issue", "2026-07-01#01")]["sticker_type"] == "1#NFC贴纸"
+    assert rows[("issue", "2026-07-01#01")]["location_name"] == "东莞加工厂鸿亚"
+    assert rows[("finished", "2026-07-02#01")]["location_name"] is None
 
     summary = client.get("/api/summary").json()
     assert summary["raw"]["issue"] == 30
@@ -889,8 +1385,52 @@ def test_hongya_nfc_legacy_workbook_imports_issue_and_finished_rows(client):
     )
     assert second.status_code == 200
     assert second.json()["created"] == 0
-    assert second.json()["skipped"] == 2
-    assert len(client.get("/api/records").json()) == 2
+    assert second.json()["skipped"] == 4
+    assert len(client.get("/api/records").json()) == 4
+
+
+def test_hongya_nfc_export_matches_legacy_workbook_layout(client):
+    login(client, "东莞加工厂鸿亚", "123456", "东莞加工厂鸿亚")
+    imported = upload_bytes(
+        client,
+        "/api/records/import",
+        legacy_hongya_nfc_workbook_bytes(),
+        "东莞加工厂鸿亚77772#NFC贴纸出入明细.xlsx",
+    )
+
+    exported = client.get("/api/records/export?material=NFC贴纸")
+    wb = openpyxl.load_workbook(io.BytesIO(exported.content), data_only=True)
+
+    assert imported.status_code == 200
+    assert exported.status_code == 200
+    assert wb.sheetnames == ["总表", "领料明细", "入仓明细"]
+
+    total = wb["总表"]
+    assert total.cell(1, 2).value == "累计领料总数"
+    assert total.cell(1, 11).value == "应存数"
+    assert total.cell(1, 12).value == "累计入仓总数"
+    assert total.cell(3, 1).value == "1#NFC\n贴纸"
+    assert total.cell(3, 2).value == 30
+    assert total.cell(3, 11).value == 10
+    assert total.cell(3, 12).value == 20
+    assert total.cell(48, 1).value is None
+    assert total.cell(49, 1).value == "小计："
+
+    issue = wb["领料明细"]
+    assert issue.cell(1, 2).value == "当月入仓总数"
+    assert [issue.cell(1, col).value for col in (3, 4)] == [
+        "2026-07-01", "2026-07-01",
+    ]
+    assert issue.cell(2, 3).value is None
+    assert issue.cell(2, 4).value is None
+    assert [issue.cell(3, col).value for col in (3, 4)] == [10, 20]
+    assert issue.cell(49, 1).value == "小计："
+
+    inbound = wb["入仓明细"]
+    assert [inbound.cell(1, col).value for col in (3, 4)] == [
+        "2026-07-02", "2026-07-02",
+    ]
+    assert [inbound.cell(3, col).value for col in (3, 4)] == [5, 15]
 
 
 def test_heyuan_legacy_workbook_imports_issue_corrections_and_finished_rows(client):
@@ -900,25 +1440,42 @@ def test_heyuan_legacy_workbook_imports_issue_corrections_and_finished_rows(clie
     records = client.get("/api/records").json()
 
     assert r.status_code == 200
-    assert r.json()["created"] == 4
+    assert r.json()["created"] == 6
     by_type_doc = {(row["rec_type"], row["doc_no"]): row for row in records}
     assert by_type_doc[("issue", "2519360")]["qty"] == 100
     assert by_type_doc[("issue", "2518791")]["qty"] == 30
+    assert by_type_doc[("issue", "2518791")]["rec_date"] == "2026-06-30"
+    assert by_type_doc[("issue", "2518791")]["summary_month"] == 7
     assert by_type_doc[("issue", "退不良品")]["qty"] == -5
     assert by_type_doc[("finished", "HY2026070301")]["qty"] == 20
+    assert by_type_doc[("finished", "HY2026070301")]["contract_no"] == "HYHT"
+    assert by_type_doc[("finished", "HY2026070301")]["item_no"] == "77794"
+    assert by_type_doc[("finished", "HY2026070301")]["product_name"] == "成品唱机"
+    assert by_type_doc[("issue", "月结")]["material"] == "NFC贴纸"
+    assert by_type_doc[("issue", "月结")]["sticker_type"] == "36#NFC贴纸"
+    assert by_type_doc[("issue", "月结")]["qty"] == 50
+    assert by_type_doc[("issue", "月结")]["rec_date"] == "2026-06-27"
+    assert by_type_doc[("issue", "2611533")]["qty"] == 25
     assert by_type_doc[("issue", "2518791")]["location_name"] == "河源华兴"
 
     summary = client.get("/api/summary").json()
     by_location = {row["location"]: row for row in summary["locations"]}
-    assert by_location["河源华兴"]["issue"] == 125
+    assert by_location["河源华兴"]["issue"] == 200
     assert by_location["河源华兴"]["finished"] == 20
-    assert by_location["河源华兴"]["balance"] == 105
+    assert by_location["河源华兴"]["balance"] == 180
+    monthly_rows = {
+        (row["location"], row["material"]): row
+        for row in summary["monthly_locations"]["locations"]
+    }
+    pcba_months = monthly_rows[("河源华兴", "77794-PCBA板")]["values"]
+    assert pcba_months[0]["issue"] == 100
+    assert pcba_months[1]["issue"] == 25
 
     second = upload_bytes(client, "/api/records/import", legacy_heyuan_workbook_bytes())
     assert second.status_code == 200
     assert second.json()["created"] == 0
-    assert second.json()["skipped"] == 4
-    assert len(client.get("/api/records").json()) == 4
+    assert second.json()["skipped"] == 6
+    assert len(client.get("/api/records").json()) == 6
 
 
 def test_supplier_pcba_legacy_workbook_imports_inbound_and_issue_rows(client):

--- a/apps/PMC跟仓管/加工管理/tests/test_static_entry_subpages.py
+++ b/apps/PMC跟仓管/加工管理/tests/test_static_entry_subpages.py
@@ -113,6 +113,19 @@ def test_lihong_entry_uses_semifinished_outbound_without_finished_entry():
     assert "<th>领料总数</th><th>半成品出库总数</th><th>应存数</th>" in js
 
 
+def test_lihong_entry_only_exposes_pcba_material():
+    js = (ROOT / "pcba/static/app.js").read_text(encoding="utf-8")
+
+    assert "if (isLihong()) return MATERIALS.filter(m => m.name === PCBA_MATERIAL);" in js
+
+
+def test_hongya_entry_only_exposes_nfc_material():
+    js = (ROOT / "pcba/static/app.js").read_text(encoding="utf-8")
+
+    assert "function isHongya()" in js
+    assert "if (isHongya()) return MATERIALS.filter(m => m.name === NFC_MATERIAL);" in js
+
+
 def test_location_dropdown_hides_current_department():
     js = (ROOT / "pcba/static/app.js").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## 主要改动
- 完善部门间出入库联动、单据查重与覆盖导入流程
- 支持东莞加工厂鸿亚仅 NFC 贴纸，并按原表格式导入导出
- 支持河源华兴 PCBA 与 36#CD 原表结构、月份区间和单据字段
- 修正导出日期及同日单号排序、物料限制和页面交互
- 补充导入导出、汇总、接口与静态页面测试

## 验证
- python -m pytest -q：199 passed
- git diff --check：通过