### PR TITLE
fix: 允许管理员配置可见厂区

### DIFF
--- a/apps/业务部/内部报价系统/backend/db/index.js
+++ b/apps/业务部/内部报价系统/backend/db/index.js
@@ -370,6 +370,10 @@ if (userCount === 0) {
     VALUES (?, ?, ?, ?, ?, ?)
   `);
   for (const p of tpl) insertPerm.run(adminId, p.menu, p.can_view, p.can_edit, p.can_review, p.can_admin);
+  db.prepare(`
+    INSERT OR IGNORE INTO user_factories (user_id, factory_code)
+    SELECT ?, code FROM factories WHERE active = 1
+  `).run(adminId);
   console.log('\n========================================');
   console.log('[seed] 初始管理员账号已创建:');
   console.log('  用户名: admin');
@@ -378,15 +382,10 @@ if (userCount === 0) {
   console.log('========================================\n');
 }
 
-// Existing users inherit their current factory; admins retain access to all factories.
+// Existing users without an explicit scope inherit their current factory.
 db.prepare(`
   INSERT OR IGNORE INTO user_factories (user_id, factory_code)
   SELECT id, factory_code FROM users
-`).run();
-db.prepare(`
-  INSERT OR IGNORE INTO user_factories (user_id, factory_code)
-  SELECT u.id, f.code FROM users u CROSS JOIN factories f
-  WHERE u.role = 'admin' AND f.active = 1
 `).run();
 
 // 包装：transaction(fn) 在 BEGIN/COMMIT/ROLLBACK 中运行 fn

--- a/apps/业务部/内部报价系统/backend/middleware/auth.js
+++ b/apps/业务部/内部报价系统/backend/middleware/auth.js
@@ -10,14 +10,12 @@ function loadUserAndPerms(userId, requestedFactory) {
     perms[r.menu] = { can_view: r.can_view, can_edit: r.can_edit, can_review: r.can_review, can_admin: r.can_admin };
   }
   const defaultFactory = u.factory_code || 'qingxi';
-  let factories = u.role === 'admin'
-    ? db.prepare('SELECT code, name_cn FROM factories WHERE active = 1 ORDER BY sort_order').all()
-    : db.prepare(`
-        SELECT f.code, f.name_cn
-        FROM user_factories uf JOIN factories f ON f.code = uf.factory_code
-        WHERE uf.user_id = ? AND f.active = 1
-        ORDER BY f.sort_order
-      `).all(userId);
+  let factories = db.prepare(`
+    SELECT f.code, f.name_cn
+    FROM user_factories uf JOIN factories f ON f.code = uf.factory_code
+    WHERE uf.user_id = ? AND f.active = 1
+    ORDER BY f.sort_order
+  `).all(userId);
   if (!factories.length) {
     factories = db.prepare('SELECT code, name_cn FROM factories WHERE code = ? AND active = 1').all(defaultFactory);
   }

--- a/apps/业务部/内部报价系统/backend/routes/admin.js
+++ b/apps/业务部/内部报价系统/backend/routes/admin.js
@@ -24,8 +24,8 @@ function applyTemplate(userId, dept, role) {
   }
 }
 
-function factoryCodesFor(scope, role) {
-  if (scope === 'all' || role === 'admin') {
+function factoryCodesFor(scope) {
+  if (scope === 'all') {
     return db.prepare('SELECT code FROM factories WHERE active = 1 ORDER BY sort_order').all().map(r => r.code);
   }
   const code = String(scope || '').trim();
@@ -59,7 +59,7 @@ router.post('/users', (req, res) => {
   if (String(password).length < 6) return res.status(400).json({ error: '密码至少 6 位' });
   const dept_ok = db.prepare('SELECT 1 FROM departments WHERE code = ?').get(dept);
   if (!dept_ok) return res.status(400).json({ error: '部门不存在' });
-  const factoryCodes = factoryCodesFor(factory_code, role);
+  const factoryCodes = factoryCodesFor(factory_code);
   if (!factoryCodes.length) return res.status(400).json({ error: '厂区不存在' });
   const exists = db.prepare('SELECT 1 FROM users WHERE username = ?').get(String(username).trim());
   if (exists) return res.status(409).json({ error: '用户名已存在' });
@@ -91,7 +91,7 @@ router.put('/users/:id/factory', (req, res) => {
   const factoryCode = String((req.body && req.body.factory_code) || '').trim();
   const u = db.prepare('SELECT username, role FROM users WHERE id = ?').get(id);
   if (!u) return res.status(404).json({ error: '用户不存在' });
-  const factoryCodes = factoryCodesFor(factoryCode, u.role);
+  const factoryCodes = factoryCodesFor(factoryCode);
   if (!factoryCodes.length) return res.status(400).json({ error: '厂区不存在' });
   const result = changeUserFactories(db, id, factoryCodes);
   const changed = result.changed;
@@ -113,9 +113,7 @@ router.put('/users/:id/role', (req, res) => {
   if (!u) return res.status(404).json({ error: '用户不存在' });
   const currentFactoryCodes = db.prepare('SELECT factory_code FROM user_factories WHERE user_id = ? ORDER BY factory_code')
     .all(id).map(r => r.factory_code);
-  const nextFactoryCodes = role === 'admin'
-    ? factoryCodesFor('all', role)
-    : (currentFactoryCodes.length ? currentFactoryCodes : [u.factory_code]);
+  const nextFactoryCodes = currentFactoryCodes.length ? currentFactoryCodes : [u.factory_code];
   const result = changeUserRole(db, id, role, nextFactoryCodes, (userId) => {
     applyTemplate(userId, u.dept, role);
     db.prepare(`INSERT INTO audit_log (dept, actor, action, detail) VALUES (?, ?, 'change_role', ?)`)

--- a/apps/业务部/内部报价系统/frontend/admin.html
+++ b/apps/业务部/内部报价系统/frontend/admin.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>管理后台 · 账号管理</title>
-  <link rel="stylesheet" href="./styles.css?v=20260717-admin-factory-select" />
+  <link rel="stylesheet" href="./styles.css?v=20260717-admin-factory-configurable" />
 </head>
 <body>
   <div class="topbar">
@@ -156,6 +156,6 @@
       };
     })();
   </script>
-  <script src="./admin.js?v=20260717-admin-factory-select"></script>
+  <script src="./admin.js?v=20260717-admin-factory-configurable"></script>
 </body>
 </html>

--- a/apps/业务部/内部报价系统/frontend/admin.js
+++ b/apps/业务部/内部报价系统/frontend/admin.js
@@ -79,13 +79,7 @@ function renderUsers() {
     const last = u.last_login ? new Date(u.last_login.includes('T') ? u.last_login : u.last_login.replace(' ', 'T') + 'Z').toLocaleString() : '—';
     const factoryCodes = new Set(String(u.factory_codes || u.factory_code || '').split(',').filter(Boolean));
     const factoryScope = factoryCodes.has('qingxi') && factoryCodes.has('heyuan') ? 'all' : (factoryCodes.has('heyuan') ? 'heyuan' : 'qingxi');
-    const factoryControl = u.role === 'admin'
-      ? `<div class="factory-control" role="group" aria-label="${esc(u.username)} 固定管理两个厂区" title="管理员固定管理两个厂区">
-          <button type="button" class="factory-option scope-qingxi" disabled aria-pressed="false">清溪</button>
-          <button type="button" class="factory-option scope-heyuan" disabled aria-pressed="false">河源</button>
-          <button type="button" class="factory-option scope-all active" disabled aria-pressed="true">双厂区</button>
-        </div>`
-      : `<div class="factory-control" role="group" aria-label="${esc(u.username)} 的可见厂区">
+    const factoryControl = `<div class="factory-control" role="group" aria-label="${esc(u.username)} 的可见厂区">
           <button type="button" class="factory-option scope-qingxi ${factoryScope==='qingxi'?'active':''}" data-id="${u.id}" data-username="${esc(u.username)}" data-scope="qingxi" data-cur="${factoryScope}" aria-pressed="${factoryScope==='qingxi'}">清溪</button>
           <button type="button" class="factory-option scope-heyuan ${factoryScope==='heyuan'?'active':''}" data-id="${u.id}" data-username="${esc(u.username)}" data-scope="heyuan" data-cur="${factoryScope}" aria-pressed="${factoryScope==='heyuan'}">河源</button>
           <button type="button" class="factory-option scope-all ${factoryScope==='all'?'active':''}" data-id="${u.id}" data-username="${esc(u.username)}" data-scope="all" data-cur="${factoryScope}" aria-pressed="${factoryScope==='all'}">双厂区</button>
@@ -268,17 +262,9 @@ async function delUser(id, username) {
 
 $('btn-new-user').onclick = () => {
   $('new-user-form').classList.remove('hidden');
-  syncNewUserFactoryScope();
   $('nu-username').focus();
 };
 $('btn-cancel-user').onclick = () => $('new-user-form').classList.add('hidden');
-$('nu-role').onchange = syncNewUserFactoryScope;
-
-function syncNewUserFactoryScope() {
-  const isAdmin = $('nu-role').value === 'admin';
-  if (isAdmin) $('nu-factory').value = 'all';
-  $('nu-factory').disabled = isAdmin;
-}
 
 $('btn-create-user').onclick = async () => {
   $('nu-msg').textContent = '';

--- a/apps/业务部/内部报价系统/tests/factory-workflows.test.js
+++ b/apps/业务部/内部报价系统/tests/factory-workflows.test.js
@@ -83,20 +83,20 @@ test('changing user factories replaces scope and clears customers only when scop
   }
 });
 
-test('promoting a user to admin expands factory scope and clears customers atomically', () => {
+test('promoting a user to admin preserves its configured factory scope', () => {
   const db = createUserAccessDb();
 
   try {
-    const result = changeUserRole(db, 1, 'admin', ['qingxi', 'heyuan'], (userId) => {
+    const result = changeUserRole(db, 1, 'admin', ['qingxi'], (userId) => {
       db.prepare('DELETE FROM user_perms WHERE user_id = ?').run(userId);
       db.prepare('INSERT INTO user_perms (user_id, menu) VALUES (?, ?)').run(userId, 'admin-template');
     });
 
-    assert.deepEqual(result, { factoriesChanged: true, clearedCustomers: 2 });
+    assert.deepEqual(result, { factoriesChanged: false, clearedCustomers: 2 });
     assert.equal(db.prepare('SELECT role FROM users WHERE id = 1').get().role, 'admin');
     assert.deepEqual(
       db.prepare('SELECT factory_code FROM user_factories WHERE user_id = 1 ORDER BY factory_code').all().map(row => row.factory_code),
-      ['heyuan', 'qingxi']
+      ['qingxi']
     );
     assert.equal(db.prepare('SELECT COUNT(*) AS n FROM user_customers WHERE user_id = 1').get().n, 0);
     assert.equal(db.prepare('SELECT menu FROM user_perms WHERE user_id = 1').get().menu, 'admin-template');


### PR DESCRIPTION
## 修改内容
- 管理员可设置为清溪、河源或双厂区
- 新建管理员时保留所选厂区，不再强制双厂区
- 角色改为管理员时保留原有厂区范围
- 登录权限按 user_factories 实际配置加载
- 移除启动时自动给所有管理员补齐双厂区的逻辑
- 初始超级管理员仍默认拥有双厂区，可后续调整

## 验证
- node tests/factory-workflows.test.js（5 项通过）
- 实际接口验证：管理员双厂区 -> 清溪 -> 双厂区，返回范围和切换能力均正确