### PR TITLE
fix: 管理员显示完整厂区选择器

### DIFF
--- a/apps/业务部/内部报价系统/frontend/admin.html
+++ b/apps/业务部/内部报价系统/frontend/admin.html
@@ -4,13 +4,14 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>管理后台 · 账号管理</title>
-  <link rel="stylesheet" href="./styles.css?v=20260717-multi-factory-ui" />
+  <link rel="stylesheet" href="./styles.css?v=20260717-admin-factory-switcher" />
 </head>
 <body>
   <div class="topbar">
     <div class="brand">⚙️ 管理后台 <small>账号管理</small></div>
     <div id="user-chip">
-      <select id="factory-switch" aria-label="切换厂区"></select>
+      <span id="factory-chip" class="factory-single-chip hidden"></span>
+      <div id="factory-switch" class="factory-switcher hidden" role="group" aria-label="切换厂区"></div>
       <span id="who-chip"></span>
       <a href="./index.html">← 报价单</a>
       <a href="#" id="btn-logout">登出</a>
@@ -153,6 +154,6 @@
       };
     })();
   </script>
-  <script src="./admin.js?v=20260717-multi-factory-ui"></script>
+  <script src="./admin.js?v=20260717-admin-factory-switcher"></script>
 </body>
 </html>

--- a/apps/业务部/内部报价系统/frontend/admin.html
+++ b/apps/业务部/内部报价系统/frontend/admin.html
@@ -4,14 +4,16 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>管理后台 · 账号管理</title>
-  <link rel="stylesheet" href="./styles.css?v=20260717-admin-factory-switcher" />
+  <link rel="stylesheet" href="./styles.css?v=20260717-admin-factory-select" />
 </head>
 <body>
   <div class="topbar">
     <div class="brand">⚙️ 管理后台 <small>账号管理</small></div>
     <div id="user-chip">
-      <span id="factory-chip" class="factory-single-chip hidden"></span>
-      <div id="factory-switch" class="factory-switcher hidden" role="group" aria-label="切换厂区"></div>
+      <div class="top-factory-select">
+        <span id="factory-switch-dot" class="factory-dot" aria-hidden="true"></span>
+        <select id="factory-switch" aria-label="切换厂区"></select>
+      </div>
       <span id="who-chip"></span>
       <a href="./index.html">← 报价单</a>
       <a href="#" id="btn-logout">登出</a>
@@ -154,6 +156,6 @@
       };
     })();
   </script>
-  <script src="./admin.js?v=20260717-admin-factory-switcher"></script>
+  <script src="./admin.js?v=20260717-admin-factory-select"></script>
 </body>
 </html>

--- a/apps/业务部/内部报价系统/frontend/admin.js
+++ b/apps/业务部/内部报价系统/frontend/admin.js
@@ -71,7 +71,9 @@ function renderUsers() {
     const factoryCodes = new Set(String(u.factory_codes || u.factory_code || '').split(',').filter(Boolean));
     const factoryScope = factoryCodes.has('qingxi') && factoryCodes.has('heyuan') ? 'all' : (factoryCodes.has('heyuan') ? 'heyuan' : 'qingxi');
     const factoryControl = u.role === 'admin'
-      ? `<div class="factory-control admin-scope" title="管理员固定管理两个厂区">
+      ? `<div class="factory-control" role="group" aria-label="${esc(u.username)} 固定管理两个厂区" title="管理员固定管理两个厂区">
+          <button type="button" class="factory-option scope-qingxi" disabled aria-pressed="false">清溪</button>
+          <button type="button" class="factory-option scope-heyuan" disabled aria-pressed="false">河源</button>
           <button type="button" class="factory-option scope-all active" disabled aria-pressed="true">双厂区</button>
         </div>`
       : `<div class="factory-control" role="group" aria-label="${esc(u.username)} 的可见厂区">

--- a/apps/业务部/内部报价系统/frontend/admin.js
+++ b/apps/业务部/内部报价系统/frontend/admin.js
@@ -38,8 +38,14 @@ async function init() {
   factorySwitch.disabled = !me.can_switch_factory;
   factorySwitch.onchange = async () => {
     factorySwitch.disabled = true;
-    await api('/auth/factory', { method: 'POST', body: JSON.stringify({ factory_code: factorySwitch.value }) });
-    location.reload();
+    try {
+      await api('/auth/factory', { method: 'POST', body: JSON.stringify({ factory_code: factorySwitch.value }) });
+      location.reload();
+    } catch (e) {
+      factorySwitch.value = me.active_factory_code;
+      factorySwitch.disabled = false;
+      alert(e.message);
+    }
   };
   window.__me = me;
   await loadUsers();

--- a/apps/业务部/内部报价系统/frontend/admin.js
+++ b/apps/业务部/内部报价系统/frontend/admin.js
@@ -29,15 +29,28 @@ async function init() {
     document.body.innerHTML = '<div style="padding:40px;text-align:center"><h2>无权访问</h2><a href="./index.html">← 返回</a></div>';
     return;
   }
-  $('who-chip').textContent = `${me.active_factory_name} · ${me.display_name || me.username} · 管理员`;
+  $('who-chip').textContent = `${me.display_name || me.username} · 管理员`;
+  const factoryChip = $('factory-chip');
+  factoryChip.textContent = me.active_factory_name || me.active_factory_code;
   const factorySwitch = $('factory-switch');
-  factorySwitch.innerHTML = (me.factories || []).map(f =>
-    `<option value="${esc(f.code)}" ${f.code === me.active_factory_code ? 'selected' : ''}>${esc(f.name_cn)}</option>`
-  ).join('');
-  factorySwitch.onchange = async () => {
-    await api('/auth/factory', { method: 'POST', body: JSON.stringify({ factory_code: factorySwitch.value }) });
-    location.reload();
-  };
+  if (me.can_switch_factory) {
+    factorySwitch.innerHTML = (me.factories || []).map(f =>
+      `<button type="button" class="top-factory-btn ${f.code === me.active_factory_code ? 'active' : ''}" data-code="${esc(f.code)}" aria-pressed="${f.code === me.active_factory_code}"><span class="factory-dot dot-${esc(f.code)}"></span>${esc(f.name_cn)}</button>`
+    ).join('');
+    factoryChip.classList.add('hidden');
+    factorySwitch.classList.remove('hidden');
+    factorySwitch.querySelectorAll('.top-factory-btn').forEach(btn => {
+      btn.onclick = async () => {
+        if (btn.classList.contains('active')) return;
+        factorySwitch.querySelectorAll('button').forEach(b => { b.disabled = true; });
+        await api('/auth/factory', { method: 'POST', body: JSON.stringify({ factory_code: btn.dataset.code }) });
+        location.reload();
+      };
+    });
+  } else {
+    factorySwitch.classList.add('hidden');
+    factoryChip.classList.remove('hidden');
+  }
   window.__me = me;
   await loadUsers();
 }

--- a/apps/业务部/内部报价系统/frontend/admin.js
+++ b/apps/业务部/内部报价系统/frontend/admin.js
@@ -30,27 +30,17 @@ async function init() {
     return;
   }
   $('who-chip').textContent = `${me.display_name || me.username} · 管理员`;
-  const factoryChip = $('factory-chip');
-  factoryChip.textContent = me.active_factory_name || me.active_factory_code;
   const factorySwitch = $('factory-switch');
-  if (me.can_switch_factory) {
-    factorySwitch.innerHTML = (me.factories || []).map(f =>
-      `<button type="button" class="top-factory-btn ${f.code === me.active_factory_code ? 'active' : ''}" data-code="${esc(f.code)}" aria-pressed="${f.code === me.active_factory_code}"><span class="factory-dot dot-${esc(f.code)}"></span>${esc(f.name_cn)}</button>`
-    ).join('');
-    factoryChip.classList.add('hidden');
-    factorySwitch.classList.remove('hidden');
-    factorySwitch.querySelectorAll('.top-factory-btn').forEach(btn => {
-      btn.onclick = async () => {
-        if (btn.classList.contains('active')) return;
-        factorySwitch.querySelectorAll('button').forEach(b => { b.disabled = true; });
-        await api('/auth/factory', { method: 'POST', body: JSON.stringify({ factory_code: btn.dataset.code }) });
-        location.reload();
-      };
-    });
-  } else {
-    factorySwitch.classList.add('hidden');
-    factoryChip.classList.remove('hidden');
-  }
+  factorySwitch.innerHTML = (me.factories || []).map(f =>
+    `<option value="${esc(f.code)}" ${f.code === me.active_factory_code ? 'selected' : ''}>${esc(f.name_cn)}</option>`
+  ).join('');
+  $('factory-switch-dot').className = `factory-dot dot-${esc(me.active_factory_code)}`;
+  factorySwitch.disabled = !me.can_switch_factory;
+  factorySwitch.onchange = async () => {
+    factorySwitch.disabled = true;
+    await api('/auth/factory', { method: 'POST', body: JSON.stringify({ factory_code: factorySwitch.value }) });
+    location.reload();
+  };
   window.__me = me;
   await loadUsers();
 }

--- a/apps/业务部/内部报价系统/frontend/styles.css
+++ b/apps/业务部/内部报价系统/frontend/styles.css
@@ -350,6 +350,54 @@ h3 .upload-mold-sheet button:hover { background: #334155; }
 #user-chip a { margin-left: 4px; padding: 2px 8px; border-radius: 6px; }
 #user-chip a:hover { background: rgba(255,255,255,.18); text-decoration: none; }
 
+.top-factory-select {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  min-width: 92px;
+  height: 34px;
+  border: 1px solid rgba(255, 255, 255, .4);
+  border-radius: 8px;
+  background: #fff;
+  box-shadow: 0 1px 4px rgba(15, 23, 42, .18);
+}
+.top-factory-select .factory-dot {
+  position: absolute;
+  left: 12px;
+  z-index: 1;
+  pointer-events: none;
+}
+.top-factory-select::after {
+  content: '';
+  position: absolute;
+  right: 12px;
+  width: 6px;
+  height: 6px;
+  border-right: 2px solid #64748b;
+  border-bottom: 2px solid #64748b;
+  transform: rotate(45deg) translateY(-2px);
+  pointer-events: none;
+}
+.top-factory-select select {
+  width: 100%;
+  height: 100%;
+  padding: 0 30px 0 27px;
+  border: 0;
+  border-radius: 8px;
+  outline: 0;
+  appearance: none;
+  background: transparent;
+  color: #1e3a5f;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+.top-factory-select:focus-within {
+  outline: 2px solid #facc15;
+  outline-offset: 2px;
+}
+.top-factory-select select:disabled { cursor: default; opacity: .82; }
+
 .factory-switcher {
   display: inline-flex;
   align-items: center;

--- a/apps/业务部/内部报价系统/frontend/styles.css
+++ b/apps/业务部/内部报价系统/frontend/styles.css
@@ -554,7 +554,6 @@ h3 .upload-mold-sheet button:hover { background: #334155; }
   background: #f8fafc;
   box-shadow: inset 0 1px 2px rgba(15, 23, 42, .04);
 }
-.factory-control.admin-scope { grid-template-columns: 94px; }
 .factory-control .factory-option {
   min-width: 0;
   height: 30px;

--- a/apps/业务部/内部报价系统/tests/admin-factory-switch.test.js
+++ b/apps/业务部/内部报价系统/tests/admin-factory-switch.test.js
@@ -1,0 +1,94 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const adminSource = fs.readFileSync(
+  path.join(__dirname, '..', 'frontend', 'admin.js'),
+  'utf8',
+);
+
+function makeElement() {
+  return {
+    value: '',
+    disabled: false,
+    innerHTML: '',
+    textContent: '',
+    style: {},
+    dataset: {},
+    classList: { add() {}, remove() {} },
+    appendChild() {},
+    querySelector() { return makeElement(); },
+  };
+}
+
+async function settle() {
+  await new Promise(resolve => setImmediate(resolve));
+  await new Promise(resolve => setImmediate(resolve));
+}
+
+test('failed admin factory switch restores the previous factory and re-enables the selector', async () => {
+  const elements = new Map();
+  const getElement = id => {
+    if (!elements.has(id)) elements.set(id, makeElement());
+    return elements.get(id);
+  };
+  const alerts = [];
+  let reloads = 0;
+
+  const context = {
+    document: {
+      body: makeElement(),
+      getElementById: getElement,
+      querySelectorAll: () => [],
+      createElement: makeElement,
+    },
+    fetch: async url => {
+      if (url.endsWith('/auth/me')) {
+        return {
+          ok: true,
+          json: async () => ({
+            username: 'admin',
+            display_name: 'Admin',
+            active_factory_code: 'qingxi',
+            can_switch_factory: true,
+            factories: [
+              { code: 'qingxi', name_cn: '清溪' },
+              { code: 'heyuan', name_cn: '河源' },
+            ],
+            perms: { '账号管理': { can_admin: true } },
+          }),
+        };
+      }
+      if (url.endsWith('/admin/users')) return { ok: true, json: async () => [] };
+      return {
+        ok: false,
+        statusText: 'Service Unavailable',
+        json: async () => ({ error: 'switch failed' }),
+      };
+    },
+    location: { href: '', reload: () => { reloads += 1; } },
+    window: {},
+    alert: message => alerts.push(message),
+    confirm: () => false,
+    prompt: () => null,
+    setTimeout,
+    clearTimeout,
+    console,
+  };
+
+  vm.runInNewContext(adminSource, context, { filename: 'admin.js' });
+  await settle();
+
+  const factorySwitch = getElement('factory-switch');
+  factorySwitch.value = 'heyuan';
+  await factorySwitch.onchange();
+
+  assert.equal(factorySwitch.value, 'qingxi');
+  assert.equal(factorySwitch.disabled, false);
+  assert.equal(reloads, 0);
+  assert.deepEqual(alerts, ['switch failed']);
+});


### PR DESCRIPTION
## 修改内容
- 管理员行恢复显示清溪、河源、双厂区三个选项
- 双厂区保持高亮，三个选项均锁定，继续执行管理员固定管理双厂区的权限规则
- 移除仅显示单个双厂区按钮的专用样式

## 验证
- node tests/factory-workflows.test.js（5 项通过）