### PR TITLE
修复唱片机系统导入导出数据与PCBA工作表

### DIFF
--- a/apps/PMC跟仓管/加工管理/pcba/main.py
+++ b/apps/PMC跟仓管/加工管理/pcba/main.py
@@ -1669,14 +1669,22 @@ def _parse_supplier_nfc_total_rows(conn, wb, department):
     return bodies
 
 
-def _parse_supplier_nfc_detail_sheet(conn, ws, rec_type, department):
+def _parse_supplier_nfc_detail_sheet(
+    conn, ws, rec_type, department, total_opening_keys=None
+):
     bodies = []
+    total_opening_keys = total_opening_keys or set()
     header_row = _find_legacy_item_header_row(ws)
     if not header_row:
         return bodies
     location_id = None
+    opening_locations = {}
     if rec_type == "issue":
         location_id = _location_id_from_name(conn, "东莞车间", 1)
+        opening_locations = {
+            "东莞期初出仓": location_id,
+            "邵阳期初领料": _location_id_from_name(conn, "邵阳华登", 1),
+        }
     for row_no in range(header_row + 1, ws.max_row + 1):
         sticker_type = _cell_text(ws.cell(row_no, 1).value)
         if "#NFC" not in sticker_type:
@@ -1687,6 +1695,16 @@ def _parse_supplier_nfc_detail_sheet(conn, ws, rec_type, department):
             if qty is None or qty == 0:
                 continue
             date_value = ws.cell(1, col_no).value
+            raw_doc_no = _cell_text(ws.cell(header_row, col_no).value)
+            opening_location_id = None
+            if rec_type == "inbound_raw" and raw_doc_no == "期初入仓":
+                opening_location_id = 0
+            elif rec_type == "issue":
+                opening_location_id = opening_locations.get(raw_doc_no)
+            if opening_location_id is not None and (
+                rec_type, opening_location_id, sticker_type
+            ) in total_opening_keys:
+                continue
             body = RecordIn(
                 rec_type=rec_type,
                 location_id=location_id,
@@ -1715,15 +1733,28 @@ def _parse_legacy_supplier_workbook(conn, wb, department):
     if "入仓明细" in wb.sheetnames:
         bodies.extend(_parse_legacy_supplier_pcba_workbook(conn, wb, department))
     if {"总表", "入库明细", "出库明细"}.issubset(set(wb.sheetnames)):
-        bodies.extend(_parse_supplier_nfc_total_rows(conn, wb, department))
+        total_bodies = _parse_supplier_nfc_total_rows(conn, wb, department)
+        bodies.extend(total_bodies)
+        total_opening_keys = {
+            (body.rec_type, body.location_id or 0, body.sticker_type)
+            for body in total_bodies
+        }
         bodies.extend(
             _parse_supplier_nfc_detail_sheet(
-                conn, wb["入库明细"], "inbound_raw", department
+                conn,
+                wb["入库明细"],
+                "inbound_raw",
+                department,
+                total_opening_keys,
             )
         )
         bodies.extend(
             _parse_supplier_nfc_detail_sheet(
-                conn, wb["出库明细"], "issue", department
+                conn,
+                wb["出库明细"],
+                "issue",
+                department,
+                total_opening_keys,
             )
         )
     if not bodies:
@@ -2880,7 +2911,6 @@ SUPPLIER_PCBA_SUMMARY_ROWS = (
     ("邵阳华登", "邵阳华登领料总数", "PCB主板", "邵阳华登领料"),
     ("河源华兴", "河源华兴领料总数", "PCB主板", "河源华兴领料"),
     ("东莞加工厂利鸿", "加工厂利鸿领料总数", "PCB主板", "加工厂利鸿领料"),
-    ("东莞加工厂鸿亚", "加工厂鸿亚领料总数", "PCB主板", "加工厂鸿亚领料"),
     ("东莞车间", "东莞车间领料", None, "东莞车间领料"),
 )
 
@@ -3245,15 +3275,28 @@ def _supplier_nfc_sticker_names(records, sticker_types):
     return names
 
 
-def _supplier_nfc_export_doc_no(row):
+def _supplier_nfc_opening_kind(row):
     text = f"{row.get('doc_no') or ''} {row.get('remark') or ''}"
     if "东莞期初出仓" in text:
-        return "东莞期初出仓"
+        return "dongguan_outbound"
     if "邵阳期初领料" in text:
-        return "邵阳期初领料"
+        return "shaoyang_outbound"
     if "期初入仓" in text:
-        return "期初入仓"
+        return "inbound"
     if "期初出仓" in text:
+        return "outbound"
+    return None
+
+
+def _supplier_nfc_export_doc_no(row):
+    opening_kind = _supplier_nfc_opening_kind(row)
+    if opening_kind == "dongguan_outbound":
+        return "东莞期初出仓"
+    if opening_kind == "shaoyang_outbound":
+        return "邵阳期初领料"
+    if opening_kind == "inbound":
+        return "期初入仓"
+    if opening_kind == "outbound":
         return "期初出仓"
     return row.get("doc_no")
 
@@ -3337,20 +3380,24 @@ def _supplier_nfc_export_workbook(records, sticker_types):
     for row_no, sticker_type in enumerate(sticker_names, start=3):
         sticker_inbound = [row for row in inbound if row.get("sticker_type") == sticker_type]
         sticker_outbound = [row for row in outbound if row.get("sticker_type") == sticker_type]
+        opening_inbound = [
+            row for row in sticker_inbound
+            if _supplier_nfc_opening_kind(row) == "inbound"
+        ]
         ws.cell(row_no, 1).value = _format_nfc_sticker_name(sticker_type)
         ws.cell(row_no, 2).value = _sum_qty(sticker_inbound) or 0
-        ws.cell(row_no, 3).value = _month_sum(sticker_inbound, 6) or 0
+        ws.cell(row_no, 3).value = _sum_qty(opening_inbound) or 0
         for col_no, month in enumerate(EXPORT_MONTHS, start=4):
             ws.cell(row_no, col_no).value = _month_sum(sticker_inbound, month) or None
         ws.cell(row_no, 11).value = _sum_qty(sticker_inbound) - _sum_qty(sticker_outbound)
         ws.cell(row_no, 12).value = _sum_qty(sticker_outbound) or 0
         dongguan_opening = [
             row for row in sticker_outbound
-            if row.get("location_name") == "东莞车间" and _export_month(row.get("rec_date")) == 6
+            if _supplier_nfc_opening_kind(row) == "dongguan_outbound"
         ]
         shaoyang_opening = [
             row for row in sticker_outbound
-            if row.get("location_name") == "邵阳华登" and _export_month(row.get("rec_date")) == 6
+            if _supplier_nfc_opening_kind(row) == "shaoyang_outbound"
         ]
         ws.cell(row_no, 13).value = _sum_qty(dongguan_opening) or 0
         ws.cell(row_no, 14).value = _sum_qty(shaoyang_opening) or 0

--- a/apps/PMC跟仓管/加工管理/pcba/main.py
+++ b/apps/PMC跟仓管/加工管理/pcba/main.py
@@ -1705,9 +1705,12 @@ def _parse_supplier_nfc_detail_sheet(
                 rec_type, opening_location_id, sticker_type
             ) in total_opening_keys:
                 continue
+            record_location_id = location_id
+            if rec_type == "issue" and opening_location_id is not None:
+                record_location_id = opening_location_id
             body = RecordIn(
                 rec_type=rec_type,
-                location_id=location_id,
+                location_id=record_location_id,
                 rec_date=_outsource_date_value(date_value),
                 doc_no=_legacy_doc_no(
                     ws.cell(header_row, col_no).value,

--- a/apps/PMC跟仓管/加工管理/tests/test_import_export.py
+++ b/apps/PMC跟仓管/加工管理/tests/test_import_export.py
@@ -1762,6 +1762,30 @@ def test_supplier_nfc_legacy_workbook_keeps_summary_rows_out_of_record_list(clie
     assert len(client.get("/api/records").json()) == 3
 
 
+def test_supplier_nfc_detail_only_shaoyang_opening_uses_shaoyang_location(client):
+    login(client, "兴信B来料仓", "123456", DEFAULT_DEPARTMENT)
+    wb = openpyxl.load_workbook(io.BytesIO(legacy_supplier_nfc_workbook_bytes()))
+    wb["总表"].cell(3, 14).value = None
+    outbound = wb["出库明细"]
+    outbound.cell(1, 4).value = "2026-06-27"
+    outbound.cell(2, 4).value = "邵阳期初领料"
+    outbound.cell(3, 4).value = 15
+    content = io.BytesIO()
+    wb.save(content)
+
+    imported = upload_bytes(
+        client,
+        "/api/records/import",
+        content.getvalue(),
+        "来料仓77772#NFC出入明细.xlsx",
+    )
+    records = client.get("/api/records").json()
+    shaoyang = next(row for row in records if row["doc_no"] == "邵阳期初领料")
+
+    assert imported.status_code == 200
+    assert shaoyang["location_name"] == "邵阳华登"
+
+
 def test_supplier_nfc_export_can_be_reimported_without_creating_opening_rows(client):
     login(client, "兴信B来料仓", "123456", DEFAULT_DEPARTMENT)
     first = upload_bytes(

--- a/apps/PMC跟仓管/加工管理/tests/test_import_export.py
+++ b/apps/PMC跟仓管/加工管理/tests/test_import_export.py
@@ -475,9 +475,9 @@ def test_xingxin_pcba_export_uses_legacy_warehouse_workbook(client):
     wb = openpyxl.load_workbook(io.BytesIO(r.content), data_only=True)
 
     assert r.status_code == 200
-    assert wb.sheetnames[:8] == [
+    assert wb.sheetnames[:7] == [
         "总表", "入仓明细", "邵阳华登领料", "河源华兴领料",
-        "加工厂利鸿领料", "加工厂鸿亚领料", "东莞车间领料", "Sheet2",
+        "加工厂利鸿领料", "东莞车间领料", "Sheet2",
     ]
     assert [cell.value for cell in wb["入仓明细"][1]] == [
         "日期", "入仓单号", "物料名称", "入仓数", "备注"]
@@ -492,19 +492,18 @@ def test_xingxin_pcba_export_uses_legacy_warehouse_workbook(client):
         "物料名称", None, "累计出入总数", "6月月结", "7月", "8月",
         "9月", "10月", "11月", "12月", "备注",
     ]
-    assert [total.cell(row, 2).value for row in range(2, 10)] == [
+    assert [total.cell(row, 2).value for row in range(2, 9)] == [
         "入仓总数", "邵阳华登领料总数", "河源华兴领料总数",
-        "加工厂利鸿领料总数", "加工厂鸿亚领料总数", "东莞车间领料",
-        None, "应存数",
+        "加工厂利鸿领料总数", "东莞车间领料", None, "应存数",
     ]
     assert total.cell(2, 1).value == "PCB主板"
     assert total.cell(2, 3).value == 40
     assert total.cell(2, 5).value == 40
     assert total.cell(4, 3).value == 25
     assert total.cell(4, 5).value == 25
-    assert total.cell(9, 3).value == 15
-    assert total.cell(9, 4).value == 0
-    assert total.cell(9, 5).value == 15
+    assert total.cell(8, 3).value == 15
+    assert total.cell(8, 4).value == 0
+    assert total.cell(8, 5).value == 15
 
 
 def test_xingxin_nfc_export_uses_legacy_matrix_workbook(client):
@@ -600,6 +599,33 @@ def test_xingxin_nfc_export_groups_opening_stock_by_document_column(client):
     assert ws.cell(4, 3).value == 865000
     assert ws.cell(1, 4).value is None
     assert ws.cell(2, 4).value is None
+
+
+def test_xingxin_nfc_export_does_not_include_regular_june_rows_in_opening_total(client):
+    login(client, "兴信B来料仓", "123456", DEFAULT_DEPARTMENT)
+    client.post("/api/records", json={
+        "rec_type": "inbound_raw",
+        "material": "NFC贴纸",
+        "sticker_type": "1#NFC贴纸",
+        "rec_date": "2026-06-27",
+        "doc_no": "1#NFC贴纸-期初入仓",
+        "qty": 100,
+        "remark": "总表期初入仓导入",
+    })
+    client.post("/api/records", json={
+        "rec_type": "inbound_raw",
+        "material": "NFC贴纸",
+        "sticker_type": "1#NFC贴纸",
+        "rec_date": "2026-06-29",
+        "doc_no": "RK-JUNE-001",
+        "qty": 25,
+    })
+
+    exported = client.get("/api/records/export?material=NFC贴纸")
+    wb = openpyxl.load_workbook(io.BytesIO(exported.content), data_only=True)
+
+    assert exported.status_code == 200
+    assert wb["总表"].cell(3, 3).value == 100
 
 
 def test_xingxin_nfc_import_does_not_treat_quantity_as_workbook_year(client):
@@ -1734,6 +1760,34 @@ def test_supplier_nfc_legacy_workbook_keeps_summary_rows_out_of_record_list(clie
     assert second.json()["created"] == 0
     assert second.json()["skipped"] == 6
     assert len(client.get("/api/records").json()) == 3
+
+
+def test_supplier_nfc_export_can_be_reimported_without_creating_opening_rows(client):
+    login(client, "兴信B来料仓", "123456", DEFAULT_DEPARTMENT)
+    first = upload_bytes(
+        client,
+        "/api/records/import",
+        legacy_supplier_nfc_workbook_bytes(),
+        "来料仓77772#NFC出入明细.xlsx",
+    )
+    assert first.status_code == 200
+
+    exported = client.get("/api/records/export?material=NFC贴纸")
+    assert exported.status_code == 200
+    before = client.get("/api/records").json()
+
+    second = upload_bytes(
+        client,
+        "/api/records/import",
+        exported.content,
+        "来料仓77772#NFC出入明细.xlsx",
+        data={"mode": "skip"},
+    )
+    after = client.get("/api/records").json()
+
+    assert second.status_code == 200
+    assert second.json()["created"] == 0
+    assert len(after) == len(before)
 
 
 def test_operator_can_import_and_export_materials(client):


### PR DESCRIPTION
## 修改内容
- 修复来料仓 NFC 期初数据导出后再次导入时重复累计的问题
- 截至6月27日只统计真正的期初数据
- 来料仓 PCBA 导出移除鸿亚汇总及工作表，鸿亚仅保留 NFC 贴纸业务
- 增加导入导出回归测试

## 验证
- 212 passed