### PR TITLE
feat: 支持账号访问清溪与河源双厂区

### DIFF
--- a/apps/业务部/内部报价系统/backend/db/index.js
+++ b/apps/业务部/内部报价系统/backend/db/index.js
@@ -378,6 +378,17 @@ if (userCount === 0) {
   console.log('========================================\n');
 }
 
+// Existing users inherit their current factory; admins retain access to all factories.
+db.prepare(`
+  INSERT OR IGNORE INTO user_factories (user_id, factory_code)
+  SELECT id, factory_code FROM users
+`).run();
+db.prepare(`
+  INSERT OR IGNORE INTO user_factories (user_id, factory_code)
+  SELECT u.id, f.code FROM users u CROSS JOIN factories f
+  WHERE u.role = 'admin' AND f.active = 1
+`).run();
+
 // 包装：transaction(fn) 在 BEGIN/COMMIT/ROLLBACK 中运行 fn
 db.transaction = function (fn) {
   return (...args) => {

--- a/apps/业务部/内部报价系统/backend/db/schema.sql
+++ b/apps/业务部/内部报价系统/backend/db/schema.sql
@@ -106,6 +106,13 @@ CREATE TABLE IF NOT EXISTS users (
 
 CREATE INDEX IF NOT EXISTS idx_users_dept ON users(dept);
 
+-- User-to-factory access; users.factory_code remains the default factory.
+CREATE TABLE IF NOT EXISTS user_factories (
+  user_id      INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  factory_code TEXT NOT NULL REFERENCES factories(code),
+  PRIMARY KEY (user_id, factory_code)
+);
+
 -- 用户 × 可见客户（多对多；空表 = 看不到任何报价单；admin 不受限）
 CREATE TABLE IF NOT EXISTS user_customers (
   user_id  INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,

--- a/apps/业务部/内部报价系统/backend/middleware/auth.js
+++ b/apps/业务部/内部报价系统/backend/middleware/auth.js
@@ -10,13 +10,23 @@ function loadUserAndPerms(userId, requestedFactory) {
     perms[r.menu] = { can_view: r.can_view, can_edit: r.can_edit, can_review: r.can_review, can_admin: r.can_admin };
   }
   const defaultFactory = u.factory_code || 'qingxi';
-  const canSwitchFactory = u.role === 'admin';
-  const requestedExists = requestedFactory && db.prepare('SELECT 1 FROM factories WHERE code = ? AND active = 1').get(requestedFactory);
-  const activeFactory = canSwitchFactory && requestedExists ? requestedFactory : defaultFactory;
-  const factory = db.prepare('SELECT name_cn FROM factories WHERE code = ?').get(activeFactory);
-  const factories = canSwitchFactory
+  let factories = u.role === 'admin'
     ? db.prepare('SELECT code, name_cn FROM factories WHERE active = 1 ORDER BY sort_order').all()
-    : db.prepare('SELECT code, name_cn FROM factories WHERE code = ? AND active = 1').all(defaultFactory);
+    : db.prepare(`
+        SELECT f.code, f.name_cn
+        FROM user_factories uf JOIN factories f ON f.code = uf.factory_code
+        WHERE uf.user_id = ? AND f.active = 1
+        ORDER BY f.sort_order
+      `).all(userId);
+  if (!factories.length) {
+    factories = db.prepare('SELECT code, name_cn FROM factories WHERE code = ? AND active = 1').all(defaultFactory);
+  }
+  const allowedFactories = new Set(factories.map(f => f.code));
+  const activeFactory = requestedFactory && allowedFactories.has(requestedFactory)
+    ? requestedFactory
+    : (allowedFactories.has(defaultFactory) ? defaultFactory : factories[0].code);
+  const canSwitchFactory = factories.length > 1;
+  const factory = db.prepare('SELECT name_cn FROM factories WHERE code = ?').get(activeFactory);
   return {
     id: u.id, username: u.username, display_name: u.display_name,
     dept: u.dept, role: u.role, factory_code: defaultFactory,

--- a/apps/业务部/内部报价系统/backend/routes/admin.js
+++ b/apps/业务部/内部报价系统/backend/routes/admin.js
@@ -5,7 +5,6 @@ const { requireAuth } = require('../middleware/auth');
 const { requirePerm } = require('../middleware/perms');
 const { MENUS } = require('../permissions/menu_catalog');
 const { templateFor } = require('../permissions/role_templates');
-const { changeUserFactory } = require('../services/userFactory');
 
 const router = express.Router();
 router.use(requireAuth);
@@ -24,11 +23,27 @@ function applyTemplate(userId, dept, role) {
   }
 }
 
+function factoryCodesFor(scope, role) {
+  if (scope === 'all' || role === 'admin') {
+    return db.prepare('SELECT code FROM factories WHERE active = 1 ORDER BY sort_order').all().map(r => r.code);
+  }
+  const code = String(scope || '').trim();
+  return db.prepare('SELECT code FROM factories WHERE code = ? AND active = 1').all(code).map(r => r.code);
+}
+
+function replaceUserFactories(userId, codes) {
+  db.prepare('DELETE FROM user_factories WHERE user_id = ?').run(userId);
+  const insert = db.prepare('INSERT INTO user_factories (user_id, factory_code) VALUES (?, ?)');
+  for (const code of codes) insert.run(userId, code);
+  db.prepare('UPDATE users SET factory_code = ? WHERE id = ?').run(codes[0], userId);
+}
+
 // GET /api/admin/users
 router.get('/users', (req, res) => {
   const rows = db.prepare(`
     SELECT u.id, u.username, u.display_name, u.dept, d.name_cn AS dept_name,
            u.factory_code, f.name_cn AS factory_name,
+           COALESCE((SELECT GROUP_CONCAT(uf.factory_code) FROM user_factories uf WHERE uf.user_id = u.id), u.factory_code) AS factory_codes,
            u.role, u.locked_until, u.login_fails, u.last_login, u.created_at
     FROM users u
     LEFT JOIN departments d ON d.code = u.dept
@@ -50,20 +65,25 @@ router.post('/users', (req, res) => {
   if (String(password).length < 6) return res.status(400).json({ error: '密码至少 6 位' });
   const dept_ok = db.prepare('SELECT 1 FROM departments WHERE code = ?').get(dept);
   if (!dept_ok) return res.status(400).json({ error: '部门不存在' });
-  const factory_ok = db.prepare('SELECT 1 FROM factories WHERE code = ? AND active = 1').get(factory_code);
-  if (!factory_ok) return res.status(400).json({ error: '厂区不存在' });
+  const factoryCodes = factoryCodesFor(factory_code, role);
+  if (!factoryCodes.length) return res.status(400).json({ error: '厂区不存在' });
   const exists = db.prepare('SELECT 1 FROM users WHERE username = ?').get(String(username).trim());
   if (exists) return res.status(409).json({ error: '用户名已存在' });
   try {
-    const info = db.prepare(`
-      INSERT INTO users (username, password_hash, display_name, dept, role, factory_code)
-      VALUES (?, ?, ?, ?, ?, ?)
-    `).run(String(username).trim(), bcrypt.hashSync(String(password), 8),
-           String(display_name).trim().slice(0, 32), dept, role, factory_code);
-    applyTemplate(info.lastInsertRowid, dept, role);
+    const createUser = db.transaction(() => {
+      const info = db.prepare(`
+        INSERT INTO users (username, password_hash, display_name, dept, role, factory_code)
+        VALUES (?, ?, ?, ?, ?, ?)
+      `).run(String(username).trim(), bcrypt.hashSync(String(password), 8),
+             String(display_name).trim().slice(0, 32), dept, role, factoryCodes[0]);
+      replaceUserFactories(info.lastInsertRowid, factoryCodes);
+      applyTemplate(info.lastInsertRowid, dept, role);
+      return info.lastInsertRowid;
+    });
+    const userId = createUser();
     db.prepare(`INSERT INTO audit_log (dept, actor, action, detail) VALUES (?, ?, 'register_user', ?)`)
       .run(dept, req.user.username, username);
-    res.json({ id: info.lastInsertRowid });
+    res.json({ id: userId });
   } catch (e) {
     res.status(500).json({ error: e.message });
   }
@@ -73,16 +93,28 @@ router.post('/users', (req, res) => {
 router.put('/users/:id/factory', (req, res) => {
   const id = Number(req.params.id);
   const factoryCode = String((req.body && req.body.factory_code) || '').trim();
-  const factory = db.prepare('SELECT code, name_cn FROM factories WHERE code = ? AND active = 1').get(factoryCode);
-  if (!factory) return res.status(400).json({ error: '厂区不存在' });
-  const u = db.prepare('SELECT username FROM users WHERE id = ?').get(id);
+  const u = db.prepare('SELECT username, role FROM users WHERE id = ?').get(id);
   if (!u) return res.status(404).json({ error: '用户不存在' });
-  const result = changeUserFactory(db, id, factory.code);
-  if (result.changed) {
-    db.prepare(`INSERT INTO audit_log (actor, action, detail) VALUES (?, 'change_user_factory', ?)`)
-      .run(req.user.username, `${u.username} -> ${factory.name_cn}; cleared customers=${result.clearedCustomers}`);
+  const factoryCodes = factoryCodesFor(factoryCode, u.role);
+  if (!factoryCodes.length) return res.status(400).json({ error: '厂区不存在' });
+  const currentCodes = db.prepare('SELECT factory_code FROM user_factories WHERE user_id = ? ORDER BY factory_code')
+    .all(id).map(r => r.factory_code);
+  const nextCodes = [...factoryCodes].sort();
+  const changed = currentCodes.join(',') !== nextCodes.join(',');
+  let clearedCustomers = 0;
+  if (changed) {
+    const updateFactories = db.transaction(() => {
+      replaceUserFactories(id, factoryCodes);
+      clearedCustomers = db.prepare('DELETE FROM user_customers WHERE user_id = ?').run(id).changes;
+    });
+    updateFactories();
   }
-  res.json({ ok: true, changed: result.changed, cleared_customers: result.clearedCustomers });
+  const factoryName = factoryCodes.length > 1 ? '清溪 + 河源' : (factoryCodes[0] === 'heyuan' ? '河源' : '清溪');
+  if (changed) {
+    db.prepare(`INSERT INTO audit_log (actor, action, detail) VALUES (?, 'change_user_factory', ?)`)
+      .run(req.user.username, `${u.username} -> ${factoryName}; cleared customers=${clearedCustomers}`);
+  }
+  res.json({ ok: true, changed, cleared_customers: clearedCustomers });
 });
 
 // PUT /api/admin/users/:id/role  { role } — 改角色并按新角色模板重置权限
@@ -93,6 +125,7 @@ router.put('/users/:id/role', (req, res) => {
   const u = db.prepare('SELECT dept, username FROM users WHERE id = ?').get(id);
   if (!u) return res.status(404).json({ error: '用户不存在' });
   db.prepare('UPDATE users SET role = ? WHERE id = ?').run(role, id);
+  if (role === 'admin') replaceUserFactories(id, factoryCodesFor('all', role));
   applyTemplate(id, u.dept, role);  // 按新角色模板重置权限
   db.prepare(`INSERT INTO audit_log (dept, actor, action, detail) VALUES (?, ?, 'change_role', ?)`)
     .run(u.dept, req.user.username, `${u.username} -> ${role}`);
@@ -151,9 +184,15 @@ router.delete('/users/:id', (req, res) => {
 // GET /api/admin/customers — 现有所有 distinct 客户
 router.get('/customers', (req, res) => {
   const userId = Number(req.query.user_id);
-  const target = userId ? db.prepare('SELECT factory_code FROM users WHERE id = ?').get(userId) : null;
-  const factoryCode = target ? target.factory_code : req.user.active_factory_code;
-  const rows = db.prepare('SELECT DISTINCT customer FROM quotes WHERE factory_code = ? AND customer IS NOT NULL AND customer != \'\' ORDER BY customer').all(factoryCode);
+  const rows = userId
+    ? db.prepare(`
+        SELECT DISTINCT q.customer FROM quotes q
+        WHERE q.factory_code IN (SELECT factory_code FROM user_factories WHERE user_id = ?)
+          AND q.customer IS NOT NULL AND q.customer != ''
+        ORDER BY q.customer
+      `).all(userId)
+    : db.prepare("SELECT DISTINCT customer FROM quotes WHERE factory_code = ? AND customer IS NOT NULL AND customer != '' ORDER BY customer")
+        .all(req.user.active_factory_code);
   res.json({ customers: rows.map(r => r.customer) });
 });
 

--- a/apps/业务部/内部报价系统/backend/routes/admin.js
+++ b/apps/业务部/内部报价系统/backend/routes/admin.js
@@ -5,6 +5,7 @@ const { requireAuth } = require('../middleware/auth');
 const { requirePerm } = require('../middleware/perms');
 const { MENUS } = require('../permissions/menu_catalog');
 const { templateFor } = require('../permissions/role_templates');
+const { changeUserFactories, changeUserRole } = require('../services/userFactory');
 
 const router = express.Router();
 router.use(requireAuth);
@@ -29,13 +30,6 @@ function factoryCodesFor(scope, role) {
   }
   const code = String(scope || '').trim();
   return db.prepare('SELECT code FROM factories WHERE code = ? AND active = 1').all(code).map(r => r.code);
-}
-
-function replaceUserFactories(userId, codes) {
-  db.prepare('DELETE FROM user_factories WHERE user_id = ?').run(userId);
-  const insert = db.prepare('INSERT INTO user_factories (user_id, factory_code) VALUES (?, ?)');
-  for (const code of codes) insert.run(userId, code);
-  db.prepare('UPDATE users SET factory_code = ? WHERE id = ?').run(codes[0], userId);
 }
 
 // GET /api/admin/users
@@ -76,7 +70,9 @@ router.post('/users', (req, res) => {
         VALUES (?, ?, ?, ?, ?, ?)
       `).run(String(username).trim(), bcrypt.hashSync(String(password), 8),
              String(display_name).trim().slice(0, 32), dept, role, factoryCodes[0]);
-      replaceUserFactories(info.lastInsertRowid, factoryCodes);
+      db.prepare('DELETE FROM user_factories WHERE user_id = ?').run(info.lastInsertRowid);
+      const insertFactory = db.prepare('INSERT INTO user_factories (user_id, factory_code) VALUES (?, ?)');
+      for (const code of factoryCodes) insertFactory.run(info.lastInsertRowid, code);
       applyTemplate(info.lastInsertRowid, dept, role);
       return info.lastInsertRowid;
     });
@@ -97,18 +93,9 @@ router.put('/users/:id/factory', (req, res) => {
   if (!u) return res.status(404).json({ error: '用户不存在' });
   const factoryCodes = factoryCodesFor(factoryCode, u.role);
   if (!factoryCodes.length) return res.status(400).json({ error: '厂区不存在' });
-  const currentCodes = db.prepare('SELECT factory_code FROM user_factories WHERE user_id = ? ORDER BY factory_code')
-    .all(id).map(r => r.factory_code);
-  const nextCodes = [...factoryCodes].sort();
-  const changed = currentCodes.join(',') !== nextCodes.join(',');
-  let clearedCustomers = 0;
-  if (changed) {
-    const updateFactories = db.transaction(() => {
-      replaceUserFactories(id, factoryCodes);
-      clearedCustomers = db.prepare('DELETE FROM user_customers WHERE user_id = ?').run(id).changes;
-    });
-    updateFactories();
-  }
+  const result = changeUserFactories(db, id, factoryCodes);
+  const changed = result.changed;
+  const clearedCustomers = result.clearedCustomers;
   const factoryName = factoryCodes.length > 1 ? '清溪 + 河源' : (factoryCodes[0] === 'heyuan' ? '河源' : '清溪');
   if (changed) {
     db.prepare(`INSERT INTO audit_log (actor, action, detail) VALUES (?, 'change_user_factory', ?)`)
@@ -122,14 +109,19 @@ router.put('/users/:id/role', (req, res) => {
   const id = Number(req.params.id);
   const { role } = req.body || {};
   if (!['staff', 'supervisor', 'admin'].includes(role)) return res.status(400).json({ error: 'role 非法' });
-  const u = db.prepare('SELECT dept, username FROM users WHERE id = ?').get(id);
+  const u = db.prepare('SELECT dept, username, factory_code FROM users WHERE id = ?').get(id);
   if (!u) return res.status(404).json({ error: '用户不存在' });
-  db.prepare('UPDATE users SET role = ? WHERE id = ?').run(role, id);
-  if (role === 'admin') replaceUserFactories(id, factoryCodesFor('all', role));
-  applyTemplate(id, u.dept, role);  // 按新角色模板重置权限
-  db.prepare(`INSERT INTO audit_log (dept, actor, action, detail) VALUES (?, ?, 'change_role', ?)`)
-    .run(u.dept, req.user.username, `${u.username} -> ${role}`);
-  res.json({ ok: true });
+  const currentFactoryCodes = db.prepare('SELECT factory_code FROM user_factories WHERE user_id = ? ORDER BY factory_code')
+    .all(id).map(r => r.factory_code);
+  const nextFactoryCodes = role === 'admin'
+    ? factoryCodesFor('all', role)
+    : (currentFactoryCodes.length ? currentFactoryCodes : [u.factory_code]);
+  const result = changeUserRole(db, id, role, nextFactoryCodes, (userId) => {
+    applyTemplate(userId, u.dept, role);
+    db.prepare(`INSERT INTO audit_log (dept, actor, action, detail) VALUES (?, ?, 'change_role', ?)`)
+      .run(u.dept, req.user.username, `${u.username} -> ${role}`);
+  });
+  res.json({ ok: true, cleared_customers: result.clearedCustomers });
 });
 
 // POST /api/admin/users/:id/reset-password  { password }

--- a/apps/业务部/内部报价系统/backend/routes/auth.js
+++ b/apps/业务部/内部报价系统/backend/routes/auth.js
@@ -79,7 +79,7 @@ router.get('/me', (req, res) => {
 router.post('/factory', requireAuth, (req, res) => {
   if (!req.user.can_switch_factory) return res.status(403).json({ error: '当前账号不能切换厂区' });
   const factoryCode = String((req.body && req.body.factory_code) || '').trim();
-  const factory = db.prepare('SELECT code, name_cn FROM factories WHERE code = ? AND active = 1').get(factoryCode);
+  const factory = (req.user.factories || []).find(f => f.code === factoryCode);
   if (!factory) return res.status(400).json({ error: '厂区不存在' });
   req.session.factory_code = factory.code;
   res.json({ ok: true, factory_code: factory.code, factory_name: factory.name_cn });

--- a/apps/业务部/内部报价系统/backend/services/userFactory.js
+++ b/apps/业务部/内部报价系统/backend/services/userFactory.js
@@ -1,22 +1,76 @@
 'use strict';
 
-function changeUserFactory(db, userId, nextFactoryCode) {
-  const current = db.prepare('SELECT factory_code FROM users WHERE id = ?').get(userId);
-  if (!current) return null;
-  if (current.factory_code === nextFactoryCode) {
-    return { changed: false, clearedCustomers: 0 };
-  }
+function factoryCodesForUser(db, userId, fallbackFactoryCode) {
+  const codes = db.prepare('SELECT factory_code FROM user_factories WHERE user_id = ? ORDER BY factory_code')
+    .all(userId).map(row => row.factory_code);
+  return codes.length ? codes : [fallbackFactoryCode];
+}
 
+function sameFactoryScope(currentCodes, nextCodes) {
+  const current = [...new Set(currentCodes)].sort();
+  const next = [...new Set(nextCodes)].sort();
+  return current.length === next.length && current.every((code, index) => code === next[index]);
+}
+
+function replaceUserFactories(db, userId, codes) {
+  db.prepare('DELETE FROM user_factories WHERE user_id = ?').run(userId);
+  const insert = db.prepare('INSERT INTO user_factories (user_id, factory_code) VALUES (?, ?)');
+  for (const code of codes) insert.run(userId, code);
+  db.prepare('UPDATE users SET factory_code = ? WHERE id = ?').run(codes[0], userId);
+}
+
+function runTransaction(db, operation) {
   db.exec('BEGIN');
   try {
-    db.prepare('UPDATE users SET factory_code = ? WHERE id = ?').run(nextFactoryCode, userId);
-    const clearedCustomers = db.prepare('DELETE FROM user_customers WHERE user_id = ?').run(userId).changes;
+    const result = operation();
     db.exec('COMMIT');
-    return { changed: true, clearedCustomers };
+    return result;
   } catch (error) {
     db.exec('ROLLBACK');
     throw error;
   }
 }
 
-module.exports = { changeUserFactory };
+function changeUserFactories(db, userId, nextFactoryCodes) {
+  const user = db.prepare('SELECT factory_code FROM users WHERE id = ?').get(userId);
+  if (!user) return null;
+  const codes = [...new Set(nextFactoryCodes)];
+  if (!codes.length) throw new Error('factory scope cannot be empty');
+  const currentCodes = factoryCodesForUser(db, userId, user.factory_code);
+  if (sameFactoryScope(currentCodes, codes)) return { changed: false, clearedCustomers: 0 };
+
+  return runTransaction(db, () => {
+    replaceUserFactories(db, userId, codes);
+    const clearedCustomers = db.prepare('DELETE FROM user_customers WHERE user_id = ?').run(userId).changes;
+    return { changed: true, clearedCustomers };
+  });
+}
+
+function changeUserRole(db, userId, role, nextFactoryCodes, applyTemplate) {
+  const user = db.prepare('SELECT role, factory_code FROM users WHERE id = ?').get(userId);
+  if (!user) return null;
+  const codes = [...new Set(nextFactoryCodes)];
+  if (!codes.length) throw new Error('factory scope cannot be empty');
+  const currentCodes = factoryCodesForUser(db, userId, user.factory_code);
+  const factoriesChanged = !sameFactoryScope(currentCodes, codes);
+  const adminBoundaryChanged = user.role !== role && (user.role === 'admin' || role === 'admin');
+
+  return runTransaction(db, () => {
+    db.prepare('UPDATE users SET role = ? WHERE id = ?').run(role, userId);
+    let clearedCustomers = 0;
+    if (factoriesChanged) {
+      replaceUserFactories(db, userId, codes);
+    }
+    if (factoriesChanged || adminBoundaryChanged) {
+      clearedCustomers = db.prepare('DELETE FROM user_customers WHERE user_id = ?').run(userId).changes;
+    }
+    applyTemplate(userId);
+    return { factoriesChanged, clearedCustomers };
+  });
+}
+
+function changeUserFactory(db, userId, nextFactoryCode) {
+  return changeUserFactories(db, userId, [nextFactoryCode]);
+}
+
+module.exports = { changeUserFactories, changeUserRole, changeUserFactory };

--- a/apps/业务部/内部报价系统/frontend/admin.html
+++ b/apps/业务部/内部报价系统/frontend/admin.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>管理后台 · 账号管理</title>
-  <link rel="stylesheet" href="./styles.css" />
+  <link rel="stylesheet" href="./styles.css?v=20260717-multi-factory-ui" />
 </head>
 <body>
   <div class="topbar">
@@ -48,10 +48,11 @@
               <option value="admin">管理员</option>
             </select>
           </label>
-          <label>所属厂区
+          <label>可见厂区
             <select id="nu-factory">
               <option value="qingxi">清溪</option>
               <option value="heyuan">河源</option>
+              <option value="all">清溪 + 河源</option>
             </select>
           </label>
         </div>
@@ -74,7 +75,7 @@
           <th style="width:120px">用户名</th>
           <th style="width:120px">姓名</th>
           <th style="width:100px">部门</th>
-          <th style="width:90px">厂区</th>
+          <th style="width:250px">可见厂区</th>
           <th style="width:80px">角色</th>
           <th style="width:100px">状态</th>
           <th style="width:150px">上次登录</th>
@@ -152,6 +153,6 @@
       };
     })();
   </script>
-  <script src="./admin.js?v=20260715-factory-scope"></script>
+  <script src="./admin.js?v=20260717-multi-factory-ui"></script>
 </body>
 </html>

--- a/apps/业务部/内部报价系统/frontend/admin.js
+++ b/apps/业务部/内部报价系统/frontend/admin.js
@@ -53,7 +53,7 @@ async function loadUsers() {
 function renderUsers() {
   const q = ($('user-search')?.value || '').trim().toLowerCase();
   const rows = q
-    ? __allUsers.filter(u => [u.username, u.display_name, u.dept_name, u.dept, u.factory_name, u.factory_code]
+    ? __allUsers.filter(u => [u.username, u.display_name, u.dept_name, u.dept, u.factory_name, u.factory_code, u.factory_codes]
         .some(v => String(v || '').toLowerCase().includes(q)))
     : __allUsers;
   const cnt = $('user-count');
@@ -68,15 +68,18 @@ function renderUsers() {
     const tr = document.createElement('tr');
     const isLocked = !!u.is_locked;
     const last = u.last_login ? new Date(u.last_login.includes('T') ? u.last_login : u.last_login.replace(' ', 'T') + 'Z').toLocaleString() : '—';
+    const factoryCodes = new Set(String(u.factory_codes || u.factory_code || '').split(',').filter(Boolean));
+    const factoryScope = factoryCodes.has('qingxi') && factoryCodes.has('heyuan') ? 'all' : (factoryCodes.has('heyuan') ? 'heyuan' : 'qingxi');
     tr.innerHTML = `
       <td>${u.id}</td>
       <td><b>${esc(u.username)}</b></td>
       <td>${esc(u.display_name)}</td>
       <td>${esc(u.dept_name || u.dept)}</td>
-      <td><select class="factory-sel" data-id="${u.id}" data-username="${esc(u.username)}" data-cur="${u.factory_code}" style="padding:3px 6px">
-        <option value="qingxi" ${u.factory_code==='qingxi'?'selected':''}>清溪</option>
-        <option value="heyuan" ${u.factory_code==='heyuan'?'selected':''}>河源</option>
-      </select></td>
+      <td><div class="factory-control" role="group" aria-label="${esc(u.username)} 的可见厂区">
+        <button type="button" class="factory-option scope-qingxi ${factoryScope==='qingxi'?'active':''}" data-id="${u.id}" data-username="${esc(u.username)}" data-scope="qingxi" data-cur="${factoryScope}" aria-pressed="${factoryScope==='qingxi'}">清溪</button>
+        <button type="button" class="factory-option scope-heyuan ${factoryScope==='heyuan'?'active':''}" data-id="${u.id}" data-username="${esc(u.username)}" data-scope="heyuan" data-cur="${factoryScope}" aria-pressed="${factoryScope==='heyuan'}">河源</button>
+        <button type="button" class="factory-option scope-all ${factoryScope==='all'?'active':''}" data-id="${u.id}" data-username="${esc(u.username)}" data-scope="all" data-cur="${factoryScope}" aria-pressed="${factoryScope==='all'}">双厂区</button>
+      </div></td>
       <td><select class="role-sel" data-id="${u.id}" data-username="${esc(u.username)}" data-cur="${u.role}" style="padding:3px 6px">
         <option value="staff" ${u.role==='staff'?'selected':''}>员工</option>
         <option value="supervisor" ${u.role==='supervisor'?'selected':''}>主管</option>
@@ -103,13 +106,14 @@ function renderUsers() {
   document.querySelectorAll('.btn-unlock').forEach(b => b.onclick = () => unlockUser(b.dataset.id));
   document.querySelectorAll('.btn-del').forEach(b => b.onclick = () => delUser(b.dataset.id, b.dataset.username));
   document.querySelectorAll('.role-sel').forEach(s => s.onchange = () => changeRole(s.dataset.id, s.dataset.username, s.value, s.dataset.cur));
-  document.querySelectorAll('.factory-sel').forEach(s => s.onchange = () => changeFactory(s.dataset.id, s.dataset.username, s.value, s.dataset.cur));
+  document.querySelectorAll('.factory-option').forEach(b => b.onclick = () => changeFactory(b.dataset.id, b.dataset.username, b.dataset.scope, b.dataset.cur));
 }
 
 async function changeFactory(id, username, factoryCode, cur) {
   if (factoryCode === cur) return;
-  const name = factoryCode === 'heyuan' ? '河源' : '清溪';
-  if (!confirm(`把「${username}」的所属厂区改为「${name}」？该账号下次登录后只会进入此厂区。`)) {
+  const name = factoryCode === 'all' ? '清溪 + 河源' : (factoryCode === 'heyuan' ? '河源' : '清溪');
+  const hint = factoryCode === 'all' ? '该账号登录后可以切换两个厂区。' : '该账号下次登录后只会进入此厂区。';
+  if (!confirm(`把「${username}」的可见厂区改为「${name}」？${hint}`)) {
     loadUsers();
     return;
   }

--- a/apps/业务部/内部报价系统/frontend/admin.js
+++ b/apps/业务部/内部报价系统/frontend/admin.js
@@ -70,16 +70,21 @@ function renderUsers() {
     const last = u.last_login ? new Date(u.last_login.includes('T') ? u.last_login : u.last_login.replace(' ', 'T') + 'Z').toLocaleString() : '—';
     const factoryCodes = new Set(String(u.factory_codes || u.factory_code || '').split(',').filter(Boolean));
     const factoryScope = factoryCodes.has('qingxi') && factoryCodes.has('heyuan') ? 'all' : (factoryCodes.has('heyuan') ? 'heyuan' : 'qingxi');
+    const factoryControl = u.role === 'admin'
+      ? `<div class="factory-control admin-scope" title="管理员固定管理两个厂区">
+          <button type="button" class="factory-option scope-all active" disabled aria-pressed="true">双厂区</button>
+        </div>`
+      : `<div class="factory-control" role="group" aria-label="${esc(u.username)} 的可见厂区">
+          <button type="button" class="factory-option scope-qingxi ${factoryScope==='qingxi'?'active':''}" data-id="${u.id}" data-username="${esc(u.username)}" data-scope="qingxi" data-cur="${factoryScope}" aria-pressed="${factoryScope==='qingxi'}">清溪</button>
+          <button type="button" class="factory-option scope-heyuan ${factoryScope==='heyuan'?'active':''}" data-id="${u.id}" data-username="${esc(u.username)}" data-scope="heyuan" data-cur="${factoryScope}" aria-pressed="${factoryScope==='heyuan'}">河源</button>
+          <button type="button" class="factory-option scope-all ${factoryScope==='all'?'active':''}" data-id="${u.id}" data-username="${esc(u.username)}" data-scope="all" data-cur="${factoryScope}" aria-pressed="${factoryScope==='all'}">双厂区</button>
+        </div>`;
     tr.innerHTML = `
       <td>${u.id}</td>
       <td><b>${esc(u.username)}</b></td>
       <td>${esc(u.display_name)}</td>
       <td>${esc(u.dept_name || u.dept)}</td>
-      <td><div class="factory-control" role="group" aria-label="${esc(u.username)} 的可见厂区">
-        <button type="button" class="factory-option scope-qingxi ${factoryScope==='qingxi'?'active':''}" data-id="${u.id}" data-username="${esc(u.username)}" data-scope="qingxi" data-cur="${factoryScope}" aria-pressed="${factoryScope==='qingxi'}">清溪</button>
-        <button type="button" class="factory-option scope-heyuan ${factoryScope==='heyuan'?'active':''}" data-id="${u.id}" data-username="${esc(u.username)}" data-scope="heyuan" data-cur="${factoryScope}" aria-pressed="${factoryScope==='heyuan'}">河源</button>
-        <button type="button" class="factory-option scope-all ${factoryScope==='all'?'active':''}" data-id="${u.id}" data-username="${esc(u.username)}" data-scope="all" data-cur="${factoryScope}" aria-pressed="${factoryScope==='all'}">双厂区</button>
-      </div></td>
+      <td>${factoryControl}</td>
       <td><select class="role-sel" data-id="${u.id}" data-username="${esc(u.username)}" data-cur="${u.role}" style="padding:3px 6px">
         <option value="staff" ${u.role==='staff'?'selected':''}>员工</option>
         <option value="supervisor" ${u.role==='supervisor'?'selected':''}>主管</option>
@@ -106,7 +111,7 @@ function renderUsers() {
   document.querySelectorAll('.btn-unlock').forEach(b => b.onclick = () => unlockUser(b.dataset.id));
   document.querySelectorAll('.btn-del').forEach(b => b.onclick = () => delUser(b.dataset.id, b.dataset.username));
   document.querySelectorAll('.role-sel').forEach(s => s.onchange = () => changeRole(s.dataset.id, s.dataset.username, s.value, s.dataset.cur));
-  document.querySelectorAll('.factory-option').forEach(b => b.onclick = () => changeFactory(b.dataset.id, b.dataset.username, b.dataset.scope, b.dataset.cur));
+  document.querySelectorAll('.factory-option:not(:disabled)').forEach(b => b.onclick = () => changeFactory(b.dataset.id, b.dataset.username, b.dataset.scope, b.dataset.cur));
 }
 
 async function changeFactory(id, username, factoryCode, cur) {
@@ -252,9 +257,18 @@ async function delUser(id, username) {
 
 $('btn-new-user').onclick = () => {
   $('new-user-form').classList.remove('hidden');
+  syncNewUserFactoryScope();
   $('nu-username').focus();
 };
 $('btn-cancel-user').onclick = () => $('new-user-form').classList.add('hidden');
+$('nu-role').onchange = syncNewUserFactoryScope;
+
+function syncNewUserFactoryScope() {
+  const isAdmin = $('nu-role').value === 'admin';
+  if (isAdmin) $('nu-factory').value = 'all';
+  $('nu-factory').disabled = isAdmin;
+}
+
 $('btn-create-user').onclick = async () => {
   $('nu-msg').textContent = '';
   const body = {

--- a/apps/业务部/内部报价系统/frontend/index.html
+++ b/apps/业务部/内部报价系统/frontend/index.html
@@ -4,14 +4,14 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>公司内部报价明细系统</title>
-  <link rel="stylesheet" href="./styles.css" />
+  <link rel="stylesheet" href="./styles.css?v=20260717-topbar-factory" />
 </head>
 <body>
   <div class="topbar">
     <div class="brand">📋 内部报价明细系统 <small>多部门协同 · 主管审核 · 受控导出</small></div>
     <div id="user-chip" class="hidden">
-      <span id="factory-chip" class="badge b-approved"></span>
-      <select id="factory-switch" class="hidden" aria-label="切换厂区"></select>
+      <span id="factory-chip" class="factory-single-chip"></span>
+      <div id="factory-switch" class="factory-switcher hidden" role="group" aria-label="切换厂区"></div>
       <span id="who-chip"></span>
       <a href="#" id="btn-change-pwd">修改密码</a>
       <a href="./admin.html" id="btn-admin" class="hidden">⚙️ 管理后台</a>
@@ -92,6 +92,6 @@
       };
     })();
   </script>
-  <script src="./main.js?v=20260715-factory-scope"></script>
+  <script src="./main.js?v=20260717-topbar-factory"></script>
 </body>
 </html>

--- a/apps/业务部/内部报价系统/frontend/main.js
+++ b/apps/业务部/内部报价系统/frontend/main.js
@@ -31,20 +31,27 @@ async function refreshMe() {
     $('user-chip').classList.remove('hidden');
     const roleZh = { admin: '管理员', supervisor: '主管', staff: '员工' }[me.role] || me.role;
     $('who-chip').textContent = `${me.dept_name} · ${roleZh} · ${me.display_name || me.username}`;
-    $('factory-chip').textContent = me.active_factory_name || me.active_factory_code;
+    const factoryChip = $('factory-chip');
+    factoryChip.textContent = me.active_factory_name || me.active_factory_code;
     $('factory-list-name').textContent = me.active_factory_name || me.active_factory_code;
     const factorySwitch = $('factory-switch');
     if (me.can_switch_factory) {
       factorySwitch.innerHTML = (me.factories || []).map(f =>
-        `<option value="${esc(f.code)}" ${f.code === me.active_factory_code ? 'selected' : ''}>${esc(f.name_cn)}</option>`
+        `<button type="button" class="top-factory-btn ${f.code === me.active_factory_code ? 'active' : ''}" data-code="${esc(f.code)}" aria-pressed="${f.code === me.active_factory_code}"><span class="factory-dot dot-${esc(f.code)}"></span>${esc(f.name_cn)}</button>`
       ).join('');
+      factoryChip.classList.add('hidden');
       factorySwitch.classList.remove('hidden');
-      factorySwitch.onchange = async () => {
-        await api('/auth/factory', { method: 'POST', body: JSON.stringify({ factory_code: factorySwitch.value }) });
-        await refreshMe();
-      };
+      factorySwitch.querySelectorAll('.top-factory-btn').forEach(btn => {
+        btn.onclick = async () => {
+          if (btn.classList.contains('active')) return;
+          factorySwitch.querySelectorAll('button').forEach(b => { b.disabled = true; });
+          await api('/auth/factory', { method: 'POST', body: JSON.stringify({ factory_code: btn.dataset.code }) });
+          await refreshMe();
+        };
+      });
     } else {
       factorySwitch.classList.add('hidden');
+      factoryChip.classList.remove('hidden');
     }
     // 新建报价：业务 dept 才显示
     if (hasPerm(me, '报价单列表', 'edit') && me.dept === 'sales') $('new-quote-form').classList.remove('hidden');

--- a/apps/业务部/内部报价系统/frontend/styles.css
+++ b/apps/业务部/内部报价系统/frontend/styles.css
@@ -554,6 +554,7 @@ h3 .upload-mold-sheet button:hover { background: #334155; }
   background: #f8fafc;
   box-shadow: inset 0 1px 2px rgba(15, 23, 42, .04);
 }
+.factory-control.admin-scope { grid-template-columns: 94px; }
 .factory-control .factory-option {
   min-width: 0;
   height: 30px;

--- a/apps/业务部/内部报价系统/frontend/styles.css
+++ b/apps/业务部/内部报价系统/frontend/styles.css
@@ -350,6 +350,72 @@ h3 .upload-mold-sheet button:hover { background: #334155; }
 #user-chip a { margin-left: 4px; padding: 2px 8px; border-radius: 6px; }
 #user-chip a:hover { background: rgba(255,255,255,.18); text-decoration: none; }
 
+.factory-switcher {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 3px;
+  border: 1px solid rgba(255, 255, 255, .2);
+  border-radius: 8px;
+  background: rgba(15, 23, 42, .14);
+}
+.factory-switcher .top-factory-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-width: 66px;
+  height: 30px;
+  padding: 0 11px;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  box-shadow: none;
+  color: rgba(255, 255, 255, .78);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 30px;
+}
+.factory-switcher .top-factory-btn:hover {
+  background: rgba(255, 255, 255, .12);
+  color: #fff;
+  transform: none;
+}
+.factory-switcher .top-factory-btn.active {
+  background: #fff;
+  color: #1e3a5f;
+  box-shadow: 0 1px 4px rgba(15, 23, 42, .18);
+}
+.factory-switcher .top-factory-btn:focus-visible {
+  outline: 2px solid #facc15;
+  outline-offset: 1px;
+}
+.factory-dot {
+  width: 7px;
+  height: 7px;
+  flex: 0 0 7px;
+  border-radius: 50%;
+  background: #cbd5e1;
+}
+.factory-dot.dot-qingxi { background: #22c55e; }
+.factory-dot.dot-heyuan { background: #38bdf8; }
+.factory-single-chip {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 0 10px;
+  border: 1px solid rgba(255, 255, 255, .22);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, .14);
+  color: #fff;
+  font-weight: 600;
+}
+#user-chip #who-chip {
+  margin: 0 4px 0 2px;
+  padding-left: 10px;
+  border-left: 1px solid rgba(255, 255, 255, .22);
+}
+
 /* ========== 报价单列表 ========== */
 .list-head {
   display: flex;
@@ -476,3 +542,42 @@ h3 .upload-mold-sheet button:hover { background: #334155; }
   transition: background .15s;
 }
 .open-btn:hover { background: var(--primary); color: #fff; }
+
+/* Admin factory access selector */
+.factory-control {
+  display: inline-grid;
+  grid-template-columns: 58px 58px 74px;
+  gap: 2px;
+  padding: 3px;
+  border: 1px solid #dbe3ee;
+  border-radius: 8px;
+  background: #f8fafc;
+  box-shadow: inset 0 1px 2px rgba(15, 23, 42, .04);
+}
+.factory-control .factory-option {
+  min-width: 0;
+  height: 30px;
+  padding: 0 8px;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  box-shadow: none;
+  color: #64748b;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 30px;
+  white-space: nowrap;
+}
+.factory-control .factory-option:hover {
+  background: #e9eef5;
+  color: #334155;
+  transform: none;
+}
+.factory-control .scope-qingxi.active { background: #dcfce7; color: #166534; }
+.factory-control .scope-heyuan.active { background: #dbeafe; color: #1d4ed8; }
+.factory-control .scope-all.active { background: #334155; color: #fff; }
+.factory-control .factory-option.active { box-shadow: 0 1px 3px rgba(15, 23, 42, .12); }
+.factory-control .factory-option:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 1px;
+}

--- a/apps/业务部/内部报价系统/tests/factory-workflows.test.js
+++ b/apps/业务部/内部报价系统/tests/factory-workflows.test.js
@@ -5,7 +5,7 @@ const test = require('node:test');
 const { DatabaseSync } = require('node:sqlite');
 
 const { expandEngineeringMolds } = require('../backend/services/engineeringMolds');
-const { changeUserFactory } = require('../backend/services/userFactory');
+const { changeUserFactories, changeUserRole } = require('../backend/services/userFactory');
 
 test('engineering mold expansion preserves material and color for each part', () => {
   const rows = expandEngineeringMolds([{
@@ -30,33 +30,115 @@ test('engineering mold expansion preserves material and color for each part', ()
   ]);
 });
 
-test('changing a user factory clears customer scope only when the factory changes', () => {
+function createUserAccessDb() {
   const db = new DatabaseSync(':memory:');
   db.exec(`
     CREATE TABLE users (
       id INTEGER PRIMARY KEY,
       username TEXT NOT NULL,
+      role TEXT NOT NULL,
       factory_code TEXT NOT NULL
+    );
+    CREATE TABLE user_factories (
+      user_id INTEGER NOT NULL,
+      factory_code TEXT NOT NULL,
+      PRIMARY KEY (user_id, factory_code)
     );
     CREATE TABLE user_customers (
       user_id INTEGER NOT NULL,
       customer TEXT NOT NULL,
       PRIMARY KEY (user_id, customer)
     );
-    INSERT INTO users (id, username, factory_code) VALUES (1, 'staff', 'qingxi');
+    CREATE TABLE user_perms (
+      user_id INTEGER NOT NULL,
+      menu TEXT NOT NULL,
+      PRIMARY KEY (user_id, menu)
+    );
+    INSERT INTO users (id, username, role, factory_code) VALUES (1, 'staff', 'staff', 'qingxi');
+    INSERT INTO user_factories (user_id, factory_code) VALUES (1, 'qingxi');
     INSERT INTO user_customers (user_id, customer) VALUES (1, 'Shared Customer'), (1, 'Qingxi Only');
   `);
+  return db;
+}
+
+test('changing user factories replaces scope and clears customers only when scope changes', () => {
+  const db = createUserAccessDb();
 
   try {
-    const changed = changeUserFactory(db, 1, 'heyuan');
+    const changed = changeUserFactories(db, 1, ['heyuan']);
     assert.deepEqual(changed, { changed: true, clearedCustomers: 2 });
     assert.equal(db.prepare('SELECT factory_code FROM users WHERE id = 1').get().factory_code, 'heyuan');
+    assert.deepEqual(
+      db.prepare('SELECT factory_code FROM user_factories WHERE user_id = 1').all().map(row => row.factory_code),
+      ['heyuan']
+    );
     assert.equal(db.prepare('SELECT COUNT(*) AS n FROM user_customers WHERE user_id = 1').get().n, 0);
 
     db.prepare('INSERT INTO user_customers (user_id, customer) VALUES (?, ?)').run(1, 'Heyuan Customer');
-    const unchanged = changeUserFactory(db, 1, 'heyuan');
+    const unchanged = changeUserFactories(db, 1, ['heyuan']);
     assert.deepEqual(unchanged, { changed: false, clearedCustomers: 0 });
     assert.equal(db.prepare('SELECT COUNT(*) AS n FROM user_customers WHERE user_id = 1').get().n, 1);
+  } finally {
+    db.close();
+  }
+});
+
+test('promoting a user to admin expands factory scope and clears customers atomically', () => {
+  const db = createUserAccessDb();
+
+  try {
+    const result = changeUserRole(db, 1, 'admin', ['qingxi', 'heyuan'], (userId) => {
+      db.prepare('DELETE FROM user_perms WHERE user_id = ?').run(userId);
+      db.prepare('INSERT INTO user_perms (user_id, menu) VALUES (?, ?)').run(userId, 'admin-template');
+    });
+
+    assert.deepEqual(result, { factoriesChanged: true, clearedCustomers: 2 });
+    assert.equal(db.prepare('SELECT role FROM users WHERE id = 1').get().role, 'admin');
+    assert.deepEqual(
+      db.prepare('SELECT factory_code FROM user_factories WHERE user_id = 1 ORDER BY factory_code').all().map(row => row.factory_code),
+      ['heyuan', 'qingxi']
+    );
+    assert.equal(db.prepare('SELECT COUNT(*) AS n FROM user_customers WHERE user_id = 1').get().n, 0);
+    assert.equal(db.prepare('SELECT menu FROM user_perms WHERE user_id = 1').get().menu, 'admin-template');
+  } finally {
+    db.close();
+  }
+});
+
+test('role update rolls back role, factories, customers, and permissions together', () => {
+  const db = createUserAccessDb();
+  db.prepare('INSERT INTO user_perms (user_id, menu) VALUES (?, ?)').run(1, 'staff-template');
+
+  try {
+    assert.throws(() => changeUserRole(db, 1, 'admin', ['qingxi', 'heyuan'], () => {
+      db.prepare('DELETE FROM user_perms WHERE user_id = ?').run(1);
+      throw new Error('template failure');
+    }), /template failure/);
+
+    assert.equal(db.prepare('SELECT role FROM users WHERE id = 1').get().role, 'staff');
+    assert.deepEqual(
+      db.prepare('SELECT factory_code FROM user_factories WHERE user_id = 1').all().map(row => row.factory_code),
+      ['qingxi']
+    );
+    assert.equal(db.prepare('SELECT COUNT(*) AS n FROM user_customers WHERE user_id = 1').get().n, 2);
+    assert.equal(db.prepare('SELECT menu FROM user_perms WHERE user_id = 1').get().menu, 'staff-template');
+  } finally {
+    db.close();
+  }
+});
+
+test('demoting an admin clears customer scope even when factory scope stays unchanged', () => {
+  const db = createUserAccessDb();
+  db.exec(`
+    UPDATE users SET role = 'admin';
+    INSERT INTO user_factories (user_id, factory_code) VALUES (1, 'heyuan');
+  `);
+
+  try {
+    const result = changeUserRole(db, 1, 'staff', ['qingxi', 'heyuan'], () => {});
+    assert.deepEqual(result, { factoriesChanged: false, clearedCustomers: 2 });
+    assert.equal(db.prepare('SELECT role FROM users WHERE id = 1').get().role, 'staff');
+    assert.equal(db.prepare('SELECT COUNT(*) AS n FROM user_customers WHERE user_id = 1').get().n, 0);
   } finally {
     db.close();
   }


### PR DESCRIPTION
## 主要更新
- 用户账号支持清溪、河源或双厂区访问范围
- 双厂区账号登录后可在顶部切换当前厂区，报价和参数仍按厂区隔离
- 管理后台增加三段式厂区权限控件，并优化首页厂区切换样式
- 管理员继续默认管理两个厂区
- 厂区范围变化时清空旧客户范围，避免跨厂区继承客户权限

## 验证
- 厂区迁移与权限流程测试 3/3 通过
- JavaScript 语法检查通过
- git diff --check 通过