### PR TITLE
修复唱片机系统导入刷新与库存导出

### DIFF
--- a/apps/PMC跟仓管/加工管理/pcba/main.py
+++ b/apps/PMC跟仓管/加工管理/pcba/main.py
@@ -590,6 +590,8 @@ def _legacy_workbook_year(wb):
     for ws in wb.worksheets:
         for row in ws.iter_rows():
             for cell in row:
+                if isinstance(cell.value, (int, float)):
+                    continue
                 rec_date = _legacy_excel_date(cell.value)
                 if rec_date:
                     year = date.fromisoformat(rec_date).year
@@ -2693,16 +2695,23 @@ def _export_date(value):
 
 
 def _legacy_opening_record_date(row):
-    if row.get("rec_date"):
-        return None
     text = f"{row.get('doc_no') or ''} {row.get('remark') or ''}"
-    if "期初" in text:
+    if "期初" not in text:
+        return None
+    rec_date = row.get("rec_date")
+    if not rec_date:
         return date(date.today().year, 6, 27).isoformat()
+    try:
+        parsed = date.fromisoformat(str(rec_date))
+    except ValueError:
+        return None
+    if parsed.year > date.today().year + 1:
+        return parsed.replace(year=date.today().year).isoformat()
     return None
 
 
 def _record_export_date(row):
-    return row.get("rec_date") or _legacy_opening_record_date(row)
+    return _legacy_opening_record_date(row) or row.get("rec_date")
 
 
 def _export_month(value):
@@ -3269,7 +3278,14 @@ def _supplier_nfc_detail_sheet(wb, title, records, sticker_names, total_header):
         row for row in records
         if _export_month(_record_export_date(row)) in (6, *EXPORT_MONTHS)
     ]
-    groups = _supplier_nfc_detail_groups(records)
+    groups = sorted(
+        _supplier_nfc_detail_groups(records),
+        key=lambda group: (
+            group["rec_date"] is None,
+            group["rec_date"] or "",
+            _natural_text_sort_key(group["doc_no"]),
+        ),
+    )
     ws.cell(1, 2).value = total_header
     ws.cell(2, 1).value = "物料名称"
     for offset, group in enumerate(groups, start=3):
@@ -3742,7 +3758,7 @@ def _semi_finished_export_workbook(records, sticker_types, monthly_totals):
     ws.cell(1, 12).value = "累计出仓总数"
     ws.cell(1, 13).value = "东莞"
     ws.cell(2, 13).value = "截止6月27号"
-    ws.cell(1, 14).value = "邵阳生产"
+    ws.cell(1, 14).value = "湖南"
     for col_no, month in enumerate(EXPORT_MONTHS, start=15):
         ws.cell(1, col_no).value = f"{month}月出仓\n总数"
 
@@ -3989,12 +4005,7 @@ def _import_document_key(body):
     doc_no = _cell_text(body.doc_no)
     if not doc_no:
         return None
-    return (
-        body.rec_type,
-        body.location_id or 0,
-        body.rec_date or "",
-        doc_no.casefold(),
-    )
+    return body.rec_type, body.location_id or 0, doc_no.casefold()
 
 
 def _group_import_documents(bodies):
@@ -4010,13 +4021,12 @@ def _group_import_documents(bodies):
 
 
 def _existing_document_ids(conn, department, key):
-    rec_type, location_id, rec_date, doc_no = key
+    rec_type, location_id, doc_no = key
     rows = conn.execute(
         "SELECT id FROM records WHERE department=? AND source_record_id IS NULL "
         "AND rec_type=? AND COALESCE(location_id, 0)=? "
-        "AND COALESCE(rec_date, '')=? "
         "AND LOWER(TRIM(COALESCE(doc_no, '')))=? ORDER BY id",
-        (department, rec_type, location_id, rec_date, doc_no),
+        (department, rec_type, location_id, doc_no),
     ).fetchall()
     return [row["id"] for row in rows]
 
@@ -4085,12 +4095,6 @@ def import_records(
         skipped_documents = 0
         skipped_document_rows = 0
         if mode == "replace":
-            for existing_ids in duplicate_keys.values():
-                for record_id in existing_ids:
-                    row = _get_record_or_404(
-                        conn, record_id, user["department"]
-                    )
-                    _check_owner(row, user)
             for existing_ids in duplicate_keys.values():
                 _delete_record_ids_with_links(conn, existing_ids)
                 replaced_documents += 1

--- a/apps/PMC跟仓管/加工管理/pcba/static/app.html
+++ b/apps/PMC跟仓管/加工管理/pcba/static/app.html
@@ -69,7 +69,7 @@
         <option value="replace">覆盖导入</option>
       </select>
       <button class="ghost-btn" onclick="checkRecordImport()">查重</button>
-      <button class="primary-btn slim" onclick="importSelectedRecords()">开始导入</button>
+      <button id="recordImportBtn" class="primary-btn slim" onclick="importSelectedRecords()">开始导入</button>
     </div>
     <div id="recordImportCheckResult" class="import-check-result" style="display:none"></div>
 
@@ -321,6 +321,6 @@
   </section>
 </main>
 
-  <script src="/static/app.js?v=30"></script>
+  <script src="/static/app.js?v=31"></script>
 </body>
 </html>

--- a/apps/PMC跟仓管/加工管理/pcba/static/app.js
+++ b/apps/PMC跟仓管/加工管理/pcba/static/app.js
@@ -1354,7 +1354,12 @@ async function importSelectedRecords() {
     const result = el('recordImportCheckResult');
     result.style.display = '';
     result.innerHTML = `<div class="import-check-summary"><strong>导入完成</strong><span>${esc(message)}</span></div>`;
-    await refreshAfterRecordImport();
+    try {
+      await refreshAfterRecordImport();
+    } catch (error) {
+      if (error.message === 'unauth') throw error;
+      setMessage('entryErr', `${message}；导入已完成，但列表刷新失败，请手动刷新页面`, false);
+    }
   } catch (error) {
     if (error.message !== 'unauth') {
       setMessage('entryErr', '导入失败，请检查网络后重试', false);

--- a/apps/PMC跟仓管/加工管理/pcba/static/app.js
+++ b/apps/PMC跟仓管/加工管理/pcba/static/app.js
@@ -1289,6 +1289,18 @@ function recordImportFormData(includeMode) {
   return form;
 }
 
+function setRecordImportBusy(busy) {
+  const button = el('recordImportBtn');
+  button.disabled = busy;
+  button.textContent = busy ? '导入中...' : '开始导入';
+}
+
+async function refreshAfterRecordImport() {
+  cancelEdit();
+  await loadRecords();
+  if (el('summary').style.display !== 'none') await loadSummary();
+}
+
 async function checkRecordImport() {
   const form = recordImportFormData(false);
   if (!form) return;
@@ -1324,23 +1336,32 @@ async function importSelectedRecords() {
   }
   const form = recordImportFormData(true);
   if (!form) return;
-  const r = await api('/api/records/import', {method: 'POST', body: form});
-  if (!r.ok) {
-    const e = await r.json().catch(() => ({}));
-    setMessage('entryErr', e.detail || '导入失败', false);
-    return;
+  setRecordImportBusy(true);
+  try {
+    const r = await api('/api/records/import', {method: 'POST', body: form});
+    if (!r.ok) {
+      const e = await r.json().catch(() => ({}));
+      setMessage('entryErr', e.detail || '导入失败', false);
+      return;
+    }
+    const data = await r.json();
+    const parts = [`导入成功：${fmt(data.created || 0)} 条`];
+    if (data.monthly_totals) parts.push(`更新当月汇总 ${fmt(data.monthly_totals)} 项`);
+    if (data.skipped_documents) parts.push(`跳过 ${fmt(data.skipped_documents)} 张重复单据`);
+    if (data.replaced_documents) parts.push(`覆盖 ${fmt(data.replaced_documents)} 张单据`);
+    const message = parts.join('，');
+    setMessage('entryErr', message, true);
+    const result = el('recordImportCheckResult');
+    result.style.display = '';
+    result.innerHTML = `<div class="import-check-summary"><strong>导入完成</strong><span>${esc(message)}</span></div>`;
+    await refreshAfterRecordImport();
+  } catch (error) {
+    if (error.message !== 'unauth') {
+      setMessage('entryErr', '导入失败，请检查网络后重试', false);
+    }
+  } finally {
+    setRecordImportBusy(false);
   }
-  const data = await r.json();
-  const parts = [`导入成功：${fmt(data.created || 0)} 条`];
-  if (data.monthly_totals) parts.push(`更新当月汇总 ${fmt(data.monthly_totals)} 项`);
-  if (data.skipped_documents) parts.push(`跳过 ${fmt(data.skipped_documents)} 张重复单据`);
-  if (data.replaced_documents) parts.push(`覆盖 ${fmt(data.replaced_documents)} 张单据`);
-  setMessage('entryErr', parts.join('，'), true);
-  await (async () => {
-    cancelEdit();
-    await loadRecords();
-    if (el('summary').style.display !== 'none') await loadSummary();
-  });
 }
 
 async function importRecords(input) {

--- a/apps/PMC跟仓管/加工管理/tests/test_import_export.py
+++ b/apps/PMC跟仓管/加工管理/tests/test_import_export.py
@@ -602,6 +602,78 @@ def test_xingxin_nfc_export_groups_opening_stock_by_document_column(client):
     assert ws.cell(2, 4).value is None
 
 
+def test_xingxin_nfc_import_does_not_treat_quantity_as_workbook_year(client):
+    login(client, "兴信B来料仓", "123456", DEFAULT_DEPARTMENT)
+    wb = openpyxl.load_workbook(io.BytesIO(legacy_supplier_nfc_workbook_bytes()))
+    wb["总表"].cell(3, 2).value = 49855
+    wb["总表"].cell(3, 3).value = 49855
+    content = io.BytesIO()
+    wb.save(content)
+
+    imported = upload_bytes(
+        client,
+        "/api/records/import",
+        content.getvalue(),
+        "来料仓77772#NFC出入明细.xlsx",
+    )
+    assert imported.status_code == 200
+
+    exported = client.get("/api/records/export?material=NFC贴纸")
+    exported_wb = openpyxl.load_workbook(
+        io.BytesIO(exported.content), data_only=True
+    )
+    assert exported_wb["入库明细"].cell(1, 3).value == "2026-06-27"
+
+
+def test_xingxin_nfc_export_sorts_columns_by_date_and_document(client):
+    login(client, "兴信B来料仓", "123456", DEFAULT_DEPARTMENT)
+    documents = [
+        ("2026-07-11", "RK-10"),
+        ("2026-06-29", "RK-2"),
+        ("2026-07-04", "RK-1"),
+        ("2026-07-11", "RK-2"),
+    ]
+    for index, (rec_date, doc_no) in enumerate(documents, start=1):
+        response = client.post("/api/records", json={
+            "rec_type": "inbound_raw",
+            "material": "NFC贴纸",
+            "sticker_type": "1#NFC贴纸",
+            "rec_date": rec_date,
+            "doc_no": doc_no,
+            "qty": index,
+        })
+        assert response.status_code == 200
+
+    exported = client.get("/api/records/export?material=NFC贴纸")
+    wb = openpyxl.load_workbook(io.BytesIO(exported.content), data_only=True)
+    ws = wb["入库明细"]
+
+    assert [ws.cell(1, col).value for col in range(3, 7)] == [
+        "2026-06-29", "2026-07-04", "2026-07-11", "2026-07-11",
+    ]
+    assert [ws.cell(2, col).value for col in range(5, 7)] == [
+        "RK-2", "RK-10",
+    ]
+
+
+def test_xingxin_nfc_export_repairs_legacy_future_opening_date(client):
+    login(client, "兴信B来料仓", "123456", DEFAULT_DEPARTMENT)
+    response = client.post("/api/records", json={
+        "rec_type": "inbound_raw",
+        "material": "NFC贴纸",
+        "sticker_type": "1#NFC贴纸",
+        "rec_date": "2036-06-27",
+        "doc_no": "1#NFC贴纸-期初入仓",
+        "qty": 100,
+        "remark": "总表期初入仓导入",
+    })
+    assert response.status_code == 200
+
+    exported = client.get("/api/records/export?material=NFC贴纸")
+    wb = openpyxl.load_workbook(io.BytesIO(exported.content), data_only=True)
+    assert wb["入库明细"].cell(1, 3).value == "2026-06-27"
+
+
 def test_semi_finished_export_uses_legacy_matrix_workbook(client):
     login(client, "碟片半成品", "123456", "碟片半成品")
     upload = upload_bytes(
@@ -620,6 +692,7 @@ def test_semi_finished_export_uses_legacy_matrix_workbook(client):
         "总表", "入库明细", "邵阳领料", "河源华兴36#CD领料", "车间36#CD领料"]
     assert wb["总表"].cell(1, 2).value == "累计入仓总数"
     assert wb["总表"].cell(1, 11).value == "应存数"
+    assert wb["总表"].cell(1, 14).value == "湖南"
     assert wb["总表"].cell(3, 1).value == "1#NFC\n贴纸"
     assert wb["总表"].cell(3, 2).value == 100
     assert wb["总表"].cell(3, 11).value == 60
@@ -772,7 +845,7 @@ def test_record_import_replace_mode_replaces_document_and_auto_records(client):
     assert target_rows[0]["source_record_id"] is not None
 
 
-def test_record_import_replace_rejects_records_owned_by_another_user(client):
+def test_record_import_replace_allows_same_department_records_owned_by_another_user(client):
     login(client)
     created = client.post("/api/records", json={
         "rec_type": "inbound_raw",
@@ -796,13 +869,13 @@ def test_record_import_replace_rejects_records_owned_by_another_user(client):
         data={"mode": "replace"},
     )
 
-    assert replaced.status_code == 403
+    assert replaced.status_code == 200
     rows = client.get("/api/records?doc_no=ADMIN-OWNED-001").json()
     assert len(rows) == 1
-    assert rows[0]["qty"] == 10
+    assert rows[0]["qty"] == 20
 
 
-def test_record_import_same_document_number_on_different_dates_is_not_duplicate(client):
+def test_record_import_same_document_number_on_different_dates_is_duplicate(client):
     login(client, "兴信B来料仓", "123456", DEFAULT_DEPARTMENT)
     headers = ["类型", "物料名称", "日期", "单据编号", "数量"]
     first = upload_xlsx(
@@ -824,12 +897,12 @@ def test_record_import_same_document_number_on_different_dates_is_not_duplicate(
 
     assert first.status_code == 200
     assert second.status_code == 200
-    assert second.json()["created"] == 1
+    assert second.json()["created"] == 0
+    assert second.json()["skipped_documents"] == 1
     rows = client.get("/api/records?doc_no=PERIODIC-001").json()
-    assert {(row["rec_date"], row["qty"]) for row in rows} == {
+    assert [(row["rec_date"], row["qty"]) for row in rows] == [
         ("2026-07-01", 10),
-        ("2026-08-01", 20),
-    }
+    ]
 
 
 def test_semi_finished_export_splits_outbound_by_target_department(client):

--- a/apps/PMC跟仓管/加工管理/tests/test_static_entry_subpages.py
+++ b/apps/PMC跟仓管/加工管理/tests/test_static_entry_subpages.py
@@ -60,6 +60,17 @@ def test_entry_page_exposes_clear_and_bulk_delete_controls():
     assert "/api/records/clear" in js
 
 
+def test_record_import_success_refreshes_records_and_shows_busy_state():
+    html = (ROOT / "pcba/static/app.html").read_text(encoding="utf-8")
+    js = (ROOT / "pcba/static/app.js").read_text(encoding="utf-8")
+
+    assert 'id="recordImportBtn"' in html
+    assert "function setRecordImportBusy(busy)" in js
+    assert "async function refreshAfterRecordImport()" in js
+    assert "await refreshAfterRecordImport();" in js
+    assert "await (async () =>" not in js
+
+
 def test_admin_department_switcher_controls_exist():
     html = (ROOT / "pcba/static/app.html").read_text(encoding="utf-8")
     js = (ROOT / "pcba/static/app.js").read_text(encoding="utf-8")

--- a/apps/PMC跟仓管/加工管理/tests/test_static_entry_subpages.py
+++ b/apps/PMC跟仓管/加工管理/tests/test_static_entry_subpages.py
@@ -71,6 +71,13 @@ def test_record_import_success_refreshes_records_and_shows_busy_state():
     assert "await (async () =>" not in js
 
 
+def test_record_import_refresh_failure_does_not_report_import_failure():
+    js = (ROOT / "pcba/static/app.js").read_text(encoding="utf-8")
+
+    assert "导入已完成，但列表刷新失败，请手动刷新页面" in js
+    assert "try {\n      await refreshAfterRecordImport();\n    } catch" in js
+
+
 def test_admin_department_switcher_controls_exist():
     html = (ROOT / "pcba/static/app.html").read_text(encoding="utf-8")
     js = (ROOT / "pcba/static/app.js").read_text(encoding="utf-8")


### PR DESCRIPTION
## 修改内容
- Excel 导入完成后立即刷新流水与汇总，并显示导入进度和结果
- 来料仓 NFC 导出按日期、单号自然排序，修复数量误判年份和旧期初日期
- 重复单据按部门、类型、目标部门和单号识别，覆盖模式允许替换本部门旧记录
- 碟片半成品导出总表将‘邵阳生产’修正为‘湖南’

## 验证
- 209 项 pytest 测试全部通过
- app.js 语法检查通过